### PR TITLE
RR-3 (2) - Configure GlobalExceptionHandler to handle validation errors

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -1,13 +1,17 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidReference
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 
 class UpdateGoalTest : IntegrationTestBase() {
@@ -36,5 +40,61 @@ class UpdateGoalTest : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isForbidden
+  }
+
+  @Test
+  fun `should fail to update goal given no steps provided`() {
+    val prisonNumber = aValidPrisonNumber()
+    val goalReference = aValidReference()
+    val updateRequest = aValidUpdateGoalRequest(
+      goalReference = goalReference,
+      steps = emptyList(),
+    )
+
+    // When
+    val response = webTestClient.put()
+      .uri(URI_TEMPLATE, prisonNumber, goalReference)
+      .withBody(updateRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.BAD_REQUEST.value())
+      .hasUserMessage("Validation failed for object='updateGoalRequest'. Error count: 1")
+      .hasDeveloperMessageContaining("Steps cannot be empty when updating a Goal")
+  }
+
+  @Test
+  fun `should fail to update goal given null fields`() {
+    val prisonNumber = aValidPrisonNumber()
+    val goalReference = aValidReference()
+
+    // When
+    val response = webTestClient.put()
+      .uri(URI_TEMPLATE, prisonNumber, goalReference)
+      .bodyValue(
+        """
+          { }
+        """.trimIndent(),
+      )
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.BAD_REQUEST.value())
+      .hasUserMessageContaining("JSON parse error")
+      .hasUserMessageContaining("value failed for JSON property goalReference due to missing (therefore NULL) value for creator parameter goalReference")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ErrorAttributesConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ErrorAttributesConfiguration.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
+
+import org.springframework.boot.web.error.ErrorAttributeOptions
+import org.springframework.boot.web.error.ErrorAttributeOptions.Include
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes
+import org.springframework.context.MessageSource
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.validation.FieldError
+import org.springframework.web.context.request.WebRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.Date
+import java.util.Locale
+
+@Configuration
+class ErrorAttributesConfiguration {
+
+  @Bean
+  fun apiRequestErrorAttributes(messageSource: MessageSource) = ApiRequestErrorAttributes(messageSource)
+}
+
+class ApiRequestErrorAttributes(
+  private val messageSource: MessageSource,
+) : DefaultErrorAttributes() {
+
+  companion object {
+    private const val TIMESTAMP = "timestamp"
+    private const val STATUS = "status"
+    private const val ERROR = "error"
+    private const val MESSAGE = "message"
+    private const val ERRORS = "errors"
+
+    private val errorAttributeOptions = ErrorAttributeOptions.defaults()
+      .including(Include.MESSAGE, Include.BINDING_ERRORS)
+  }
+
+  fun getErrorResponse(request: WebRequest): ErrorResponse =
+    getErrorAttributes(request, errorAttributeOptions).let {
+      ErrorResponse(
+        status = it.getStatus(),
+        errorCode = it.getError(),
+        userMessage = it.getMessage(),
+        developerMessage = it.getErrors().toString(),
+      )
+    }
+
+  private fun Map<String, Any>.getTimeStamp(): OffsetDateTime =
+    (this[TIMESTAMP] as Date).toInstant().atOffset(ZoneOffset.UTC)
+
+  private fun Map<String, Any>.getStatus(): Int =
+    this[STATUS] as Int
+
+  private fun Map<String, Any>.getError(): String =
+    this[ERROR].toString()
+
+  private fun Map<String, Any>.getMessage(): String =
+    this[MESSAGE].toString()
+
+  private fun Map<String, Any>.getErrors(): List<String>? =
+    (this[ERRORS] as List<*>?)
+      ?.map { it as FieldError }
+      ?.map {
+        with(it) {
+          val message = messageSource.getMessage(this, Locale.getDefault())
+          "Error on field '$field': rejected value [$rejectedValue], $message"
+        }
+      }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GlobalExceptionHandler.kt
@@ -1,25 +1,50 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
-import jakarta.validation.ValidationException
+import jakarta.servlet.RequestDispatcher.ERROR_STATUS_CODE
 import mu.KotlinLogging
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanNotFoundException
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.InvalidGoalException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 
 private val log = KotlinLogging.logger {}
 
+/**
+ * Global Exception Handler. Handles specific exceptions thrown by the application by returning a suitable [ErrorResponse]
+ * response entity.
+ *
+ * Our standard pattern here is to return an [ErrorResponse]. Please think carefully about writing a response handler
+ * method that does not follow this pattern. Please try not to use [handleExceptionInternal] as this returns a response
+ * body of a simple string rather than a structured response body.
+ *
+ * Our preferred approach is to use the method [populateErrorResponseAndHandleExceptionInternal] which builds and returns
+ * the [ErrorResponse] complete with correctly populated status code field. This method also populates the message field
+ * of [ErrorResponse] from the exception. In the case that the exception message is not suitable for exposing through
+ * the REST API, this can be overridden by manually setting the message on the request attribute. eg:
+ *
+ * ```
+ *     request.setAttribute(ERROR_MESSAGE, "A simpler error message that does not expose internal detail", SCOPE_REQUEST)
+ * ```
+ *
+ */
 @RestControllerAdvice
-class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
+class GlobalExceptionHandler(
+  private val errorAttributes: ApiRequestErrorAttributes,
+) : ResponseEntityExceptionHandler() {
 
   @ExceptionHandler(AccessDeniedException::class)
   fun handleAccessDeniedException(e: AccessDeniedException, request: WebRequest): ResponseEntity<ErrorResponse> {
@@ -48,31 +73,28 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
       )
   }
 
-  @ExceptionHandler(InvalidGoalException::class)
-  fun handleInvalidGoalException(e: InvalidGoalException): ResponseEntity<ErrorResponse> {
-    log.info("Invalid goal: {}", e.message)
-    return ResponseEntity
-      .status(BAD_REQUEST)
-      .body(
-        ErrorResponse(
-          status = BAD_REQUEST.value(),
-          userMessage = e.message,
-        ),
-      )
+  /**
+   * Overrides the MethodArgumentNotValidException exception handler to return a 400 Bad Request ErrorResponse
+   */
+  override fun handleMethodArgumentNotValid(
+    e: MethodArgumentNotValidException,
+    headers: HttpHeaders,
+    status: HttpStatusCode,
+    request: WebRequest,
+  ): ResponseEntity<Any>? {
+    return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
   }
 
-  @ExceptionHandler(ValidationException::class)
-  fun handleValidationException(e: ValidationException): ResponseEntity<ErrorResponse> {
-    log.info("Validation exception: {}", e.message)
-    return ResponseEntity
-      .status(BAD_REQUEST)
-      .body(
-        ErrorResponse(
-          status = BAD_REQUEST.value(),
-          userMessage = "Validation failure: ${e.message}",
-          developerMessage = e.message,
-        ),
-      )
+  /**
+   * Overrides the HttpMessageNotReadableException exception handler to return a 400 Bad Request ErrorResponse
+   */
+  override fun handleHttpMessageNotReadable(
+    e: HttpMessageNotReadableException,
+    headers: HttpHeaders,
+    status: HttpStatusCode,
+    request: WebRequest,
+  ): ResponseEntity<Any>? {
+    return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
   }
 
   @ExceptionHandler(Exception::class)
@@ -87,5 +109,15 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
           developerMessage = e.message,
         ),
       )
+  }
+
+  private fun populateErrorResponseAndHandleExceptionInternal(
+    exception: Exception,
+    status: HttpStatus,
+    request: WebRequest,
+  ): ResponseEntity<Any>? {
+    request.setAttribute(ERROR_STATUS_CODE, status.value(), SCOPE_REQUEST)
+    val body = errorAttributes.getErrorResponse(request)
+    return handleExceptionInternal(exception, body, HttpHeaders(), status, request)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
@@ -26,7 +27,12 @@ class GoalController(
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
-  fun createGoal(@PathVariable prisonNumber: String, @RequestBody request: CreateGoalRequest) {
+  fun createGoal(
+    @Valid
+    @RequestBody
+    request: CreateGoalRequest,
+    @PathVariable prisonNumber: String,
+  ) {
     goalService.createGoal(
       prisonNumber = prisonNumber,
       goal = goalResourceMapper.fromModelToDomain(request),
@@ -36,7 +42,13 @@ class GoalController(
   @PutMapping("{goalReference}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
-  fun updateGoal(@PathVariable prisonNumber: String, @PathVariable goalReference: UUID, @RequestBody updateGoalRequest: UpdateGoalRequest) {
+  fun updateGoal(
+    @Valid
+    @RequestBody
+    updateGoalRequest: UpdateGoalRequest,
+    @PathVariable prisonNumber: String,
+    @PathVariable goalReference: UUID,
+  ) {
     TODO("not yet implemented")
   }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,2 @@
+Size.createGoalRequest.steps=Steps cannot be empty when creating a Goal
+Size.updateGoalRequest.steps=Steps cannot be empty when updating a Goal

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ErrorResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ErrorResponseAssert.kt
@@ -40,7 +40,7 @@ class ErrorResponseAssert(actual: ErrorResponse?) :
   fun hasUserMessageContaining(expected: String): ErrorResponseAssert {
     isNotNull
     with(actual!!) {
-      if (userMessage?.contains(expected) == false) {
+      if (userMessage == null || !userMessage!!.contains(expected)) {
         failWithMessage("Expected message to contain $expected, but was $userMessage")
       }
     }
@@ -60,7 +60,7 @@ class ErrorResponseAssert(actual: ErrorResponse?) :
   fun hasDeveloperMessageContaining(expected: String): ErrorResponseAssert {
     isNotNull
     with(actual!!) {
-      if (developerMessage?.contains(expected) == false) {
+      if (developerMessage == null || !developerMessage!!.contains(expected)) {
         failWithMessage("Expected message to contain $expected, but was $developerMessage")
       }
     }


### PR DESCRIPTION
This PR adds request body validation to the Update Goal API (and also the Create Goal API, as it was not quite right)
Configured the GlobalExceptionHandler to process the correct exceptions and to process the ErrorAttributes instance into an ErrorResponse
