### PR TITLE
Fix security config so that openapi doc is served to unauthenticated requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,5 @@ The easiest (and slowest) way to run the app is to use docker compose to create 
 
 `docker-compose up`
 
-See `http://localhost:8080/health` to check the app is running.
+* See `http://localhost:8081/health` to check the app is running.
+* See `http://localhost:8081/swagger-ui/index.html?configUrl=/v3/api-docs` to explore the OpenAPI spec document.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/ResourceServerConfiguration.kt
@@ -30,6 +30,7 @@ class ResourceServerConfiguration {
           "/v3/api-docs/**",
           "/swagger-ui/**",
           "/swagger-ui.html",
+          "/openapi/**",
           "/h2-console/**",
         ).forEach { authorize(it, permitAll) }
         authorize(anyRequest, authenticated)


### PR DESCRIPTION
This PR updates the web security config to allow the openapi spec document (static document) to be served without any authentication token.

To demonstrate the current problem, go to: https://hmpps-education-and-work-plan-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs
<img width="1632" alt="Screenshot 2023-06-22 at 10 38 40" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/assets/94835226/d4946c5e-63dd-4403-915a-5a3ff71876a7">
