### PR TITLE
Correct rds secret name

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -30,7 +30,7 @@ generic-service:
   namespace_secrets:
     hmpps-education-and-work-plan-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
-    rds-instance-output:
+    rds-postgresql-instance-output:
       DB_SERVER: "rds_instance_address"
       DB_NAME: "database_name"
       DB_USER: "database_username"


### PR DESCRIPTION
The PR corrects the RDS secret name that [our namespace in cloud platform environment sets up](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/rds-postgresql.tf#L88)

(That'll teach me to blindly copy & paste from other apps! 😁 )
