### PR TITLE
RR-161 - Return the goals in chronological order

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -2,18 +2,18 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.FORBIDDEN
-import org.springframework.security.authentication.TestingAuthenticationToken
-import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.http.MediaType
+import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.DpsPrincipal
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidGoalEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 
 class GetActionPlanTest : IntegrationTestBase() {
@@ -78,15 +78,7 @@ class GetActionPlanTest : IntegrationTestBase() {
   fun `should get action plan for prisoner`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val actionPlanEntity = aValidActionPlanEntity(
-      prisonNumber = prisonNumber,
-      goals = listOf(aValidGoalEntity()),
-    )
-
-    SecurityContextHolder.getContext().authentication =
-      TestingAuthenticationToken(DpsPrincipal("asmith_gen", "Alex Smith"), null, emptyList())
-    actionPlanRepository.save(actionPlanEntity)
-    SecurityContextHolder.clearContext()
+    createGoal(prisonNumber, aValidCreateGoalRequest())
 
     // When
     val response = webTestClient.get()
@@ -102,10 +94,54 @@ class GetActionPlanTest : IntegrationTestBase() {
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
       .goal(0) {
-        it.wasCreatedBy("asmith_gen")
-          .hasCreatedByDisplayName("Alex Smith")
-          .wasUpdatedBy("asmith_gen")
-          .hasUpdatedByDisplayName("Alex Smith")
+        it.wasCreatedBy("auser_gen")
+          .hasCreatedByDisplayName("Albert User")
+          .wasUpdatedBy("auser_gen")
+          .hasUpdatedByDisplayName("Albert User")
       }
+  }
+
+  @Test
+  fun `should get action plan with multiple goals in order`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn German"))
+    createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn French"))
+    createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn Spanish"))
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(ActionPlanResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .isForPrisonNumber(prisonNumber)
+      .goal(0) {
+        it.hasTitle("Learn German")
+      }
+      // verify order of remaining goals
+      .goal(1) {
+        it.hasTitle("Learn French")
+      }
+      .goal(2) {
+        it.hasTitle("Learn Spanish")
+      }
+  }
+
+  private fun createGoal(prisonNumber: String, createGoalRequest: CreateGoalRequest) {
+    webTestClient.post()
+      .uri("$URI_TEMPLATE/goals", prisonNumber)
+      .body(Mono.just(createGoalRequest), CreateGoalRequest::class.java)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntity.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
 import org.hibernate.Hibernate
@@ -36,6 +37,7 @@ class ActionPlanEntity(
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "action_plan_id", nullable = false)
+  @OrderBy(value = "createdAt")
   @field:NotNull
   var goals: MutableList<GoalEntity>? = null,
 

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.0.2'
+  version: '1.0.3'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -32,7 +32,7 @@ paths:
         required: true
     get:
       summary: Return a Prisoner's Action Plan
-      description: Return a Prisoner's Action Plan. If the prisoner does not yet have any goals set, then an Action Plan with no goals (empty array) is returned.
+      description: Return a Prisoner's Action Plan with the goals ordered in chronological order (oldest first). If the prisoner does not yet have any goals set, then an Action Plan with no goals (empty array) is returned.
       tags:
         - Action Plan
       responses:


### PR DESCRIPTION
As per the ACs in RR-106, the goals should be ordered chronologically (oldest first) and it makes sense to do this in the API.