### PR TITLE
ActionPlanRepository and JPA PersistenceAdapter to retrieve an ActionPlan

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ActionPlanEntityMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanNotFoundException
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanPersistenceAdapter
+
+@Component
+class JpaActionPlanPersistenceAdapter(
+  private val actionPlanRepository: ActionPlanRepository,
+  private val actionPlanMapper: ActionPlanEntityMapper,
+) : ActionPlanPersistenceAdapter {
+  override fun getActionPlan(prisonNumber: String): ActionPlan {
+    val entity = actionPlanRepository.findByPrisonNumber(prisonNumber)
+      ?: throw ActionPlanNotFoundException("No Action Plan found for prisoner [$prisonNumber]")
+    return actionPlanMapper.fromEntityToDomain(entity)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapper.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper
+
+import org.mapstruct.Mapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
+
+@Mapper(
+  uses = [
+    GoalEntityMapper::class,
+  ],
+)
+interface ActionPlanEntityMapper {
+  fun fromEntityToDomain(actionPlanEntity: ActionPlanEntity): ActionPlan
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/ActionPlanRepository.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanEntity
+
+@Repository
+interface ActionPlanRepository : JpaRepository<ActionPlanEntity, String> {
+
+  fun findByPrisonNumber(prisonNumber: String): ActionPlanEntity?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Exceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Exceptions.kt
@@ -4,3 +4,8 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
  * Thrown when a Goal cannot be created, for example because it is missing mandatory data.
  */
 class InvalidGoalException(message: String) : RuntimeException(message)
+
+/**
+ * Thrown when an ActionPlan cannot be found.
+ */
+class ActionPlanNotFoundException(message: String) : RuntimeException(message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ActionPlanEntityMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
+
+@ExtendWith(MockitoExtension::class)
+class JpaActionPlanPersistenceAdapterTest {
+
+  @InjectMocks
+  private lateinit var persistenceAdapter: JpaActionPlanPersistenceAdapter
+
+  @Mock
+  private lateinit var actionPlanRepository: ActionPlanRepository
+
+  @Mock
+  private lateinit var actionPlanMapper: ActionPlanEntityMapper
+
+  @Test
+  fun `should retrieve Action Plan`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val actionPlanEntity = aValidActionPlanEntity(prisonNumber = prisonNumber)
+    val expectedActionPlanDomain = aValidActionPlan(prisonNumber = prisonNumber)
+    given(actionPlanRepository.findByPrisonNumber(any())).willReturn(actionPlanEntity)
+    given(actionPlanMapper.fromEntityToDomain(any())).willReturn(expectedActionPlanDomain)
+
+    // When
+    val actual = persistenceAdapter.getActionPlan(prisonNumber)
+
+    // Then
+    assertThat(actual).isEqualTo(expectedActionPlanDomain)
+    verify(actionPlanRepository).findByPrisonNumber(prisonNumber)
+    verify(actionPlanMapper).fromEntityToDomain(actionPlanEntity)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
+
+@ExtendWith(MockitoExtension::class)
+class ActionPlanEntityMapperTest {
+
+  @InjectMocks
+  private lateinit var mapper: ActionPlanEntityMapperImpl
+
+  @Mock
+  private lateinit var goalMapper: GoalEntityMapper
+
+  @Test
+  fun `should map from entity to domain`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val actionPlanEntity = aValidActionPlanEntity(prisonNumber = prisonNumber)
+    val goalDomain = aValidGoal()
+    given(goalMapper.fromEntityToDomain(any())).willReturn(goalDomain)
+    val expected = aValidActionPlan(prisonNumber = prisonNumber, goals = mutableListOf(goalDomain))
+
+    // When
+    val actual = mapper.fromEntityToDomain(actionPlanEntity)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+    verify(goalMapper).fromEntityToDomain(actionPlanEntity.goals!![0])
+  }
+}


### PR DESCRIPTION
This PR should enable us to retrieve an `ActionPlan` all the way via the REST controller (subject to integration tests which I'll add in a subsequent PR).