### PR TITLE
RR-106 - Map and return display names in GoalResponse

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
@@ -112,6 +112,9 @@ class CreateGoalTest : IntegrationTestBase() {
       .hasTitle(createGoalRequest.title)
       .hasNumberOfSteps(createGoalRequest.steps.size)
       .wasCreatedBy(dpsUsername)
+      .hasCreatedByDisplayName(displayName)
+      .wasUpdatedBy(dpsUsername)
+      .hasUpdatedByDisplayName(displayName)
     val step = goal.steps!![0]
     assertThat(step)
       .hasTitle(createStepRequest.title)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapper.kt
@@ -17,13 +17,14 @@ interface GoalEntityMapper {
    * The JPA managed fields are not mapped.
    * This method is suitable for creating a new [GoalEntity] to be subsequently persisted to the database.
    */
-  @ExcludeJpaManagedFields
+  @ExcludeJpaManagedFieldsIncludingDisplayNameFields
   fun fromDomainToEntity(goal: Goal): GoalEntity
 
   /**
    * Maps the supplied [GoalEntity] into the domain [Goal].
    */
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
+  @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")
   @Mapping(target = "lastUpdatedAt", source = "updatedAt")
   fun fromEntityToDomain(goalEntity: GoalEntity): Goal
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/MappingExclusions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/MappingExclusions.kt
@@ -9,5 +9,7 @@ import org.mapstruct.Mapping
 @Mapping(target = "updatedBy", ignore = true)
 annotation class ExcludeJpaManagedFields
 
-@Mapping(target = "reference", ignore = true)
-annotation class ExcludeReferenceField
+@ExcludeJpaManagedFields
+@Mapping(target = "createdByDisplayName", ignore = true)
+@Mapping(target = "updatedByDisplayName", ignore = true)
+annotation class ExcludeJpaManagedFieldsIncludingDisplayNameFields

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
@@ -22,17 +22,16 @@ interface GoalResourceMapper {
   @Mapping(target = "reference", expression = "java(UUID.randomUUID())")
   @Mapping(target = "status", constant = "ACTIVE")
   @Mapping(target = "createdBy", ignore = true)
+  @Mapping(target = "createdByDisplayName", ignore = true)
   @Mapping(target = "createdAt", ignore = true)
   @Mapping(target = "lastUpdatedBy", ignore = true)
+  @Mapping(target = "lastUpdatedByDisplayName", ignore = true)
   @Mapping(target = "lastUpdatedAt", ignore = true)
   fun fromModelToDomain(createGoalRequest: CreateGoalRequest): Goal
 
   @Mapping(target = "goalReference", source = "reference")
-  // TODO RR-106 - map createdByDisplayName
-  @Mapping(target = "createdByDisplayName", constant = "")
   @Mapping(target = "updatedBy", source = "lastUpdatedBy")
-  // TODO RR-106 - map updatedByDisplayName
-  @Mapping(target = "updatedByDisplayName", constant = "")
+  @Mapping(target = "updatedByDisplayName", source = "lastUpdatedByDisplayName")
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
   fun fromDomainToModel(goalDomain: Goal): GoalResponse
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
@@ -23,8 +23,10 @@ class Goal(
   var status: GoalStatus = GoalStatus.ACTIVE,
   val notes: String? = null,
   val createdBy: String?,
+  val createdByDisplayName: String?,
   val createdAt: Instant?,
   val lastUpdatedBy: String?,
+  val lastUpdatedByDisplayName: String?,
   val lastUpdatedAt: Instant?,
   steps: List<Step>,
 ) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperTest.kt
@@ -45,9 +45,11 @@ class GoalEntityMapperTest {
       status = DomainStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(domainStep),
-      createdBy = "a.user.id",
+      createdBy = "asmith_gen",
+      createdByDisplayName = "Alex Smith",
       createdAt = Instant.now(),
-      lastUpdatedBy = "another.user.id",
+      lastUpdatedBy = "bjones_gen",
+      lastUpdatedByDisplayName = "Barry Jones",
       lastUpdatedAt = Instant.now(),
     )
 
@@ -66,8 +68,10 @@ class GoalEntityMapperTest {
       id = null,
       createdAt = null,
       createdBy = null,
+      createdByDisplayName = null,
       updatedAt = null,
       updatedBy = null,
+      updatedByDisplayName = null,
     )
 
     // When
@@ -96,9 +100,11 @@ class GoalEntityMapperTest {
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = mutableListOf(entityStep),
       createdAt = createdAt,
-      createdBy = "a.user.id",
+      createdBy = "asmith_gen",
+      createdByDisplayName = "Alex Smith",
       updatedAt = updatedAt,
-      updatedBy = "another.user.id",
+      updatedBy = "bjones_gen",
+      updatedByDisplayName = "Barry Jones",
     )
 
     val domainStep = aValidStep()
@@ -113,9 +119,11 @@ class GoalEntityMapperTest {
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(domainStep),
       createdAt = createdAt,
-      createdBy = "a.user.id",
+      createdBy = "asmith_gen",
+      createdByDisplayName = "Alex Smith",
       lastUpdatedAt = updatedAt,
-      lastUpdatedBy = "another.user.id",
+      lastUpdatedBy = "bjones_gen",
+      lastUpdatedByDisplayName = "Barry Jones",
     )
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
@@ -57,8 +57,10 @@ internal class GoalResourceMapperTest {
       // JPA managed fields - expect these all to be null
       createdAt = null,
       createdBy = null,
+      createdByDisplayName = null,
       lastUpdatedAt = null,
       lastUpdatedBy = null,
+      lastUpdatedByDisplayName = null,
     )
 
     // When
@@ -79,8 +81,10 @@ internal class GoalResourceMapperTest {
       status = GoalStatus.ACTIVE,
       reviewDate = null,
       steps = mutableListOf(step),
-      createdBy = "a.user.id",
-      lastUpdatedBy = "another.user.id",
+      createdBy = "asmith_gen",
+      createdByDisplayName = "Alex Smith",
+      lastUpdatedBy = "bjones_gen",
+      lastUpdatedByDisplayName = "Barry Jones",
     )
     val expectedStepResponse = aValidStepResponse()
     val expectedDateTime = OffsetDateTime.now()
@@ -95,11 +99,11 @@ internal class GoalResourceMapperTest {
       notes = goal.notes,
       steps = listOf(expectedStepResponse),
       createdAt = expectedDateTime,
-      createdBy = "a.user.id",
-      createdByDisplayName = "",
+      createdBy = "asmith_gen",
+      createdByDisplayName = "Alex Smith",
       updatedAt = expectedDateTime,
-      updatedBy = "another.user.id",
-      updatedByDisplayName = "",
+      updatedBy = "bjones_gen",
+      updatedByDisplayName = "Barry Jones",
     )
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalTest.kt
@@ -63,9 +63,11 @@ class GoalTest {
           reviewDate = LocalDate.now().plusMonths(6),
           category = RESETTLEMENT,
           status = ACTIVE,
-          createdBy = "",
+          createdBy = "bjones_gen",
+          createdByDisplayName = "Barry Jones",
           createdAt = Instant.now(),
-          lastUpdatedBy = "",
+          lastUpdatedBy = "bjones_gen",
+          lastUpdatedByDisplayName = "Barry Jones",
           lastUpdatedAt = Instant.now(),
           steps = steps,
         )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanBuilder.kt
@@ -5,10 +5,10 @@ import java.util.UUID
 fun aValidActionPlanEntity(
   id: UUID? = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  goals: MutableList<GoalEntity> = mutableListOf(aValidGoalEntity()),
+  goals: List<GoalEntity> = listOf(aValidGoalEntity()),
 ): ActionPlanEntity =
   ActionPlanEntity(
     id = id,
     prisonNumber = prisonNumber,
-    goals = goals,
+    goals = goals.toMutableList(),
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityAssert.kt
@@ -53,6 +53,16 @@ class GoalEntityAssert(actual: GoalEntity?) :
     return this
   }
 
+  fun hasCreatedByDisplayName(expected: String): GoalEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
   fun wasCreatedAt(expected: Instant): GoalEntityAssert {
     isNotNull
     with(actual!!) {
@@ -68,6 +78,16 @@ class GoalEntityAssert(actual: GoalEntity?) :
     with(actual!!) {
       if (updatedBy != expected) {
         failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun hasUpdatedByDisplayName(expected: String): GoalEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityBuilder.kt
@@ -16,9 +16,11 @@ fun aValidGoalEntity(
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
   steps: MutableList<StepEntity> = mutableListOf(aValidStepEntity()),
   createdAt: Instant? = Instant.now(),
-  createdBy: String? = "a.user.id",
+  createdBy: String? = "asmith_gen",
+  createdByDisplayName: String? = "Alex Smith",
   updatedAt: Instant? = Instant.now(),
-  updatedBy: String? = "another.user.id",
+  updatedBy: String? = "bjones_gen",
+  updatedByDisplayName: String? = "Barry Jones",
 ): GoalEntity =
   GoalEntity(
     id = id,
@@ -31,6 +33,8 @@ fun aValidGoalEntity(
     steps = steps,
     createdAt = createdAt,
     createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
     updatedAt = updatedAt,
     updatedBy = updatedBy,
+    updatedByDisplayName = updatedByDisplayName,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalBuilder.kt
@@ -14,9 +14,11 @@ fun aValidGoal(
   steps: List<Step> = listOf(aValidStep(), anotherValidStep()),
   status: GoalStatus = ACTIVE,
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
-  createdBy: String? = "",
+  createdBy: String? = "asmith_gen",
+  createdByDisplayName: String? = "Alex Smith",
   createdAt: Instant? = Instant.now(),
-  lastUpdatedBy: String? = "",
+  lastUpdatedBy: String? = "bjones_gen",
+  lastUpdatedByDisplayName: String? = "Barry Jones",
   lastUpdatedAt: Instant? = Instant.now(),
 ): Goal =
   Goal(
@@ -28,7 +30,9 @@ fun aValidGoal(
     status = status,
     notes = notes,
     createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
     createdAt = createdAt,
     lastUpdatedBy = lastUpdatedBy,
+    lastUpdatedByDisplayName = lastUpdatedByDisplayName,
     lastUpdatedAt = lastUpdatedAt,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 
 import org.assertj.core.api.AbstractObjectAssert
+import java.util.function.Consumer
 
 fun assertThat(actual: ActionPlanResponse?) = ActionPlanResponseAssert(actual)
 
@@ -25,6 +26,36 @@ class ActionPlanResponseAssert(actual: ActionPlanResponse?) :
     with(actual!!) {
       if (goals.isNotEmpty()) {
         failWithMessage("Expected ActionPlan to be have no goals set, but has $goals")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [GoalResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [GoalResponseAssert].
+   * Returns this [ActionPlanResponseAssert] to allow further chained assertions on the parent [ActionPlanResponse]
+   */
+  fun goal(goalNumber: Int, consumer: Consumer<GoalResponseAssert>): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val goal = goals[goalNumber]
+      consumer.accept(assertThat(goal))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into all child [GoalResponse]s. Takes a lambda as the method argument
+   * to call assertion methods provided by [GoalResponseAssert].
+   * Returns this [ActionPlanResponseAssert] to allow further chained assertions on the parent [ActionPlanResponse]
+   * The assertions on all [GoalResponse]s must pass as true.
+   */
+  fun allGoals(consumer: Consumer<GoalResponseAssert>): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      goals.onEach {
+        consumer.accept(assertThat(it))
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseAssert.kt
@@ -1,0 +1,114 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
+
+import org.assertj.core.api.AbstractObjectAssert
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+fun assertThat(actual: GoalResponse?) = GoalResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [GoalResponse]
+ */
+class GoalResponseAssert(actual: GoalResponse?) :
+  AbstractObjectAssert<GoalResponseAssert, GoalResponse?>(actual, GoalResponseAssert::class.java) {
+
+  fun wasCreatedBy(expected: String): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun hasCreatedByDisplayName(expected: String): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun hasUpdatedByDisplayName(expected: String): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun hasTitle(expected: String): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (title != expected) {
+        failWithMessage("Expected title to be $expected, but was $title")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDate(expected: LocalDate): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDate != expected) {
+        failWithMessage("Expected reviewDate to be $expected, but was $reviewDate")
+      }
+    }
+    return this
+  }
+
+  fun hasNumberOfSteps(expected: Int): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (steps.size != expected) {
+        failWithMessage("Expected goal to have $expected Steps, but was ${steps.size}")
+      }
+    }
+    return this
+  }
+
+  fun hasReference(expected: String): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (goalReference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $goalReference")
+      }
+    }
+    return this
+  }
+}


### PR DESCRIPTION
This PR updates the relevant mappers so that the created by and updated by display names are returned out through the API response