### PR TITLE
Add basic GoalService along with builders and tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
 
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ARCHIVED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.COMPLETED
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -13,31 +15,44 @@ import java.util.UUID
  * Each goal has its own lifecycle (such as active or completed) and a prisoner can have many goals at the same time
  * (e.g. more than one active goal), thereby creating a "Action Plan".
  */
-data class Goal(
+class Goal(
   val reference: UUID,
   val title: String,
   val reviewDate: LocalDate,
   val category: GoalCategory,
-  val steps: List<Step>,
   var status: GoalStatus = GoalStatus.ACTIVE,
-  val notes: String?,
+  val notes: String? = null,
   val createdBy: String,
   val createdAt: Instant,
   val lastUpdatedBy: String,
   val lastUpdatedAt: Instant,
+  steps: List<Step>,
 ) {
+
+  /**
+   * Returns the Goal's [Step]s, ordered by their sequence number (ascending).
+   */
+  val steps: MutableList<Step>
+    get() = field.also { steps -> steps.sortBy { it.sequenceNumber } }
 
   init {
     if (steps.isEmpty()) {
       throw InvalidGoalException("Cannot create Goal with reference [$reference]. At least one Step is required.")
     }
+    this.steps = steps.toMutableList()
   }
 
+  /**
+   * Adds a [Step] to this Goal.
+   */
+  fun addStep(step: Step) =
+    steps.add(step)
+
   fun complete() {
-    status = GoalStatus.COMPLETED
+    status = COMPLETED
   }
 
   fun archive() {
-    status = GoalStatus.ARCHIVED
+    status = ARCHIVED
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Step.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Step.kt
@@ -1,18 +1,19 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
 
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus.NOT_STARTED
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 /**
  * Represents an individual Step (or task) within a Goal. For example there could be a number of Steps to take before
  * the Goal itself can be considered complete, such as booking a course, doing the course and then taking an exam.
  *
- * Each step has its own lifecycle (such as active or completed) and are ordered sequentially within the parent Goal.
+ * Each Step has its own lifecycle (such as active or completed) and are ordered sequentially within the parent Goal.
  */
 data class Step(
   val reference: UUID,
   val title: String,
   val targetDate: LocalDate,
-  val status: StepStatus,
+  val status: StepStatus = NOT_STARTED,
   val sequenceNumber: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalPersistenceAdapter.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+
+/**
+ * Persistence Adapter for [Goal] instances.
+ *
+ * Implementations should use the underlying persistence of the application in question, eg: JPA, Mongo, Dynamo, Redis etc
+ *
+ * Implementations should not throw exceptions. These are not part of the interface and are not checked or handled by
+ * [GoalService].
+ */
+interface GoalPersistenceAdapter {
+
+  /**
+   * Creates a [Goal].
+   */
+  fun saveGoal(goal: Goal): Goal
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalService.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+
+/**
+ * Service class exposing methods that implement the business rules for the Goal domain, and is how applications
+ * must create and manage [Goal]s.
+ *
+ * Applications using [Goal]s must new up an instance of this class providing an implementation of
+ * [GoalPersistenceAdapter].
+ *
+ * This class is deliberately final so that it cannot be subclassed, ensuring that the business rules stay within the
+ * domain.
+ */
+class GoalService(
+  private val persistenceAdapter: GoalPersistenceAdapter,
+) {
+
+  fun saveGoal(goal: Goal): Goal =
+    persistenceAdapter.saveGoal(goal)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalTest.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalCategory.RESETTLEMENT
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+class GoalTest {
+
+  @Test
+  fun `should create Goal given Steps out of sequence`() {
+    // Given
+    val step1 = aValidStep(sequenceNumber = 1)
+    val step2 = aValidStep(sequenceNumber = 2)
+    val step3 = aValidStep(sequenceNumber = 3)
+
+    // When
+    val goal = aValidGoal(steps = mutableListOf(step2, step3, step1))
+
+    // Then
+    assertThat(goal.steps).containsExactly(
+      step1,
+      step2,
+      step3,
+    )
+  }
+
+  @Test
+  fun `should add Step and maintain Step order`() {
+    // Given
+    val step1 = aValidStep(sequenceNumber = 1)
+    val step2 = aValidStep(sequenceNumber = 2)
+    val step3 = aValidStep(sequenceNumber = 3)
+    val goal = aValidGoal(steps = mutableListOf(step1, step3))
+
+    // When
+    goal.addStep(step2)
+
+    // Then
+    assertThat(goal.steps).containsExactly(
+      step1,
+      step2,
+      step3,
+    )
+  }
+
+  @Test
+  fun `should fail to create Goal given no Steps`() {
+    // Given
+    val goalReference = UUID.randomUUID()
+    val steps = emptyList<Step>()
+
+    // When
+    val exception: InvalidGoalException = catchThrowableOfType(
+      {
+        Goal(
+          reference = goalReference,
+          title = "Improve woodworking skills",
+          reviewDate = LocalDate.now().plusMonths(6),
+          category = RESETTLEMENT,
+          status = ACTIVE,
+          createdBy = "",
+          createdAt = Instant.now(),
+          lastUpdatedBy = "",
+          lastUpdatedAt = Instant.now(),
+          steps = steps,
+        )
+      },
+      InvalidGoalException::class.java,
+    )
+
+    // Then
+    assertThat(exception.message).isEqualTo("Cannot create Goal with reference [$goalReference]. At least one Step is required.")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
+
+@ExtendWith(MockitoExtension::class)
+class GoalServiceTest {
+  @InjectMocks
+  private lateinit var service: GoalService
+
+  @Mock
+  private lateinit var persistenceAdapter: GoalPersistenceAdapter
+
+  @Test
+  fun `should create goal`() {
+    // Given
+    val goal = aValidGoal()
+    given(persistenceAdapter.saveGoal(any())).willReturn(goal)
+
+    // When
+    service.saveGoal(goal)
+
+    // Then
+    verify(persistenceAdapter).saveGoal(goal)
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalBuilder.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalCategory.PERSONAL_DEVELOPMENT
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+fun aValidGoal(
+  reference: UUID = UUID.randomUUID(),
+  title: String = "Improve communication skills",
+  reviewDate: LocalDate = LocalDate.now().plusMonths(6),
+  category: GoalCategory = PERSONAL_DEVELOPMENT,
+  steps: List<Step> = mutableListOf(aValidStep(), anotherValidStep()),
+  status: GoalStatus = ACTIVE,
+  notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
+  createdBy: String = "",
+  createdAt: Instant = Instant.now(),
+  lastUpdatedBy: String = "",
+  lastUpdatedAt: Instant = Instant.now(),
+): Goal =
+  Goal(
+    reference = reference,
+    title = title,
+    reviewDate = reviewDate,
+    category = category,
+    steps = steps,
+    status = status,
+    notes = notes,
+    createdBy = createdBy,
+    createdAt = createdAt,
+    lastUpdatedBy = lastUpdatedBy,
+    lastUpdatedAt = lastUpdatedAt,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/StepBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/StepBuilder.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus.NOT_STARTED
+import java.time.LocalDate
+import java.util.UUID
+
+fun aValidStep(
+  reference: UUID = UUID.randomUUID(),
+  title: String = "Book communication skills course",
+  targetDate: LocalDate = LocalDate.now().plusMonths(1),
+  status: StepStatus = NOT_STARTED,
+  sequenceNumber: Int = 1,
+): Step =
+  Step(
+    reference = reference,
+    title = title,
+    targetDate = targetDate,
+    status = status,
+    sequenceNumber = sequenceNumber,
+  )
+
+fun anotherValidStep(
+  reference: UUID = UUID.randomUUID(),
+  title: String = "Complete communication skills course",
+  targetDate: LocalDate = LocalDate.now().plusMonths(6),
+  status: StepStatus = NOT_STARTED,
+  sequenceNumber: Int = 2,
+): Step =
+  Step(
+    reference = reference,
+    title = title,
+    targetDate = targetDate,
+    status = status,
+    sequenceNumber = sequenceNumber,
+  )


### PR DESCRIPTION
Following on from @nathanrussell-moj-digital's [PR](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/pull/5) to add a basic service for Timeline events, this PR follows the same pattern and introduces a service for Goals.