### PR TITLE
Enable jar task to fix test-fixtures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,11 +50,11 @@ tasks.named("assemble") {
   // `assemble` task assembles the classes and dependencies into a fat jar
   // Beforehand we need to remove the plain jar and test-fixtures jars if they exist
   doFirst {
-    files(
+    delete(
       fileTree(project.buildDir.absolutePath)
         .include("libs/*-plain.jar")
         .include("libs/*-test-fixtures.jar")
-    ).forEach { delete(it) }
+    )
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,9 @@ configurations {
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+  // Test fixtures dependencies
+  testFixturesImplementation("org.assertj:assertj-core")
 }
 
 java {
@@ -25,6 +28,33 @@ tasks {
     kotlinOptions {
       jvmTarget = "19"
     }
+  }
+}
+
+/*
+  `dps-gradle-spring-boot` disabled the jar task in jira DT-2070, specifically to prevent the generation of the
+  Spring Boot plain jar. The reason was that the `Dockerfile` copies the Spring Boot fat jar with:
+  `COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-education-and-work-plan-api*.jar /app/app.jar`
+  The fat jar includes the date in the filename, hence needing to use a wildcard. Using the wildcard causes problems
+  if there are multiple matching files (eg: the plain jar)
+
+  The plugin `java-test-fixtures` requires the plain jar in order to access the compiled classes from the `main` source
+  root. The `jar` task has been re-enabled here to allow `java-test-fixtures` to see the `main` classes, and a hook
+  has been added to the `assemble` task to remove the plain jar and test-fixtures jar before assembling the Spring Boot
+  fat jar.
+ */
+tasks.named("jar") {
+  enabled = true
+}
+tasks.named("assemble") {
+  // `assemble` task assembles the classes and dependencies into a fat jar
+  // Beforehand we need to remove the plain jar and test-fixtures jars if they exist
+  doFirst {
+    files(
+      fileTree(project.buildDir.absolutePath)
+        .include("libs/*-plain.jar")
+        .include("libs/*-test-fixtures.jar")
+    ).forEach { delete(it) }
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimelineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimelineTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.testfixtures.domain.timeline.aValidTimelineEvent
 import java.time.Instant
 
 class TimelineTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
@@ -10,7 +10,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Timeline
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.testfixtures.domain.timeline.aValidTimelineEvent
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimelineEvent
 import java.time.Instant
 
 @ExtendWith(MockitoExtension::class)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimeLineBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimeLineBuilder.kt
@@ -1,8 +1,5 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.testfixtures.domain.timeline
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline
 
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Link
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Timeline
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
 import java.time.Instant
 
 fun aValidTimeline(


### PR DESCRIPTION
This PR fixes the test fixtures.
The problem was that `java-test-fixtures` is dependent on the `jar` task at build time (to access the `main` classes from the Spring Boot plain jar).
However, `dps-gradle-spring-boot` disables the `jar` task because it creates the Spring Boot plain jar, which in turn means there are 2 jars in the lib folder once the Spring Boot fat jar has been created. This means the `Dockerfile` has indeterminate behaviour as to which jar file to copies into the container.

This PR fixes the problem by enabling the `jar` task (to get `java-test-fixtures` working again); and then deleting the plain jar (and the test fixtures jar) before the Spring Boot fat jar is created.

