### PR TITLE
RR-81 - Date related changes in DB, entity and domain

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
@@ -11,13 +11,17 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TargetDateRange
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TargetDateRange as TargetDateRangeEntity
 
 class CreateGoalTest : IntegrationTestBase() {
 
@@ -75,12 +79,13 @@ class CreateGoalTest : IntegrationTestBase() {
   fun `should add goal and create a new action plan given prisoner does not have an action plan`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val createRequest = aValidCreateGoalRequest()
+    val createStepRequest = aValidCreateStepRequest(targetDateRange = TargetDateRange.ZERO_TO_THREE_MONTHS)
+    val createGoalRequest = aValidCreateGoalRequest(steps = listOf(createStepRequest))
 
     // When
     webTestClient.post()
       .uri(URI_TEMPLATE, prisonNumber)
-      .body(Mono.just(createRequest), CreateGoalRequest::class.java)
+      .body(Mono.just(createGoalRequest), CreateGoalRequest::class.java)
       .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
       .contentType(APPLICATION_JSON)
       .exchange()
@@ -92,8 +97,12 @@ class CreateGoalTest : IntegrationTestBase() {
     assertThat(actionPlan).isForPrisonNumber(prisonNumber)
     assertThat(actionPlan).hasNumberOfGoals(1)
     val goal = actionPlan!!.goals!![0]
-    assertThat(goal).hasTitle(createRequest.title)
-    assertThat(goal).hasNumberOfSteps(createRequest.steps.size)
+    assertThat(goal).hasTitle(createGoalRequest.title)
+    assertThat(goal).hasNumberOfSteps(createGoalRequest.steps.size)
+    val step = goal.steps!![0]
+    assertThat(step).hasTitle(createStepRequest.title)
+    assertThat(step).hasTargetDateRange(TargetDateRangeEntity.ZERO_TO_THREE_MONTHS)
+    assertThat(step).hasStatus(StepStatus.NOT_STARTED)
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
@@ -94,15 +94,18 @@ class CreateGoalTest : IntegrationTestBase() {
 
     // Then
     val actionPlan = actionPlanRepository.findByPrisonNumber(prisonNumber)
-    assertThat(actionPlan).isForPrisonNumber(prisonNumber)
-    assertThat(actionPlan).hasNumberOfGoals(1)
+    assertThat(actionPlan)
+      .isForPrisonNumber(prisonNumber)
+      .hasNumberOfGoals(1)
     val goal = actionPlan!!.goals!![0]
-    assertThat(goal).hasTitle(createGoalRequest.title)
-    assertThat(goal).hasNumberOfSteps(createGoalRequest.steps.size)
+    assertThat(goal)
+      .hasTitle(createGoalRequest.title)
+      .hasNumberOfSteps(createGoalRequest.steps.size)
     val step = goal.steps!![0]
-    assertThat(step).hasTitle(createStepRequest.title)
-    assertThat(step).hasTargetDateRange(TargetDateRangeEntity.ZERO_TO_THREE_MONTHS)
-    assertThat(step).hasStatus(StepStatus.NOT_STARTED)
+    assertThat(step)
+      .hasTitle(createStepRequest.title)
+      .hasTargetDateRange(TargetDateRangeEntity.ZERO_TO_THREE_MONTHS)
+      .hasStatus(StepStatus.NOT_STARTED)
   }
 
   @Test
@@ -130,8 +133,9 @@ class CreateGoalTest : IntegrationTestBase() {
 
     // Then
     val actual = actionPlanRepository.findByPrisonNumber(prisonNumber)
-    assertThat(actual).isForPrisonNumber(prisonNumber)
-    assertThat(actual).hasNumberOfGoals(2)
+    assertThat(actual)
+      .isForPrisonNumber(prisonNumber)
+      .hasNumberOfGoals(2)
   }
 
   @Test
@@ -159,11 +163,13 @@ class CreateGoalTest : IntegrationTestBase() {
 
     // Then
     val actual = actionPlanRepository.findByPrisonNumber(prisonNumber)
-    assertThat(actual).isForPrisonNumber(prisonNumber)
-    assertThat(actual).hasNumberOfGoals(2)
+    assertThat(actual)
+      .isForPrisonNumber(prisonNumber)
+      .hasNumberOfGoals(2)
     val goal = actual!!.goals!![1]
-    assertThat(goal).hasTitle(createRequest.title)
-    assertThat(goal).hasNumberOfSteps(createRequest.steps.size)
+    assertThat(goal)
+      .hasTitle(createRequest.title)
+      .hasNumberOfSteps(createRequest.steps.size)
     assertThat(goal.notes).isNull()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
@@ -42,7 +42,6 @@ class GoalEntity(
   var title: String? = null,
 
   @Column
-  @field:NotNull
   var reviewDate: LocalDate? = null,
 
   @Column

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/StepEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/StepEntity.kt
@@ -38,6 +38,12 @@ class StepEntity(
   var title: String? = null,
 
   @Column
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var targetDateRange: TargetDateRange? = null,
+
+  // targetDate is no longer used but remains here (and in the database table) in case the business decide to use it again
+  @Column
   var targetDate: LocalDate? = null,
 
   @Column
@@ -79,6 +85,13 @@ class StepEntity(
   override fun toString(): String {
     return this::class.simpleName + "(id = $id, reference = $reference, title = $title)"
   }
+}
+
+enum class TargetDateRange {
+  ZERO_TO_THREE_MONTHS,
+  THREE_TO_SIX_MONTHS,
+  SIX_TO_TWELVE_MONTHS,
+  MORE_THAN_TWELVE_MONTHS,
 }
 
 enum class StepStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapper.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper
 
 import org.mapstruct.Mapper
+import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
 
@@ -13,6 +14,7 @@ interface StepEntityMapper {
    * This method is suitable for creating a new [StepEntity] to be subsequently persisted to the database.
    */
   @ExcludeJpaManagedFields
+  @Mapping(target = "targetDate", ignore = true)
   fun fromDomainToEntity(step: Step): StepEntity
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapper.kt
@@ -18,7 +18,5 @@ interface StepResourceMapper {
   fun fromModelToDomain(createStepRequest: CreateStepRequest): Step
 
   @Mapping(target = "stepReference", source = "reference")
-  // TODO - RR-81 - map once targetDateRange have been added to the domain model etc
-  @Mapping(target = "targetDateRange", constant = "ZERO_TO_THREE_MONTHS")
   fun fromDomainToModel(stepDomain: Step): StepResponse
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 class Goal(
   val reference: UUID,
   val title: String,
-  val reviewDate: LocalDate,
+  val reviewDate: LocalDate?,
   val category: GoalCategory,
   var status: GoalStatus = GoalStatus.ACTIVE,
   val notes: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Step.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Step.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus.NOT_STARTED
-import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -13,7 +12,7 @@ import java.util.UUID
 data class Step(
   val reference: UUID,
   val title: String,
-  val targetDate: LocalDate?,
+  val targetDateRange: TargetDateRange,
   val status: StepStatus = NOT_STARTED,
   val sequenceNumber: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/TargetDateRange.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/TargetDateRange.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
+
+enum class TargetDateRange {
+  ZERO_TO_THREE_MONTHS,
+  THREE_TO_SIX_MONTHS,
+  SIX_TO_TWELVE_MONTHS,
+  MORE_THAN_TWELVE_MONTHS,
+}

--- a/src/main/resources/db/migration/V2023.07.10.0001__date_field_changes_.sql
+++ b/src/main/resources/db/migration/V2023.07.10.0001__date_field_changes_.sql
@@ -1,5 +1,79 @@
---- Table goal - make review_date nullable
-ALTER TABLE goal ALTER COLUMN review_date DROP NOT NULL;
+--- Drop all the tables because the ID columns were originally created incorrectly
+--- Given that there is no data in the tables the safest and easiest thing to do is to drop and re-create them
+drop table step;
+drop table goal;
+drop table action_plan;
 
---- Table step - add target_date_range
-ALTER TABLE step ADD COLUMN target_date_range VARCHAR(50);
+--- Table action_plan
+CREATE TABLE action_plan
+(
+    id            UUID         PRIMARY KEY,
+    prison_number VARCHAR(10)  NOT NULL,
+    created_at    TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by    VARCHAR(50)  NOT NULL,
+    updated_at    TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by    VARCHAR(50)  NOT NULL
+);
+
+CREATE UNIQUE INDEX action_plan_prison_number_idx ON action_plan
+    (
+     prison_number
+        );
+
+
+--- Table goal
+CREATE TABLE goal
+(
+    id              UUID         PRIMARY KEY,
+    action_plan_id  UUID         NOT NULL,
+    reference       UUID         NOT NULL,
+    title           VARCHAR(512) NOT NULL,
+    review_date     DATE,
+    category        VARCHAR(50)  NOT NULL,
+    status          VARCHAR(50)  NOT NULL,
+    notes           TEXT,
+    created_at      TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by      VARCHAR(50)  NOT NULL,
+    updated_at      TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by      VARCHAR(50)  NOT NULL,
+
+    CONSTRAINT fk_action_plan_goal FOREIGN KEY (action_plan_id) REFERENCES action_plan(id)
+);
+
+CREATE UNIQUE INDEX goal_reference_idx ON goal
+    (
+     reference
+        );
+CREATE INDEX goal_action_plan_id_idx ON goal
+    (
+     action_plan_id
+        );
+
+
+--- Table step
+CREATE TABLE step
+(
+    id                 UUID         PRIMARY KEY,
+    goal_id            UUID         NOT NULL,
+    reference          UUID         NOT NULL,
+    title              VARCHAR(512) NOT NULL,
+    target_date_range  VARCHAR(50)  NOT NULL,
+    target_date        DATE,
+    status             VARCHAR(50)  NOT NULL,
+    sequence_number    SMALLINT     NOT NULL,
+    created_at         TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by         VARCHAR(50)  NOT NULL,
+    updated_at         TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by         VARCHAR(50)  NOT NULL,
+
+    CONSTRAINT fk_goal_step FOREIGN KEY (goal_id) REFERENCES goal(id)
+);
+
+CREATE UNIQUE INDEX step_reference_idx ON step
+    (
+     reference
+        );
+CREATE INDEX step_goal_id_idx ON step
+    (
+     goal_id
+        );

--- a/src/main/resources/db/migration/V2023.07.10.0001__date_field_changes_.sql
+++ b/src/main/resources/db/migration/V2023.07.10.0001__date_field_changes_.sql
@@ -1,0 +1,5 @@
+--- Table goal - make review_date nullable
+ALTER TABLE goal ALTER COLUMN review_date DROP NOT NULL;
+
+--- Table step - add target_date_range
+ALTER TABLE step ADD COLUMN target_date_range VARCHAR(50);

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -236,7 +236,7 @@ components:
     CreateStepRequest:
       title: CreateStepRequest
       type: object
-      description: A request to create a Step within a Goal. The Step is created a status of NOT_STARTED.
+      description: A request to create a Step within a Goal. The Step is created a status of NOT_STARTED. Note that either a targetDateRange or targetDate must be provided, but not both.
       properties:
         title:
           type: string

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -236,7 +236,7 @@ components:
     CreateStepRequest:
       title: CreateStepRequest
       type: object
-      description: A request to create a Step within a Goal. The Step is created a status of NOT_STARTED. Note that either a targetDateRange or targetDate must be provided, but not both.
+      description: A request to create a Step within a Goal. The Step is created a status of NOT_STARTED.
       properties:
         title:
           type: string

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapperTest.kt
@@ -4,10 +4,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidStepEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDateRange
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
-import java.time.LocalDate
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepStatus as EntityStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TargetDateRange as EntityTargetDateRange
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus as DomainStatus
 
 class StepEntityMapperTest {
@@ -17,12 +18,10 @@ class StepEntityMapperTest {
   @Test
   fun `should map from domain to entity`() {
     // Given
-    val targetDate = LocalDate.now().plusMonths(6)
-
     val domainStep = aValidStep(
       reference = UUID.randomUUID(),
       title = "Book communication skills course",
-      targetDate = targetDate,
+      targetDateRange = TargetDateRange.ZERO_TO_THREE_MONTHS,
       status = DomainStatus.ACTIVE,
       sequenceNumber = 1,
     )
@@ -30,7 +29,7 @@ class StepEntityMapperTest {
     val expected = aValidStepEntity(
       reference = domainStep.reference,
       title = "Book communication skills course",
-      targetDate = targetDate,
+      targetDateRange = EntityTargetDateRange.ZERO_TO_THREE_MONTHS,
       status = EntityStatus.ACTIVE,
       sequenceNumber = 1,
       // JPA managed fields - expect these all to be null, implying a new db entity
@@ -55,7 +54,7 @@ class StepEntityMapperTest {
       id = null,
       reference = UUID.randomUUID(),
       title = "Book communication skills course",
-      targetDate = LocalDate.now().plusMonths(6),
+      targetDateRange = EntityTargetDateRange.THREE_TO_SIX_MONTHS,
       status = EntityStatus.ACTIVE,
       sequenceNumber = 1,
     )
@@ -63,7 +62,7 @@ class StepEntityMapperTest {
     val expected = aValidStep(
       reference = entityStep.reference!!,
       title = "Book communication skills course",
-      targetDate = LocalDate.now().plusMonths(6),
+      targetDateRange = TargetDateRange.THREE_TO_SIX_MONTHS,
       status = DomainStatus.ACTIVE,
       sequenceNumber = 1,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aVali
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidGoalResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidStepResponse
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalCategory as GoalCategoryApi
@@ -40,6 +41,7 @@ internal class GoalResourceMapperTest {
     val createStepRequest = aValidCreateStepRequest()
     val createGoalRequest = aValidCreateGoalRequest(
       category = GoalCategoryApi.PERSONAL_DEVELOPMENT,
+      reviewDate = LocalDate.now(),
       steps = mutableListOf(createStepRequest),
     )
     val expectedStep = aValidStep()
@@ -47,7 +49,7 @@ internal class GoalResourceMapperTest {
     val expectedGoal = aValidGoal(
       reference = UUID.randomUUID(),
       title = createGoalRequest.title,
-      reviewDate = createGoalRequest.reviewDate!!,
+      reviewDate = createGoalRequest.reviewDate,
       category = GoalCategory.PERSONAL_DEVELOPMENT,
       status = GoalStatus.ACTIVE,
       notes = createGoalRequest.notes,
@@ -75,6 +77,7 @@ internal class GoalResourceMapperTest {
     val goal = aValidGoal(
       category = GoalCategory.PERSONAL_DEVELOPMENT,
       status = GoalStatus.ACTIVE,
+      reviewDate = null,
       steps = mutableListOf(step),
       createdBy = "a.user.id",
       lastUpdatedBy = "another.user.id",
@@ -86,7 +89,7 @@ internal class GoalResourceMapperTest {
     val expected = aValidGoalResponse(
       reference = goal.reference,
       title = goal.title,
-      reviewDate = goal.reviewDate,
+      reviewDate = null,
       category = GoalCategoryApi.PERSONAL_DEVELOPMENT,
       status = GoalStatusApi.ACTIVE,
       notes = goal.notes,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapperTest.kt
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.junit.jupiter.MockitoExtension
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDateRange
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidStepResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.StepStatus as StepStatusApi
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TargetDateRange as TargetDateRangeApi
 
 @ExtendWith(MockitoExtension::class)
 internal class StepResourceMapperTest {
@@ -23,7 +25,7 @@ internal class StepResourceMapperTest {
     val createStepRequest = aValidCreateStepRequest()
     val expectedStep = aValidStep(
       title = createStepRequest.title,
-      targetDate = null,
+      targetDateRange = TargetDateRange.ZERO_TO_THREE_MONTHS,
       status = StepStatus.NOT_STARTED,
       sequenceNumber = createStepRequest.sequenceNumber,
     )
@@ -43,6 +45,7 @@ internal class StepResourceMapperTest {
     val expected = aValidStepResponse(
       reference = step.reference,
       title = step.title,
+      targetDateRange = TargetDateRangeApi.ZERO_TO_THREE_MONTHS,
       status = StepStatusApi.NOT_STARTED,
       sequenceNumber = step.sequenceNumber,
     )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/StepEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/StepEntityAssert.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.en
 
 import org.assertj.core.api.AbstractObjectAssert
 import java.time.Instant
-import java.time.LocalDate
 import java.util.UUID
 
 fun assertThat(actual: StepEntity?) = StepEntityAssert(actual)
@@ -92,11 +91,21 @@ class StepEntityAssert(actual: StepEntity?) :
     return this
   }
 
-  fun hasTargetDate(expected: LocalDate): StepEntityAssert {
+  fun hasTargetDateRange(expected: TargetDateRange): StepEntityAssert {
     isNotNull
     with(actual!!) {
-      if (targetDate != expected) {
-        failWithMessage("Expected reviewDate to be $expected, but was $targetDate")
+      if (targetDateRange != expected) {
+        failWithMessage("Expected targetDateRange to be $expected, but was $targetDateRange")
+      }
+    }
+    return this
+  }
+
+  fun hasStatus(expected: StepStatus): StepEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (status != expected) {
+        failWithMessage("Expected status to be $expected, but was $status")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/StepEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/StepEntityBuilder.kt
@@ -1,15 +1,15 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepStatus.NOT_STARTED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TargetDateRange.ZERO_TO_THREE_MONTHS
 import java.time.Instant
-import java.time.LocalDate
 import java.util.UUID
 
 fun aValidStepEntity(
   id: UUID? = UUID.randomUUID(),
   reference: UUID = UUID.randomUUID(),
   title: String = "Book communication skills course",
-  targetDate: LocalDate? = LocalDate.now().plusMonths(1),
+  targetDateRange: TargetDateRange = ZERO_TO_THREE_MONTHS,
   status: StepStatus = NOT_STARTED,
   sequenceNumber: Int = 1,
   createdAt: Instant? = Instant.now(),
@@ -21,7 +21,7 @@ fun aValidStepEntity(
     id = id,
     reference = reference,
     title = title,
-    targetDate = targetDate,
+    targetDateRange = targetDateRange,
     status = status,
     sequenceNumber = sequenceNumber,
     createdAt = createdAt,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalBuilder.kt
@@ -9,7 +9,7 @@ import java.util.UUID
 fun aValidGoal(
   reference: UUID = UUID.randomUUID(),
   title: String = "Improve communication skills",
-  reviewDate: LocalDate = LocalDate.now().plusMonths(6),
+  reviewDate: LocalDate? = null,
   category: GoalCategory = PERSONAL_DEVELOPMENT,
   steps: List<Step> = listOf(aValidStep(), anotherValidStep()),
   status: GoalStatus = ACTIVE,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/StepBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/StepBuilder.kt
@@ -1,20 +1,21 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus.NOT_STARTED
-import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDateRange.THREE_TO_SIX_MONTHS
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDateRange.ZERO_TO_THREE_MONTHS
 import java.util.UUID
 
 fun aValidStep(
   reference: UUID = UUID.randomUUID(),
   title: String = "Book communication skills course",
-  targetDate: LocalDate? = LocalDate.now().plusMonths(1),
+  targetDateRange: TargetDateRange = ZERO_TO_THREE_MONTHS,
   status: StepStatus = NOT_STARTED,
   sequenceNumber: Int = 1,
 ): Step =
   Step(
     reference = reference,
     title = title,
-    targetDate = targetDate,
+    targetDateRange = targetDateRange,
     status = status,
     sequenceNumber = sequenceNumber,
   )
@@ -22,14 +23,14 @@ fun aValidStep(
 fun anotherValidStep(
   reference: UUID = UUID.randomUUID(),
   title: String = "Complete communication skills course",
-  targetDate: LocalDate? = LocalDate.now().plusMonths(6),
+  targetDateRange: TargetDateRange = THREE_TO_SIX_MONTHS,
   status: StepStatus = NOT_STARTED,
   sequenceNumber: Int = 2,
 ): Step =
   Step(
     reference = reference,
     title = title,
-    targetDate = targetDate,
+    targetDateRange = targetDateRange,
     status = status,
     sequenceNumber = sequenceNumber,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateGoalRequestBuilder.kt
@@ -4,8 +4,7 @@ import java.time.LocalDate
 
 fun aValidCreateGoalRequest(
   title: String = "Improve communication skills",
-  // TODO RR-81 - set review date to null by default
-  reviewDate: LocalDate = LocalDate.now().plusMonths(6),
+  reviewDate: LocalDate? = null,
   category: GoalCategory = GoalCategory.PERSONAL_DEVELOPMENT,
   steps: List<CreateStepRequest> = listOf(aValidCreateStepRequest(), anotherValidCreateStepRequest()),
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseBuilder.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 fun aValidGoalResponse(
   reference: UUID = UUID.randomUUID(),
   title: String = "Improve communication skills",
-  reviewDate: LocalDate = LocalDate.now().plusMonths(6),
+  reviewDate: LocalDate? = null,
   category: GoalCategory = GoalCategory.PERSONAL_DEVELOPMENT,
   steps: List<StepResponse> = listOf(aValidStepResponse(), anotherValidStepResponse()),
   status: GoalStatus = GoalStatus.ACTIVE,


### PR DESCRIPTION
This PR introduces the following changes:

- `reviewDate` is now optional throughout.
- `targetDateRange` has been added to the domain, entity and DB.
- `targetDate` has been removed from the domain and all builders. It remains in the entity and DB but is effectively ignored. This is in case the business change their mind and revert back to `targetDate` (which is unlikely, but possible given the indecision over it in the first place).

Needs to be merged at the same time as https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/pull/36