### PR TITLE
RR-3 - Updated goal steps to ensure and enforce sequence number ordering

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE
 import java.time.Instant
@@ -13,38 +14,82 @@ class GoalTest {
   @Test
   fun `should create Goal given Steps out of sequence`() {
     // Given
-    val step1 = aValidStep(sequenceNumber = 1)
-    val step2 = aValidStep(sequenceNumber = 2)
-    val step3 = aValidStep(sequenceNumber = 3)
+    val step1 = aValidStep(sequenceNumber = 1, title = "Book course")
+    val step2 = aValidStep(sequenceNumber = 2, title = "Attend course")
+    val step3 = aValidStep(sequenceNumber = 3, title = "Pass exam")
 
     // When
-    val goal = aValidGoal(steps = mutableListOf(step2, step3, step1))
+    val goal = aValidGoal(steps = mutableListOf(step2, step3, step1)) // Steps passed into the goal out of sequence
 
     // Then
-    assertThat(goal.steps).containsExactly(
-      step1,
-      step2,
-      step3,
+    assertThat(goal.steps.map { it.title }).containsExactly( // steps are returned in correct sequence based on sequenceNumber
+      "Book course",
+      "Attend course",
+      "Pass exam",
     )
   }
 
-  @Test
-  fun `should add Step and maintain Step order`() {
-    // Given
-    val step1 = aValidStep(sequenceNumber = 1)
-    val step2 = aValidStep(sequenceNumber = 2)
-    val step3 = aValidStep(sequenceNumber = 3)
-    val goal = aValidGoal(steps = mutableListOf(step1, step3))
+  @Nested
+  inner class AddStep {
+    @Test
+    fun `should add Step and enforce Step sequence and order`() {
+      // Given
+      val step1 = aValidStep(sequenceNumber = 1, title = "Book course")
+      val step2 = aValidStep(sequenceNumber = 2, title = "Pass exam")
+      val goal = aValidGoal(steps = mutableListOf(step1, step2)) // goal contains steps "Book course" and "Pass exam", but not "Attend Course"
 
-    // When
-    goal.addStep(step2)
+      val newStep = aValidStep(sequenceNumber = 2, title = "Attend course")
 
-    // Then
-    assertThat(goal.steps).containsExactly(
-      step1,
-      step2,
-      step3,
-    )
+      // When
+      goal.addStep(newStep) // add "Attend course" step
+
+      // Then
+      assertThat(goal.steps.map { it.title }).containsExactly( // steps are returned in correct sequence
+        "Book course",
+        "Attend course",
+        "Pass exam",
+      )
+    }
+
+    @Test
+    fun `should add Step and enforce Step sequence and order given new step has a negative sequence number`() {
+      // Given
+      val step1 = aValidStep(sequenceNumber = 1, title = "Book course")
+      val step2 = aValidStep(sequenceNumber = 2, title = "Pass exam")
+      val goal = aValidGoal(steps = mutableListOf(step1, step2)) // goal contains steps "Book course" and "Pass exam"
+
+      val newStep = aValidStep(sequenceNumber = -1, title = "The new step")
+
+      // When
+      goal.addStep(newStep)
+
+      // Then
+      assertThat(goal.steps.map { it.title }).containsExactly( // steps are returned in correct sequence
+        "The new step",
+        "Book course",
+        "Pass exam",
+      )
+    }
+
+    @Test
+    fun `should add Step and enforce Step sequence and order given new step has a sequence number greater than the list size`() {
+      // Given
+      val step1 = aValidStep(sequenceNumber = 1, title = "Book course")
+      val step2 = aValidStep(sequenceNumber = 2, title = "Pass exam")
+      val goal = aValidGoal(steps = mutableListOf(step1, step2)) // goal contains steps "Book course" and "Pass exam"
+
+      val newStep = aValidStep(sequenceNumber = 10, title = "The new step")
+
+      // When
+      goal.addStep(newStep)
+
+      // Then
+      assertThat(goal.steps.map { it.title }).containsExactly( // steps are returned in correct sequence
+        "Book course",
+        "Pass exam",
+        "The new step",
+      )
+    }
   }
 
   @Test


### PR DESCRIPTION
This PR updates the domain `Goal` class to enforce that a `Goal`s `Step`s are correctly ordered based on their `sequenceNumber` ; and that when adding a new `Step` it is added in the correct position in the ordered list of `Step`s based on it's `sequenceNumber`