### PR TITLE
Added the prisonNumber to the domain Goal service and persistence adapter methods

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalPersistenceAdapter.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
 interface GoalPersistenceAdapter {
 
   /**
-   * Creates a [Goal].
+   * Saves the [Goal] for the prisoner identified by their prison number.
    */
-  fun saveGoal(goal: Goal): Goal
+  fun saveGoal(goal: Goal, prisonNumber: String): Goal
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalService.kt
@@ -16,6 +16,9 @@ class GoalService(
   private val persistenceAdapter: GoalPersistenceAdapter,
 ) {
 
-  fun saveGoal(goal: Goal): Goal =
-    persistenceAdapter.saveGoal(goal)
+  /**
+   * Saves the [Goal] for the prisoner identified by their prison number.
+   */
+  fun saveGoal(goal: Goal, prisonNumber: String): Goal =
+    persistenceAdapter.saveGoal(goal, prisonNumber)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
 
 @ExtendWith(MockitoExtension::class)
@@ -19,15 +20,17 @@ class GoalServiceTest {
   private lateinit var persistenceAdapter: GoalPersistenceAdapter
 
   @Test
-  fun `should create goal`() {
+  fun `should save goal for a prison number`() {
     // Given
     val goal = aValidGoal()
-    given(persistenceAdapter.saveGoal(any())).willReturn(goal)
+    given(persistenceAdapter.saveGoal(any(), any())).willReturn(goal)
+
+    val prisonNumber = aValidPrisonNumber()
 
     // When
-    service.saveGoal(goal)
+    service.saveGoal(goal, prisonNumber)
 
     // Then
-    verify(persistenceAdapter).saveGoal(goal)
+    verify(persistenceAdapter).saveGoal(goal, prisonNumber)
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/CommonBuilders.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/CommonBuilders.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi
+
+/**
+ * Builder functions for common data items that are not aligned to a specific domain, REST model or JPA entity; such as
+ * prison numbers, times and dates etc.
+ */
+
+fun aValidPrisonNumber() = "A1234BC"

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/Placeholder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/Placeholder.kt
@@ -1,4 +1,0 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi
-
-// This file is only here as part of the initial commit in order to maintain the package directory structure
-// Remove once the first classes are added to this package


### PR DESCRIPTION
This PR adds the prison number as an argument to the domain Goal service and persistence adapter methods for `saveGoal`

The need for this has come out of the work I am currently doing re: creating the Goal JPA entities and writing the implementation to actually save to the database - without the prison number we cannot fulfil the RDBMS relationship of a Goal to its 'parent' ActionPlan
