### PR TITLE
Renamed base package; added sub packages for app and domain

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/HmppsEducationAndWorkPlanApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/HmppsEducationAndWorkPlanApi.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/HmppsEducationAndWorkPlanApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/HmppsEducationAndWorkPlanApiExceptionHandler.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi.config
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
 
 import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/health/HealthInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/health/HealthInfo.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi.health
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.health
 
 import org.springframework.boot.actuate.health.Health
 import org.springframework.boot.actuate.health.HealthIndicator

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/health/VersionOutputter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/health/VersionOutputter.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi.health
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.health
 
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.event.ApplicationReadyEvent

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/Placeholder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/Placeholder.kt
@@ -1,0 +1,4 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain
+
+// Placeholder file to maintain directory / package structure whilst there are no classes
+// Remove this file once we start adding classes

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -12,7 +12,7 @@
     </layout>
   </appender>
 
-  <logger name="uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi.HmppsEducationAndWorkPlanApiKt" additivity="false"
+  <logger name="uk.gov.justice.digital.hmpps.educationandworkplanapi.HmppsEducationAndWorkPlanApiKt" additivity="false"
           level="DEBUG">
     <appender-ref ref="consoleAppender"/>
   </logger>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/health/HealthInfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/health/HealthInfoTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi.health
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.health
 
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/integration/IntegrationTestBase.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi.integration
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.integration
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/integration/health/HealthCheckTest.kt
@@ -1,8 +1,8 @@
-package uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi.integration.health
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.integration.health
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.integration.IntegrationTestBase
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.function.Consumer

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/integration/health/InfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/integration/health/InfoTest.kt
@@ -1,8 +1,8 @@
-package uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi.integration.health
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.integration.health
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.integration.IntegrationTestBase
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/hmppseducationandworkplanapi/Placeholder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/hmppseducationandworkplanapi/Placeholder.kt
@@ -1,0 +1,4 @@
+package uk.gov.justice.digital.hmpps.hmppseducationandworkplanapi
+
+// This file is only here as part of the initial commit in order to maintain the package directory structure
+// Remove once the first classes are added to this package


### PR DESCRIPTION
This PR renames the base package from `hmppseducationandworkplanapi` to `educationandworkplanapi` because the `hmpps` prefix is redundant because its in the parent package.
Also added sub packages for `app` and `domain`