### PR TITLE
Wire in database

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.2.0"
   kotlin("plugin.spring") version "1.8.21"
+  kotlin("plugin.jpa") version "1.8.21"
 
   id("jacoco")
   id("name.remal.integration-tests") version "4.0.0"
@@ -14,6 +15,15 @@ configurations {
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+  implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+  implementation("io.github.microutils:kotlin-logging:3.0.5")
+
+  runtimeOnly("org.flywaydb:flyway-core")
+  runtimeOnly("org.postgresql:postgresql:42.6.0")
+
+  // Integration test dependencies
+  integrationTestImplementation("com.h2database:h2")
 
   // Test fixtures dependencies
   testFixturesImplementation("org.assertj:assertj-core")

--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -30,6 +30,11 @@ generic-service:
   namespace_secrets:
     hmpps-education-and-work-plan-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+    rds-instance-output:
+      DB_SERVER: "rds_instance_address"
+      DB_NAME: "database_name"
+      DB_USER: "database_username"
+      DB_PASS: "database_password"
 
   allowlist:
     office: "217.33.148.210/32"

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -7,7 +7,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-@ActiveProfiles("test")
+@ActiveProfiles("integration-test")
 abstract class IntegrationTestBase {
 
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")

--- a/src/integrationTest/resources/application-integration-test.yml
+++ b/src/integrationTest/resources/application-integration-test.yml
@@ -1,0 +1,16 @@
+server:
+  shutdown: immediate
+
+management.endpoint:
+  health.cache.time-to-live: 0
+  info.cache.time-to-live: 0
+
+spring:
+  datasource:
+    url: 'jdbc:h2:mem:education_and_work_plan_api_db;MODE=PostgreSQL'
+    username: admin
+    password: admin_password
+
+  h2:
+    console:
+      enabled: true

--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -1,6 +1,0 @@
-server:
-  shutdown: immediate
-
-management.endpoint:
-  health.cache.time-to-live: 0
-  info.cache.time-to-live: 0

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 info.app:
-  name: Hmpps Education And Work Plan Api
+  name: HMPPS Education And Work Plan API
   version: 1.0
 
 spring:
@@ -17,6 +17,20 @@ spring:
     group:
       test:
         - "stdout"
+
+  datasource:
+    url: 'jdbc:postgresql://${DB_SERVER}/${DB_NAME}?sslmode=verify-full'
+    username: ${DB_USER}
+    password: ${DB_PASS}
+    hikari:
+      pool-name: EducationAndWorkPlan-DB-CP
+      connectionTimeout: 1000
+      validationTimeout: 500
+
+  flyway:
+    url: ${spring.datasource.url}
+    user: ${spring.datasource.username}
+    password: ${spring.datasource.password}
 
 server:
   port: 8080


### PR DESCRIPTION
This PR adds the JPA and flyway dependencies, and sets up the helm gubbins to provide the database secrets from the environment.

At the moment I've wired in h2 as the database for the integration tests as it was easier. As we start building out the functionality we can consider whether we'd be better off with h2 or postgres in docker (testcontainers)