### PR TITLE
RR-164 Add display names to swagger spec

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
@@ -28,7 +28,11 @@ interface GoalResourceMapper {
   fun fromModelToDomain(createGoalRequest: CreateGoalRequest): Goal
 
   @Mapping(target = "goalReference", source = "reference")
+  // TODO RR-106 - map createdByDisplayName
+  @Mapping(target = "createdByDisplayName", constant = "")
   @Mapping(target = "updatedBy", source = "lastUpdatedBy")
+  // TODO RR-106 - map updatedByDisplayName
+  @Mapping(target = "updatedByDisplayName", constant = "")
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
   fun fromDomainToModel(goalDomain: Goal): GoalResponse
 }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -151,8 +151,12 @@ components:
           example: Pay close attention to Peter's behaviour.
         createdBy:
           type: string
-          description: The name/ID of the person who created the goal. **Note that this is a placeholder for now currently not populated.**
-          example: 'TBD'
+          description: The DPS username of the person who created the goal.
+          example: 'asmith_gen'
+        createdByDisplayName:
+          type: string
+          description: The display name of the person who created the goal.
+          example: 'Alex Smith'
         createdAt:
           type: string
           format: date-time
@@ -160,8 +164,12 @@ components:
           example: '2023-06-19T09:39:44Z'
         updatedBy:
           type: string
-          description: The name/ID of the person who last updated the goal. **Note that this is a placeholder for now currently not populated.**
-          example: 'TBD'
+          description: The DPS username of the person who last updated the goal.
+          example: 'asmith_gen'
+        updatedByDisplayName:
+          type: string
+          description: The display name of the person who last updated the goal.
+          example: 'Alex Smith'
         updatedAt:
           type: string
           format: date-time
@@ -173,8 +181,10 @@ components:
         - status
         - steps
         - createdBy
+        - createdByDisplayName
         - createdAt
         - updatedBy
+        - updatedByDisplayName
         - updatedAt
     StepResponse:
       title: StepResponse

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
@@ -96,8 +96,10 @@ internal class GoalResourceMapperTest {
       steps = listOf(expectedStepResponse),
       createdAt = expectedDateTime,
       createdBy = "a.user.id",
+      createdByDisplayName = "",
       updatedAt = expectedDateTime,
       updatedBy = "another.user.id",
+      updatedByDisplayName = "",
     )
 
     // When

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseBuilder.kt
@@ -12,9 +12,11 @@ fun aValidGoalResponse(
   steps: List<StepResponse> = listOf(aValidStepResponse(), anotherValidStepResponse()),
   status: GoalStatus = GoalStatus.ACTIVE,
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
-  createdBy: String = "",
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
   createdAt: OffsetDateTime = OffsetDateTime.now(),
-  updatedBy: String = "",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
   updatedAt: OffsetDateTime = OffsetDateTime.now(),
 ): GoalResponse =
   GoalResponse(
@@ -26,8 +28,10 @@ fun aValidGoalResponse(
     status = status,
     notes = notes,
     createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
     createdAt = createdAt,
     updatedBy = updatedBy,
+    updatedByDisplayName = updatedByDisplayName,
     updatedAt = updatedAt,
   )
 
@@ -39,9 +43,11 @@ fun anotherValidGoalResponse(
   steps: List<StepResponse> = listOf(aValidStepResponse(title = "Attend in house bricklaying course")),
   status: GoalStatus = GoalStatus.ACTIVE,
   notes: String? = null,
-  createdBy: String = "",
+  createdBy: String = "bjones_gen",
+  createdByDisplayName: String = "Barry Jones",
   createdAt: OffsetDateTime = OffsetDateTime.now(),
-  updatedBy: String = "",
+  updatedBy: String = "bjones_gen",
+  updatedByDisplayName: String = "Barry Jones",
   updatedAt: OffsetDateTime = OffsetDateTime.now(),
 ): GoalResponse =
   GoalResponse(
@@ -53,7 +59,9 @@ fun anotherValidGoalResponse(
     status = status,
     notes = notes,
     createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
     createdAt = createdAt,
     updatedBy = updatedBy,
     updatedAt = updatedAt,
+    updatedByDisplayName = updatedByDisplayName,
   )


### PR DESCRIPTION
This PR adds the display name equivalents for the `createdBy` and `updatedBy` fields to each Goal response in the swagger spec.