### PR TITLE
RR-106 - Add and populate display name audit fields to Goal table

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
@@ -82,11 +82,20 @@ class CreateGoalTest : IntegrationTestBase() {
     val createStepRequest = aValidCreateStepRequest(targetDateRange = TargetDateRange.ZERO_TO_THREE_MONTHS)
     val createGoalRequest = aValidCreateGoalRequest(steps = listOf(createStepRequest))
 
+    val dpsUsername = "auser_gen"
+    val displayName = "Albert User"
+
     // When
     webTestClient.post()
       .uri(URI_TEMPLATE, prisonNumber)
       .body(Mono.just(createGoalRequest), CreateGoalRequest::class.java)
-      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .bearerToken(
+        aValidTokenWithEditAuthority(
+          username = dpsUsername,
+          displayName = displayName,
+          privateKey = keyPair.private,
+        ),
+      )
       .contentType(APPLICATION_JSON)
       .exchange()
       .expectStatus()
@@ -97,15 +106,18 @@ class CreateGoalTest : IntegrationTestBase() {
     assertThat(actionPlan)
       .isForPrisonNumber(prisonNumber)
       .hasNumberOfGoals(1)
+      .wasCreatedBy(dpsUsername)
     val goal = actionPlan!!.goals!![0]
     assertThat(goal)
       .hasTitle(createGoalRequest.title)
       .hasNumberOfSteps(createGoalRequest.steps.size)
+      .wasCreatedBy(dpsUsername)
     val step = goal.steps!![0]
     assertThat(step)
       .hasTitle(createStepRequest.title)
       .hasTargetDateRange(TargetDateRangeEntity.ZERO_TO_THREE_MONTHS)
       .hasStatus(StepStatus.NOT_STARTED)
+      .wasCreatedBy(dpsUsername)
   }
 
   @Test

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/AuthAwareTokenConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/AuthAwareTokenConverter.kt
@@ -8,6 +8,7 @@ import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
 import org.springframework.stereotype.Component
+import java.security.Principal
 
 @Component
 class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
@@ -15,17 +16,26 @@ class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
 
   override fun convert(jwt: Jwt): AbstractAuthenticationToken {
     val claims = jwt.claims
-    val principal = findPrincipal(claims)
+
+    val username = findUsername(claims)
+    val displayName = findDisplayName(claims) ?: username
+    val principal = DpsPrincipal(username, displayName)
+
     val authorities = extractAuthorities(jwt)
+
     return AuthAwareAuthenticationToken(jwt, principal, authorities)
   }
 
-  private fun findPrincipal(claims: Map<String, Any?>): String {
+  private fun findUsername(claims: Map<String, Any?>): String {
     return if (claims.containsKey("user_name")) {
       claims["user_name"] as String
     } else {
       claims["client_id"] as String
     }
+  }
+
+  private fun findDisplayName(claims: Map<String, Any?>): String? {
+    return claims["name"] as String?
   }
 
   private fun extractAuthorities(jwt: Jwt): Collection<GrantedAuthority> =
@@ -37,10 +47,18 @@ class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
 
 class AuthAwareAuthenticationToken(
   jwt: Jwt,
-  private val principal: String,
+  private val principal: DpsPrincipal,
   authorities: Collection<GrantedAuthority>,
 ) : JwtAuthenticationToken(jwt, authorities) {
   override fun getPrincipal(): Any {
     return principal
   }
+}
+
+class DpsPrincipal(
+  private val username: String,
+  val displayName: String,
+) : Principal {
+
+  override fun getName(): String = username
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/DisplayNameAuditingEntityListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/DisplayNameAuditingEntityListener.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
+
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+
+/**
+ * JPA Entity Listener that sets fields annotated with [AuditDisplayName] with the authenticated user's display name.
+ */
+class DisplayNameAuditingEntityListener {
+
+  @PrePersist
+  @PreUpdate
+  fun updateAuditDisplayNameFields(target: Any) {
+    val currentUserDisplayName = UserPrincipalAuditorAware.getCurrentAuditorDisplayName()
+    target.javaClass.declaredFields
+      .filter { field -> field.isAnnotationPresent(AuditDisplayName::class.java) }
+      .onEach { field ->
+        field.isAccessible = true
+        field.set(target, currentUserDisplayName)
+      }
+  }
+
+  /**
+   * Simple marker annotation to mark an entity field as having its value set by [DisplayNameAuditingEntityListener].
+   */
+  @Target(AnnotationTarget.FIELD)
+  @Retention(AnnotationRetention.RUNTIME)
+  @MustBeDocumented
+  annotation class AuditDisplayName
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAware.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAware.kt
@@ -3,21 +3,36 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
 import org.springframework.data.domain.AuditorAware
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.DpsPrincipal
 import java.util.Optional
 
 @Component
 class UserPrincipalAuditorAware : AuditorAware<String> {
 
-  private companion object {
-    const val SYSTEM: String = "system"
+  companion object {
+    fun getCurrentAuditorDisplayName(): String = CurrentUser().displayName
   }
 
-  override fun getCurrentAuditor(): Optional<String> {
-    return with(SecurityContextHolder.getContext().authentication) {
+  override fun getCurrentAuditor(): Optional<String> = Optional.of(CurrentUser().username)
+}
+
+class CurrentUser {
+  companion object {
+    private const val SYSTEM: String = "system"
+  }
+
+  val username: String
+  val displayName: String
+
+  init {
+    with(SecurityContextHolder.getContext()?.authentication) {
       if (this != null && this.isAuthenticated) {
-        Optional.of(this.name)
+        val principal = this.principal as DpsPrincipal
+        username = principal.name
+        displayName = principal.displayName
       } else {
-        Optional.of(SYSTEM)
+        username = SYSTEM
+        displayName = SYSTEM
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
@@ -20,13 +20,15 @@ import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.AuditDisplayName
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
 @Table(name = "goal")
 @Entity
-@EntityListeners(AuditingEntityListener::class)
+@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class])
 class GoalEntity(
   @Id
   @GeneratedValue
@@ -71,12 +73,20 @@ class GoalEntity(
   var createdBy: String? = null,
 
   @Column
+  @AuditDisplayName
+  var createdByDisplayName: String? = null,
+
+  @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
 
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
+
+  @Column
+  @AuditDisplayName
+  var updatedByDisplayName: String? = null,
 ) {
 
   override fun equals(other: Any?): Boolean {

--- a/src/main/resources/db/migration/V2023.07.25.0001__add_audit_display_name_fields_to_goal.sql
+++ b/src/main/resources/db/migration/V2023.07.25.0001__add_audit_display_name_fields_to_goal.sql
@@ -1,0 +1,8 @@
+ALTER TABLE goal ADD COLUMN created_by_display_name VARCHAR(100);
+ALTER TABLE goal ADD COLUMN updated_by_display_name VARCHAR(100);
+
+UPDATE goal SET created_by_display_name = created_by;
+UPDATE goal SET updated_by_display_name = updated_by;
+
+ALTER TABLE goal ALTER COLUMN created_by_display_name VARCHAR(100) NOT NULL;
+ALTER TABLE goal ALTER COLUMN updated_by_display_name VARCHAR(100) NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAwareTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAwareTest.kt
@@ -1,0 +1,85 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.DpsPrincipal
+import java.util.Optional
+
+class UserPrincipalAuditorAwareTest {
+
+  companion object {
+    private const val USERNAME = "auser_gen"
+    private const val DISPLAY_NAME = "Albert User"
+    private val ROLES = emptyList<GrantedAuthority>()
+
+    private val PRINCIPAL = DpsPrincipal(USERNAME, DISPLAY_NAME)
+    private val AUTHENTICATION = TestingAuthenticationToken(PRINCIPAL, null, ROLES)
+  }
+
+  private val auditorAware = UserPrincipalAuditorAware()
+
+  @AfterEach
+  fun resetSpringSecurity() {
+    SecurityContextHolder.clearContext()
+  }
+
+  @Test
+  fun `should get current auditor`() {
+    // Given
+    SecurityContextHolder.getContext().authentication = AUTHENTICATION
+
+    val expected = Optional.of("auser_gen")
+
+    // When
+    val actual = auditorAware.currentAuditor
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should get current auditor display name`() {
+    // Given
+    SecurityContextHolder.getContext().authentication = AUTHENTICATION
+
+    val expected = "Albert User"
+
+    // When
+    val actual = UserPrincipalAuditorAware.getCurrentAuditorDisplayName()
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should get current auditor given no authentication`() {
+    // Given
+    SecurityContextHolder.clearContext()
+
+    val expected = Optional.of("system")
+
+    // When
+    val actual = auditorAware.currentAuditor
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should get current auditor display name given no authentication`() {
+    // Given
+    SecurityContextHolder.clearContext()
+
+    val expected = "system"
+
+    // When
+    val actual = UserPrincipalAuditorAware.getCurrentAuditorDisplayName()
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/JwtAccessTokenBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/JwtAccessTokenBuilder.kt
@@ -9,48 +9,56 @@ import java.util.Date
 import java.util.UUID
 
 fun aValidTokenWithViewAuthority(
-  dpsUsername: String = "auser_gen",
+  username: String = "auser_gen",
+  displayName: String = "Albert User",
   privateKey: PrivateKey,
 ): String =
   buildAccessToken(
-    dpsUsername,
-    listOf("ROLE_EDUCATION_WORK_PLAN_VIEWER"),
-    privateKey,
+    username = username,
+    displayName = displayName,
+    roles = listOf("ROLE_EDUCATION_WORK_PLAN_VIEWER"),
+    privateKey = privateKey,
   )
 
 fun aValidTokenWithEditAuthority(
-  dpsUsername: String = "auser_gen",
+  username: String = "auser_gen",
+  displayName: String = "Albert User",
   privateKey: PrivateKey,
 ): String =
   buildAccessToken(
-    dpsUsername,
-    listOf("ROLE_EDUCATION_WORK_PLAN_EDITOR"),
-    privateKey,
+    username = username,
+    displayName = displayName,
+    roles = listOf("ROLE_EDUCATION_WORK_PLAN_EDITOR"),
+    privateKey = privateKey,
   )
 
 fun aValidTokenWithNoAuthorities(
-  dpsUsername: String = "auser_gen",
+  username: String = "auser_gen",
+  displayName: String = "Albert User",
   privateKey: PrivateKey,
 ): String =
   buildAccessToken(
-    dpsUsername,
-    emptyList(),
-    privateKey,
+    username = username,
+    displayName = displayName,
+    roles = emptyList(),
+    privateKey = privateKey,
   )
 
 fun buildAccessToken(
-  dpsUsername: String = "auser_gen",
+  username: String = "auser_gen",
+  displayName: String = "Albert User",
   roles: List<String> = emptyList(),
   privateKey: PrivateKey,
 ): String =
   Jwts.builder()
-    .setSubject(dpsUsername)
+    .setSubject(username)
     .addClaims(
       mapOf(
         "authorities" to roles,
-        "user_name" to dpsUsername,
+        "user_name" to username,
         "auth_source" to "nomis",
         "user_uuid" to UUID.randomUUID(),
+        "name" to displayName,
       ),
     )
     .setIssuedAt(Date.from(Instant.now()))


### PR DESCRIPTION
This PR adds `createdByDisplayName` and `updatedByDisplay` name fields to the `Goal` entity class and table; and populates the fields with an Entity Listener. 
The authenticated user's display name is captured from their JWT and used held in a custom Spring Security `Principal` implementation (`DpsPrincipal`)