### PR TITLE
RR-3 - Remove Goal category

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
@@ -50,11 +50,6 @@ class GoalEntity(
   @Column
   @Enumerated(value = EnumType.STRING)
   @field:NotNull
-  var category: GoalCategory? = null,
-
-  @Column
-  @Enumerated(value = EnumType.STRING)
-  @field:NotNull
   var status: GoalStatus? = null,
 
   @Column
@@ -103,13 +98,6 @@ class GoalEntity(
   override fun toString(): String {
     return this::class.simpleName + "(id = $id, reference = $reference, title = $title)"
   }
-}
-
-enum class GoalCategory {
-  WORK,
-  PERSONAL_DEVELOPMENT,
-  EDUCATION,
-  RESETTLEMENT,
 }
 
 enum class GoalStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
@@ -9,7 +9,7 @@ import java.util.UUID
 /**
  * Represents a prisoner's Goal in their Education and Work Plan (or so-called "Action Plan").
  *
- * The goals have different categories and may be personal development based (e.g. improving communication) or related
+ * The goals vary significantly and may be personal development based (e.g. improving communication) or related
  * to a future job/career and consist of one or more [Step Steps] (at least one).
  *
  * Each goal has its own lifecycle (such as active or completed) and a prisoner can have many goals at the same time
@@ -19,7 +19,6 @@ class Goal(
   val reference: UUID,
   val title: String,
   val reviewDate: LocalDate?,
-  val category: GoalCategory,
   var status: GoalStatus = GoalStatus.ACTIVE,
   val notes: String? = null,
   val createdBy: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalCategory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalCategory.kt
@@ -1,8 +1,0 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
-
-enum class GoalCategory {
-  WORK,
-  PERSONAL_DEVELOPMENT,
-  EDUCATION,
-  RESETTLEMENT,
-}

--- a/src/main/resources/db/migration/V2023.07.27.0001__remove_goal_category.sql
+++ b/src/main/resources/db/migration/V2023.07.27.0001__remove_goal_category.sql
@@ -1,0 +1,1 @@
+ALTER TABLE goal DROP COLUMN category;

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.0.3'
+  version: '1.1.0'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -122,6 +122,7 @@ components:
       properties:
         goalReference:
           type: string
+          format: uuid
           description: The Goal's unique reference
           example: c88a6c48-97e2-4c04-93b5-98619966447b
         title:
@@ -135,8 +136,6 @@ components:
           example: '2023-12-19'
         status:
           $ref: '#/components/schemas/GoalStatus'
-        category:
-          $ref: '#/components/schemas/GoalCategory'
         steps:
           type: array
           minItems: 1
@@ -191,6 +190,7 @@ components:
       properties:
         stepReference:
           type: string
+          format: uuid
           description: A unique reference for the Step
           example: d38a6c41-13d1-1d05-13c2-24619966119b
         title:
@@ -226,8 +226,6 @@ components:
           format: date
           description: An optional ISO-8601 date representing when the Goal is up for review.
           example: '2023-12-19'
-        category:
-          $ref: '#/components/schemas/GoalCategory'
         steps:
           type: array
           minItems: 1
@@ -269,15 +267,6 @@ components:
         - ACTIVE
         - COMPLETED
         - ARCHIVED
-    GoalCategory:
-      title: GoalCategory
-      description: Enum describing the category of a Goal.
-      type: string
-      enum:
-        - WORK
-        - PERSONAL_DEVELOPMENT
-        - EDUCATION
-        - RESETTLEMENT
     StepStatus:
       title: StepStatus
       description: Enum describing the various statuses of a Step's lifecycle.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperTest.kt
@@ -17,9 +17,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidSt
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.GoalCategory as EntityCategory
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.GoalStatus as EntityStatus
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalCategory as DomainCategory
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus as DomainStatus
 
 @ExtendWith(MockitoExtension::class)
@@ -41,7 +39,6 @@ class GoalEntityMapperTest {
       reference = UUID.randomUUID(),
       title = "Improve communication skills",
       reviewDate = reviewDate,
-      category = DomainCategory.PERSONAL_DEVELOPMENT,
       status = DomainStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(domainStep),
@@ -60,7 +57,6 @@ class GoalEntityMapperTest {
       reference = domainGoal.reference,
       title = "Improve communication skills",
       reviewDate = reviewDate,
-      category = EntityCategory.PERSONAL_DEVELOPMENT,
       status = EntityStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = mutableListOf(expectedEntityStep),
@@ -95,7 +91,6 @@ class GoalEntityMapperTest {
       reference = UUID.randomUUID(),
       title = "Improve communication skills",
       reviewDate = reviewDate,
-      category = EntityCategory.PERSONAL_DEVELOPMENT,
       status = EntityStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = mutableListOf(entityStep),
@@ -114,7 +109,6 @@ class GoalEntityMapperTest {
       reference = entityGoal.reference!!,
       title = "Improve communication skills",
       reviewDate = reviewDate,
-      category = DomainCategory.PERSONAL_DEVELOPMENT,
       status = DomainStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(domainStep),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
@@ -9,7 +9,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalCategory
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
@@ -20,7 +19,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aVali
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalCategory as GoalCategoryApi
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus as GoalStatusApi
 
 @ExtendWith(MockitoExtension::class)
@@ -40,7 +38,6 @@ internal class GoalResourceMapperTest {
     // Given
     val createStepRequest = aValidCreateStepRequest()
     val createGoalRequest = aValidCreateGoalRequest(
-      category = GoalCategoryApi.PERSONAL_DEVELOPMENT,
       reviewDate = LocalDate.now(),
       steps = mutableListOf(createStepRequest),
     )
@@ -50,7 +47,6 @@ internal class GoalResourceMapperTest {
       reference = UUID.randomUUID(),
       title = createGoalRequest.title,
       reviewDate = createGoalRequest.reviewDate,
-      category = GoalCategory.PERSONAL_DEVELOPMENT,
       status = GoalStatus.ACTIVE,
       notes = createGoalRequest.notes,
       steps = mutableListOf(expectedStep),
@@ -77,7 +73,6 @@ internal class GoalResourceMapperTest {
     // Given
     val step = aValidStep()
     val goal = aValidGoal(
-      category = GoalCategory.PERSONAL_DEVELOPMENT,
       status = GoalStatus.ACTIVE,
       reviewDate = null,
       steps = mutableListOf(step),
@@ -94,7 +89,6 @@ internal class GoalResourceMapperTest {
       reference = goal.reference,
       title = goal.title,
       reviewDate = null,
-      category = GoalCategoryApi.PERSONAL_DEVELOPMENT,
       status = GoalStatusApi.ACTIVE,
       notes = goal.notes,
       steps = listOf(expectedStepResponse),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowableOfType
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalCategory.RESETTLEMENT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE
 import java.time.Instant
 import java.time.LocalDate
@@ -61,7 +60,6 @@ class GoalTest {
           reference = goalReference,
           title = "Improve woodworking skills",
           reviewDate = LocalDate.now().plusMonths(6),
-          category = RESETTLEMENT,
           status = ACTIVE,
           createdBy = "bjones_gen",
           createdByDisplayName = "Barry Jones",

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityBuilder.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
 
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.GoalCategory.PERSONAL_DEVELOPMENT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.GoalStatus.ACTIVE
 import java.time.Instant
 import java.time.LocalDate
@@ -11,7 +10,6 @@ fun aValidGoalEntity(
   reference: UUID = UUID.randomUUID(),
   title: String = "Improve communication skills",
   reviewDate: LocalDate = LocalDate.now().plusMonths(6),
-  category: GoalCategory = PERSONAL_DEVELOPMENT,
   status: GoalStatus = ACTIVE,
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
   steps: MutableList<StepEntity> = mutableListOf(aValidStepEntity()),
@@ -27,7 +25,6 @@ fun aValidGoalEntity(
     reference = reference,
     title = title,
     reviewDate = reviewDate,
-    category = category,
     status = status,
     notes = notes,
     steps = steps,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalBuilder.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
 
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalCategory.PERSONAL_DEVELOPMENT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE
 import java.time.Instant
 import java.time.LocalDate
@@ -10,7 +9,6 @@ fun aValidGoal(
   reference: UUID = UUID.randomUUID(),
   title: String = "Improve communication skills",
   reviewDate: LocalDate? = null,
-  category: GoalCategory = PERSONAL_DEVELOPMENT,
   steps: List<Step> = listOf(aValidStep(), anotherValidStep()),
   status: GoalStatus = ACTIVE,
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
@@ -25,7 +23,6 @@ fun aValidGoal(
     reference = reference,
     title = title,
     reviewDate = reviewDate,
-    category = category,
     steps = steps,
     status = status,
     notes = notes,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateGoalRequestBuilder.kt
@@ -5,14 +5,12 @@ import java.time.LocalDate
 fun aValidCreateGoalRequest(
   title: String = "Improve communication skills",
   reviewDate: LocalDate? = null,
-  category: GoalCategory = GoalCategory.PERSONAL_DEVELOPMENT,
   steps: List<CreateStepRequest> = listOf(aValidCreateStepRequest(), anotherValidCreateStepRequest()),
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
 ): CreateGoalRequest =
   CreateGoalRequest(
     title = title,
     reviewDate = reviewDate,
-    category = category,
     steps = steps,
     notes = notes,
   )
@@ -20,14 +18,12 @@ fun aValidCreateGoalRequest(
 fun anotherValidCreateGoalRequest(
   title: String = "Learn bricklaying",
   reviewDate: LocalDate = LocalDate.now().plusMonths(6),
-  category: GoalCategory = GoalCategory.WORK,
   steps: List<CreateStepRequest> = listOf(aValidCreateStepRequest("Attend in house bricklaying course")),
   notes: String? = "",
 ): CreateGoalRequest =
   CreateGoalRequest(
     title = title,
     reviewDate = reviewDate,
-    category = category,
     steps = steps,
     notes = notes,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseAssert.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 import org.assertj.core.api.AbstractObjectAssert
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.util.UUID
 
 fun assertThat(actual: GoalResponse?) = GoalResponseAssert(actual)
 
@@ -102,7 +103,7 @@ class GoalResponseAssert(actual: GoalResponse?) :
     return this
   }
 
-  fun hasReference(expected: String): GoalResponseAssert {
+  fun hasReference(expected: UUID): GoalResponseAssert {
     isNotNull
     with(actual!!) {
       if (goalReference != expected) {

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseBuilder.kt
@@ -8,7 +8,6 @@ fun aValidGoalResponse(
   reference: UUID = UUID.randomUUID(),
   title: String = "Improve communication skills",
   reviewDate: LocalDate? = null,
-  category: GoalCategory = GoalCategory.PERSONAL_DEVELOPMENT,
   steps: List<StepResponse> = listOf(aValidStepResponse(), anotherValidStepResponse()),
   status: GoalStatus = GoalStatus.ACTIVE,
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
@@ -20,10 +19,9 @@ fun aValidGoalResponse(
   updatedAt: OffsetDateTime = OffsetDateTime.now(),
 ): GoalResponse =
   GoalResponse(
-    goalReference = reference.toString(),
+    goalReference = reference,
     title = title,
     reviewDate = reviewDate,
-    category = category,
     steps = steps,
     status = status,
     notes = notes,
@@ -39,7 +37,6 @@ fun anotherValidGoalResponse(
   reference: UUID = UUID.randomUUID(),
   title: String = "Learn bricklaying",
   reviewDate: LocalDate = LocalDate.now().plusMonths(6),
-  category: GoalCategory = GoalCategory.WORK,
   steps: List<StepResponse> = listOf(aValidStepResponse(title = "Attend in house bricklaying course")),
   status: GoalStatus = GoalStatus.ACTIVE,
   notes: String? = null,
@@ -51,10 +48,9 @@ fun anotherValidGoalResponse(
   updatedAt: OffsetDateTime = OffsetDateTime.now(),
 ): GoalResponse =
   GoalResponse(
-    goalReference = reference.toString(),
+    goalReference = reference,
     title = title,
     reviewDate = reviewDate,
-    category = category,
     steps = steps,
     status = status,
     notes = notes,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/StepResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/StepResponseBuilder.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TargetDateRange.THREE_TO_SIX_MONTHS
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TargetDateRange.ZERO_TO_THREE_MONTHS
-import java.util.*
+import java.util.UUID
 
 fun aValidStepResponse(
   reference: UUID = UUID.randomUUID(),
@@ -12,7 +12,7 @@ fun aValidStepResponse(
   sequenceNumber: Int = 1,
 ): StepResponse =
   StepResponse(
-    stepReference = reference.toString(),
+    stepReference = reference,
     title = title,
     targetDateRange = targetDateRange,
     status = status,
@@ -27,7 +27,7 @@ fun anotherValidStepResponse(
   sequenceNumber: Int = 2,
 ): StepResponse =
   StepResponse(
-    stepReference = reference.toString(),
+    stepReference = reference,
     title = title,
     targetDateRange = targetDateRange,
     status = status,


### PR DESCRIPTION
A tidy up of the API, prior to adding a new endpoint to edit a Goal:

* Remove the redundant `category` field from Goal
* Set the reference fields to UUID types