### PR TITLE
Setup spring security

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,9 @@ configurations {
 }
 
 dependencies {
+  implementation("org.springframework.boot:spring-boot-starter-security")
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/JwtConfig.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/JwtConfig.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPublicKey
+
+@Configuration
+class JwtConfig {
+  private val keyPair: KeyPair
+
+  init {
+    val gen = KeyPairGenerator.getInstance("RSA")
+    gen.initialize(2048)
+    keyPair = gen.generateKeyPair()
+  }
+
+  @Bean
+  fun jwtDecoder(): JwtDecoder = NimbusJwtDecoder.withPublicKey(keyPair.public as RSAPublicKey).build()
+
+  @Bean
+  fun keyPair() = keyPair
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/JwtConfig.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/JwtConfig.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/AuthAwareTokenConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/AuthAwareTokenConverter.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
+import org.springframework.stereotype.Component
+
+@Component
+class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
+  private val jwtGrantedAuthoritiesConverter: Converter<Jwt, Collection<GrantedAuthority>> = JwtGrantedAuthoritiesConverter()
+
+  override fun convert(jwt: Jwt): AbstractAuthenticationToken {
+    val claims = jwt.claims
+    val principal = findPrincipal(claims)
+    val authorities = extractAuthorities(jwt)
+    return AuthAwareAuthenticationToken(jwt, principal, authorities)
+  }
+
+  private fun findPrincipal(claims: Map<String, Any?>): String {
+    return if (claims.containsKey("user_name")) {
+      claims["user_name"] as String
+    } else {
+      claims["client_id"] as String
+    }
+  }
+
+  private fun extractAuthorities(jwt: Jwt): Collection<GrantedAuthority> =
+    mutableListOf<GrantedAuthority>().apply {
+      addAll(jwtGrantedAuthoritiesConverter.convert(jwt)!!)
+      jwt.getClaimAsStringList("authorities")?.map(::SimpleGrantedAuthority)?.let(::addAll)
+    }.toSet()
+}
+
+class AuthAwareAuthenticationToken(
+  jwt: Jwt,
+  private val principal: String,
+  authorities: Collection<GrantedAuthority>,
+) : JwtAuthenticationToken(jwt, authorities) {
+  override fun getPrincipal(): Any {
+    return principal
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/ResourceServerConfiguration.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true, proxyTargetClass = true)
+class ResourceServerConfiguration {
+
+  @Bean
+  fun filterChain(http: HttpSecurity): SecurityFilterChain {
+    http {
+      sessionManagement { SessionCreationPolicy.STATELESS }
+      headers { frameOptions { sameOrigin = true } }
+      csrf { disable() }
+      authorizeHttpRequests {
+        listOf(
+          "/webjars/**",
+          "favicon.ico",
+          "/health/**",
+          "/info",
+          "/swagger-resources/**",
+          "/v3/api-docs/**",
+          "/swagger-ui/**",
+          "/swagger-ui.html",
+          "/h2-console/**",
+        ).forEach { authorize(it, permitAll) }
+        authorize(anyRequest, authenticated)
+      }
+      oauth2ResourceServer { jwt { jwtAuthenticationConverter = AuthAwareTokenConverter() } }
+    }
+
+    return http.build()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/UserContext.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/UserContext.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
+
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+
+@Component
+object UserContext {
+  private val authToken = ThreadLocal<String>()
+  private val authentication = ThreadLocal<Authentication>()
+  fun setAuthToken(token: String?) = authToken.set(token)
+
+  // fun getAuthToken(): String = authToken.get() - not used yet
+  fun setAuthentication(auth: Authentication?) = authentication.set(auth)
+  fun getAuthentication(): Authentication = authentication.get()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/UserContextFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/UserContextFilter.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
+
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.FilterConfig
+import jakarta.servlet.ServletException
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpHeaders
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import java.io.IOException
+
+@Component
+@Order(4)
+class UserContextFilter : Filter {
+  @Throws(IOException::class, ServletException::class)
+  override fun doFilter(servletRequest: ServletRequest, servletResponse: ServletResponse, filterChain: FilterChain) {
+    val httpServletRequest = servletRequest as HttpServletRequest
+    val authToken = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)
+    val authentication = SecurityContextHolder.getContext().authentication
+    UserContext.setAuthToken(authToken)
+    UserContext.setAuthentication(authentication)
+    filterChain.doFilter(httpServletRequest, servletResponse)
+  }
+
+  override fun init(filterConfig: FilterConfig) {}
+  override fun destroy() {}
+}


### PR DESCRIPTION
This PR copies the basic spring security config from activities-api
This is needed as part of the JPA work (because we need the user principal for the createdBy etc fields), but I didnt want to bring all the spring security stuff into that PR because that PR is big enough already!

Its a bare bones spring security config - we can configure it to our needs once we get into the detail of the controllers etc