### PR TITLE
RR-3 - Refactor CreateStepRequest and UpdateStepRequest in API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
@@ -5,6 +5,7 @@ import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
 import java.time.Instant
 import java.util.UUID
 
@@ -28,6 +29,16 @@ interface GoalResourceMapper {
   @Mapping(target = "lastUpdatedByDisplayName", ignore = true)
   @Mapping(target = "lastUpdatedAt", ignore = true)
   fun fromModelToDomain(createGoalRequest: CreateGoalRequest): Goal
+
+  @Mapping(target = "reference", source = "goalReference")
+  @Mapping(target = "status", constant = "ACTIVE") // TODO - change when we support updating a Goal's status
+  @Mapping(target = "createdBy", ignore = true)
+  @Mapping(target = "createdByDisplayName", ignore = true)
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "lastUpdatedBy", ignore = true)
+  @Mapping(target = "lastUpdatedByDisplayName", ignore = true)
+  @Mapping(target = "lastUpdatedAt", ignore = true)
+  fun fromModelToDomain(updateGoalRequest: UpdateGoalRequest): Goal
 
   @Mapping(target = "goalReference", source = "reference")
   @Mapping(target = "updatedBy", source = "lastUpdatedBy")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
@@ -31,7 +31,6 @@ interface GoalResourceMapper {
   fun fromModelToDomain(createGoalRequest: CreateGoalRequest): Goal
 
   @Mapping(target = "reference", source = "goalReference")
-  @Mapping(target = "status", constant = "ACTIVE") // TODO - change when we support updating a Goal's status
   @Mapping(target = "createdBy", ignore = true)
   @Mapping(target = "createdByDisplayName", ignore = true)
   @Mapping(target = "createdAt", ignore = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapper.kt
@@ -3,8 +3,9 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.StepRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.StepResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateStepRequest
 import java.util.UUID
 
 @Mapper(
@@ -13,10 +14,12 @@ import java.util.UUID
   ],
 )
 interface StepResourceMapper {
-  // TODO - RR-3 - this will need to change when creating vs updating a Step
   @Mapping(target = "reference", expression = "java(UUID.randomUUID())")
   @Mapping(target = "status", constant = "NOT_STARTED")
-  fun fromModelToDomain(stepRequest: StepRequest): Step
+  fun fromModelToDomain(createStepRequest: CreateStepRequest): Step
+
+  @Mapping(target = "reference", source = "stepReference")
+  fun fromModelToDomain(updateStepRequest: UpdateStepRequest): Step
 
   @Mapping(target = "stepReference", source = "reference")
   fun fromDomainToModel(stepDomain: Step): StepResponse

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -291,6 +291,8 @@ components:
           format: date
           description: An optional ISO-8601 date representing when the Goal is up for review.
           example: '2023-12-19'
+        status:
+          $ref: '#/components/schemas/GoalStatus'
         steps:
           type: array
           minItems: 1
@@ -304,6 +306,7 @@ components:
       required:
         - goalReference
         - title
+        - status
         - steps
 
     CreateStepRequest:

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.1.1'
+  version: '1.1.2'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -263,7 +263,7 @@ components:
           minItems: 1
           description: A List of at least one Step.
           items:
-            $ref: '#/components/schemas/StepRequest'
+            $ref: '#/components/schemas/CreateStepRequest'
         notes:
           type: string
           description: Some additional notes related to the Goal.
@@ -280,7 +280,7 @@ components:
         goalReference:
           type: string
           format: uuid
-          description: The Goal's unique reference
+          description: The Goal's unique reference. This is used as an identifier to update the required Goal. It is not possible or supported to update the `goalReference`.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
         title:
           type: string
@@ -296,7 +296,7 @@ components:
           minItems: 1
           description: A List of at least one Step.
           items:
-            $ref: '#/components/schemas/StepRequest'
+            $ref: '#/components/schemas/UpdateStepRequest'
         notes:
           type: string
           description: Some additional notes related to the Goal.
@@ -306,16 +306,11 @@ components:
         - title
         - steps
 
-    StepRequest:
-      title: StepRequest
+    CreateStepRequest:
+      title: CreateStepRequest
       type: object
-      description: A request to create or update a Step within a Goal (determined by the existence of the 'stepReference' field - see below). Note that new Steps are created with a status of NOT_STARTED.
+      description: A request to create a Step within a Goal. Note that new Steps are created with an implicit status of NOT_STARTED.
       properties:
-        stepReference:
-          type: string
-          format: uuid
-          description: A unique reference for the Step, which should only be provided when updating an existing known Step. This should be null when creating a new Step, otherwise a 404 ('Not found') error will be returned.
-          example: d38a6c41-13d1-1d05-13c2-24619966119b
         title:
           type: string
           description: A title describing the step
@@ -330,6 +325,24 @@ components:
         - title
         - targetDateRange
         - sequenceNumber
+
+    UpdateStepRequest:
+      title: UpdateStepRequest
+      type: object
+      description: A request to update a Step within a Goal.
+      allOf:
+        - $ref: '#/components/schemas/CreateStepRequest'
+      properties:
+        stepReference:
+          type: string
+          format: uuid
+          description: The Step's unique reference. This is used as an identifier to update the required Step. It is not possible or supported to update the `stepReference`.
+          example: d38a6c41-13d1-1d05-13c2-24619966119b
+        status:
+          $ref: '#/components/schemas/StepStatus'
+      required:
+        - stepReference
+        - status
 
     GoalStatus:
       title: GoalStatus

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
@@ -80,6 +80,7 @@ internal class GoalResourceMapperTest {
     val updateStepRequest = aValidUpdateStepRequest()
     val updateGoalRequest = aValidUpdateGoalRequest(
       reviewDate = LocalDate.now(),
+      status = GoalStatusApi.COMPLETED,
       steps = mutableListOf(updateStepRequest),
     )
 
@@ -90,7 +91,7 @@ internal class GoalResourceMapperTest {
       reference = updateGoalRequest.goalReference,
       title = updateGoalRequest.title,
       reviewDate = updateGoalRequest.reviewDate,
-      status = GoalStatus.ACTIVE,
+      status = GoalStatus.COMPLETED,
       notes = updateGoalRequest.notes,
       steps = mutableListOf(expectedStep),
       // JPA managed fields - expect these all to be null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
@@ -12,10 +12,14 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateStepRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidGoalResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidStepResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateStepRequest
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -34,15 +38,17 @@ internal class GoalResourceMapperTest {
   private lateinit var instantMapper: InstantMapper
 
   @Test
-  fun `should map from model to domain`() {
+  fun `should map from CreateStepRequest model to domain`() {
     // Given
-    val stepRequest = aValidCreateStepRequest()
+    val createStepRequest = aValidCreateStepRequest()
     val createGoalRequest = aValidCreateGoalRequest(
       reviewDate = LocalDate.now(),
-      steps = mutableListOf(stepRequest),
+      steps = mutableListOf(createStepRequest),
     )
+
     val expectedStep = aValidStep()
-    given(stepMapper.fromModelToDomain(any())).willReturn(expectedStep)
+    given(stepMapper.fromModelToDomain(any<CreateStepRequest>())).willReturn(expectedStep)
+
     val expectedGoal = aValidGoal(
       reference = UUID.randomUUID(),
       title = createGoalRequest.title,
@@ -65,7 +71,43 @@ internal class GoalResourceMapperTest {
     // Then
     assertThat(actual).usingRecursiveComparison().ignoringFields("reference").isEqualTo(expectedGoal)
     assertThat(actual.reference).isNotNull()
-    verify(stepMapper).fromModelToDomain(stepRequest)
+    verify(stepMapper).fromModelToDomain(createStepRequest)
+  }
+
+  @Test
+  fun `should map from UpdateStepRequest model to domain`() {
+    // Given
+    val updateStepRequest = aValidUpdateStepRequest()
+    val updateGoalRequest = aValidUpdateGoalRequest(
+      reviewDate = LocalDate.now(),
+      steps = mutableListOf(updateStepRequest),
+    )
+
+    val expectedStep = aValidStep()
+    given(stepMapper.fromModelToDomain(any<UpdateStepRequest>())).willReturn(expectedStep)
+
+    val expectedGoal = aValidGoal(
+      reference = updateGoalRequest.goalReference,
+      title = updateGoalRequest.title,
+      reviewDate = updateGoalRequest.reviewDate,
+      status = GoalStatus.ACTIVE,
+      notes = updateGoalRequest.notes,
+      steps = mutableListOf(expectedStep),
+      // JPA managed fields - expect these all to be null
+      createdAt = null,
+      createdBy = null,
+      createdByDisplayName = null,
+      lastUpdatedAt = null,
+      lastUpdatedBy = null,
+      lastUpdatedByDisplayName = null,
+    )
+
+    // When
+    val actual = mapper.fromModelToDomain(updateGoalRequest)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expectedGoal)
+    verify(stepMapper).fromModelToDomain(updateStepRequest)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapperTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDa
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidStepResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.StepStatus as StepStatusApi
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TargetDateRange as TargetDateRangeApi
 
@@ -20,22 +21,48 @@ internal class StepResourceMapperTest {
   private lateinit var mapper: StepResourceMapperImpl
 
   @Test
-  fun `should map from model to domain`() {
+  fun `should map from CreateStepRequest model to domain`() {
     // Given
-    val stepRequest = aValidCreateStepRequest()
+    val createStepRequest = aValidCreateStepRequest(
+      targetDateRange = TargetDateRangeApi.ZERO_TO_THREE_MONTHS,
+    )
+
     val expectedStep = aValidStep(
-      title = stepRequest.title,
+      title = createStepRequest.title,
       targetDateRange = TargetDateRange.ZERO_TO_THREE_MONTHS,
       status = StepStatus.NOT_STARTED,
-      sequenceNumber = stepRequest.sequenceNumber,
+      sequenceNumber = createStepRequest.sequenceNumber,
     )
 
     // When
-    val actual = mapper.fromModelToDomain(stepRequest)
+    val actual = mapper.fromModelToDomain(createStepRequest)
 
     // Then
     assertThat(actual).usingRecursiveComparison().ignoringFields("reference").isEqualTo(expectedStep)
     assertThat(actual.reference).isNotNull()
+  }
+
+  @Test
+  fun `should map from UpdateStepRequest model to domain`() {
+    // Given
+    val updateStepRequest = aValidUpdateStepRequest(
+      targetDateRange = TargetDateRangeApi.SIX_TO_TWELVE_MONTHS,
+      status = StepStatusApi.COMPLETE,
+    )
+
+    val expectedStep = aValidStep(
+      reference = updateStepRequest.stepReference,
+      title = updateStepRequest.title,
+      targetDateRange = TargetDateRange.SIX_TO_TWELVE_MONTHS,
+      status = StepStatus.COMPLETE,
+      sequenceNumber = updateStepRequest.sequenceNumber,
+    )
+
+    // When
+    val actual = mapper.fromModelToDomain(updateStepRequest)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expectedStep)
   }
 
   @Test

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateGoalRequestBuilder.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 fun aValidCreateGoalRequest(
   title: String = "Improve communication skills",
   reviewDate: LocalDate? = null,
-  steps: List<StepRequest> = listOf(aValidCreateStepRequest(), anotherValidCreateStepRequest()),
+  steps: List<CreateStepRequest> = listOf(aValidCreateStepRequest(), anotherValidCreateStepRequest()),
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
 ): CreateGoalRequest =
   CreateGoalRequest(
@@ -18,7 +18,7 @@ fun aValidCreateGoalRequest(
 fun anotherValidCreateGoalRequest(
   title: String = "Learn bricklaying",
   reviewDate: LocalDate = LocalDate.now().plusMonths(6),
-  steps: List<StepRequest> = listOf(aValidCreateStepRequest("Attend in house bricklaying course")),
+  steps: List<CreateStepRequest> = listOf(aValidCreateStepRequest("Attend in house bricklaying course")),
   notes: String? = "",
 ): CreateGoalRequest =
   CreateGoalRequest(

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateStepRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateStepRequestBuilder.kt
@@ -2,14 +2,13 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TargetDateRange.THREE_TO_SIX_MONTHS
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TargetDateRange.ZERO_TO_THREE_MONTHS
-import java.util.UUID
 
 fun aValidCreateStepRequest(
   title: String = "Book communication skills course",
   targetDateRange: TargetDateRange = ZERO_TO_THREE_MONTHS,
   sequenceNumber: Int = 1,
-): StepRequest =
-  StepRequest(
+): CreateStepRequest =
+  CreateStepRequest(
     title = title,
     targetDateRange = targetDateRange,
     sequenceNumber = sequenceNumber,
@@ -19,21 +18,8 @@ fun anotherValidCreateStepRequest(
   title: String = "Complete communication skills course",
   targetDateRange: TargetDateRange = THREE_TO_SIX_MONTHS,
   sequenceNumber: Int = 2,
-): StepRequest =
-  StepRequest(
-    title = title,
-    targetDateRange = targetDateRange,
-    sequenceNumber = sequenceNumber,
-  )
-
-fun aValidUpdateStepRequest(
-  stepReference: UUID = UUID.randomUUID(),
-  title: String = "Book French course",
-  targetDateRange: TargetDateRange = ZERO_TO_THREE_MONTHS,
-  sequenceNumber: Int = 1,
-): StepRequest =
-  StepRequest(
-    stepReference = stepReference,
+): CreateStepRequest =
+  CreateStepRequest(
     title = title,
     targetDateRange = targetDateRange,
     sequenceNumber = sequenceNumber,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateGoalRequestBuilder.kt
@@ -8,6 +8,7 @@ fun aValidUpdateGoalRequest(
   goalReference: UUID = aValidReference(),
   title: String = "Improve communication skills",
   reviewDate: LocalDate? = null,
+  status: GoalStatus = GoalStatus.ACTIVE,
   steps: List<UpdateStepRequest> = listOf(aValidUpdateStepRequest()),
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
 ): UpdateGoalRequest =
@@ -15,6 +16,7 @@ fun aValidUpdateGoalRequest(
     goalReference = goalReference,
     title = title,
     reviewDate = reviewDate,
+    status = status,
     steps = steps,
     notes = notes,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateGoalRequestBuilder.kt
@@ -8,7 +8,7 @@ fun aValidUpdateGoalRequest(
   goalReference: UUID = aValidReference(),
   title: String = "Improve communication skills",
   reviewDate: LocalDate? = null,
-  steps: List<StepRequest> = listOf(aValidUpdateStepRequest()),
+  steps: List<UpdateStepRequest> = listOf(aValidUpdateStepRequest()),
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
 ): UpdateGoalRequest =
   UpdateGoalRequest(

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateStepRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateStepRequestBuilder.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
+
+import java.util.UUID
+
+fun aValidUpdateStepRequest(
+  stepReference: UUID = UUID.randomUUID(),
+  title: String = "Book French course",
+  targetDateRange: TargetDateRange = TargetDateRange.ZERO_TO_THREE_MONTHS,
+  status: StepStatus = StepStatus.ACTIVE,
+  sequenceNumber: Int = 1,
+): UpdateStepRequest =
+  UpdateStepRequest(
+    stepReference = stepReference,
+    title = title,
+    targetDateRange = targetDateRange,
+    status = status,
+    sequenceNumber = sequenceNumber,
+  )


### PR DESCRIPTION
This PR makes a change to the OpenAPI / swagger spec that @mattwills-moj-digital updated last week (sorry Matt! 😁 )

Matt's PR and change to the API had separate objects for `CreateGoalRequest` and `UpdateGoalRequest`, but they both shared a common `StepRequest` object to represent the steps in the goal.

Because it was a shared object it meant the `stepReference` field had to be optional, because when creating a Step the client (our UI) doesn't know the step reference (the UI is not responsible for generating it). But when updating a Step (via updating the Goal) the client does know the step reference and needs to include it in the request so we know what Step to retrieve and update.

So we made the `stepReference` optional - not 100% ideal, but it served its purpose at the time ....

As part of RR-3 Update A Goal, I've discovered that the step (Matt's `StepRequest`) also doesn't include a `status` field. This is because when creating a step (as part of creating a goal) you don't specify the status - we default it to `NOT_STARTED`.
But when updating a step (as part of updating a goal) we need to be able to update the status .... so the request object needs to carry that field ...

I did consider making it another optional field (like we have with `stepReference`), but it didn't feel right.

So I have refactored the API definition in respect of the `StepRequest` class. I have renamed `StepRequest` to `CreateStepRequest` and removed the optional `stepReference` field. And I have created a new class `UpdateStepRequest` that extends `CreateStepRequest` (using `allOf`) and added the `stepReference` and `status` fields as mandatory fields.