### PR TITLE
RR-3 (1) - Implement controller signature for new API endpoint to update a Goal

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.context.transaction.TestTransaction
 import org.springframework.transaction.annotation.Transactional
-import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
@@ -15,12 +14,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TargetDateRange
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TargetDateRange as TargetDateRangeEntity
 
 class CreateGoalTest : IntegrationTestBase() {
@@ -43,7 +42,7 @@ class CreateGoalTest : IntegrationTestBase() {
   fun `should return forbidden given bearer token with view only role`() {
     webTestClient.post()
       .uri(URI_TEMPLATE, aValidPrisonNumber())
-      .body(Mono.just(aValidCreateGoalRequest()), CreateGoalRequest::class.java)
+      .withBody(aValidCreateGoalRequest())
       .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
       .contentType(APPLICATION_JSON)
       .exchange()
@@ -59,7 +58,7 @@ class CreateGoalTest : IntegrationTestBase() {
     // When
     val response = webTestClient.post()
       .uri(URI_TEMPLATE, prisonNumber)
-      .body(Mono.just(createRequest), CreateGoalRequest::class.java)
+      .withBody(createRequest)
       .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
       .contentType(APPLICATION_JSON)
       .exchange()
@@ -88,7 +87,7 @@ class CreateGoalTest : IntegrationTestBase() {
     // When
     webTestClient.post()
       .uri(URI_TEMPLATE, prisonNumber)
-      .body(Mono.just(createGoalRequest), CreateGoalRequest::class.java)
+      .withBody(createGoalRequest)
       .bearerToken(
         aValidTokenWithEditAuthority(
           username = dpsUsername,
@@ -139,7 +138,7 @@ class CreateGoalTest : IntegrationTestBase() {
     // When
     webTestClient.post()
       .uri(URI_TEMPLATE, prisonNumber)
-      .body(Mono.just(createRequest), CreateGoalRequest::class.java)
+      .withBody(createRequest)
       .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
       .contentType(APPLICATION_JSON)
       .exchange()
@@ -169,7 +168,7 @@ class CreateGoalTest : IntegrationTestBase() {
     // When
     webTestClient.post()
       .uri(URI_TEMPLATE, prisonNumber)
-      .body(Mono.just(createRequest), CreateGoalRequest::class.java)
+      .withBody(createRequest)
       .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
       .contentType(APPLICATION_JSON)
       .exchange()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.MediaType
-import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
@@ -15,6 +14,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 
 class GetActionPlanTest : IntegrationTestBase() {
 
@@ -137,7 +137,7 @@ class GetActionPlanTest : IntegrationTestBase() {
   private fun createGoal(prisonNumber: String, createGoalRequest: CreateGoalRequest) {
     webTestClient.post()
       .uri("$URI_TEMPLATE/goals", prisonNumber)
-      .body(Mono.just(createGoalRequest), CreateGoalRequest::class.java)
+      .withBody(createGoalRequest)
       .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
       .contentType(MediaType.APPLICATION_JSON)
       .exchange()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType.APPLICATION_JSON
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidReference
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
+
+class UpdateGoalTest : IntegrationTestBase() {
+
+  companion object {
+    private const val URI_TEMPLATE = "/action-plans/{prisonNumber}/goals/{goalReference}"
+  }
+
+  @Test
+  fun `should return unauthorized given no bearer token`() {
+    webTestClient.put()
+      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `should return forbidden given bearer token with view only role`() {
+    webTestClient.put()
+      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
+      .withBody(aValidUpdateGoalRequest())
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -5,6 +5,7 @@ import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.GoalResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
+import java.util.UUID
 
 @RestController
 @RequestMapping(value = ["/action-plans/{prisonNumber}/goals"], produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -28,5 +31,12 @@ class GoalController(
       prisonNumber = prisonNumber,
       goal = goalResourceMapper.fromModelToDomain(request),
     )
+  }
+
+  @PutMapping("{goalReference}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PreAuthorize(HAS_EDIT_AUTHORITY)
+  fun updateGoal(@PathVariable prisonNumber: String, @PathVariable goalReference: UUID, @RequestBody updateGoalRequest: UpdateGoalRequest) {
+    TODO("not yet implemented")
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/CommonBuilders.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/CommonBuilders.kt
@@ -1,8 +1,12 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi
 
+import java.util.UUID
+
 /**
  * Builder functions for common data items that are not aligned to a specific domain, REST model or JPA entity; such as
  * prison numbers, times and dates etc.
  */
 
 fun aValidPrisonNumber() = "A1234BC"
+
+fun aValidReference() = UUID.randomUUID()

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateGoalRequestBuilder.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidReference
+import java.time.LocalDate
+import java.util.UUID
+
+fun aValidUpdateGoalRequest(
+  goalReference: UUID = aValidReference(),
+  title: String = "Improve communication skills",
+  reviewDate: LocalDate? = null,
+  steps: List<StepRequest> = listOf(aValidUpdateStepRequest()),
+  notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
+): UpdateGoalRequest =
+  UpdateGoalRequest(
+    goalReference = goalReference,
+    title = title,
+    reviewDate = reviewDate,
+    steps = steps,
+    notes = notes,
+  )


### PR DESCRIPTION
This PR implements the controller method signature to implement the new API defined in the swagger spec to Update A Goal

The controller method does not yet implement the behaviour, but does implement the endpoint signature and security, so basic integration tests have been added 👍 

Subsequent PRs will start to build upon this ...