### PR TITLE
RR-32 - Fix Update Goal to support adding new steps

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -194,6 +194,7 @@ class UpdateGoalTest : IntegrationTestBase() {
           sequenceNumber = 1,
         ),
         aValidUpdateStepRequest(
+          stepReference = null,
           title = "Attend course before March 2024",
           sequenceNumber = 2,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapper.kt
@@ -13,14 +13,19 @@ import java.util.UUID
     UUID::class,
   ],
 )
-interface StepResourceMapper {
-  @Mapping(target = "reference", expression = "java(UUID.randomUUID())")
+abstract class StepResourceMapper {
+  @Mapping(target = "reference", expression = "java( generateNewReference() )")
   @Mapping(target = "status", constant = "NOT_STARTED")
-  fun fromModelToDomain(createStepRequest: CreateStepRequest): Step
+  abstract fun fromModelToDomain(createStepRequest: CreateStepRequest): Step
 
-  @Mapping(target = "reference", source = "stepReference")
-  fun fromModelToDomain(updateStepRequest: UpdateStepRequest): Step
+  @Mapping(target = "reference", expression = "java( existingReferenceElseNewReference(updateStepRequest) )")
+  abstract fun fromModelToDomain(updateStepRequest: UpdateStepRequest): Step
 
   @Mapping(target = "stepReference", source = "reference")
-  fun fromDomainToModel(stepDomain: Step): StepResponse
+  abstract fun fromDomainToModel(stepDomain: Step): StepResponse
+
+  protected fun generateNewReference(): UUID = UUID.randomUUID()
+
+  protected fun existingReferenceElseNewReference(updateStepRequest: UpdateStepRequest): UUID =
+    updateStepRequest.stepReference ?: generateNewReference()
 }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.1.2'
+  version: '1.1.3'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -339,12 +339,14 @@ components:
         stepReference:
           type: string
           format: uuid
-          description: The Step's unique reference. This is used as an identifier to update the required Step. It is not possible or supported to update the `stepReference`.
+          description: |
+            Optional reference number for the Step.
+            The Step's unique reference. This is used as an identifier to update the required Step. It is not possible or supported to update the `stepReference` for an existing step.
+            If the Step reference is not supplied this will be treated as a new Step and will be added to the Goal.
           example: d38a6c41-13d1-1d05-13c2-24619966119b
         status:
           $ref: '#/components/schemas/StepStatus'
       required:
-        - stepReference
         - status
 
     GoalStatus:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapperTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidSt
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidStepResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateStepRequest
+import java.util.UUID
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.StepStatus as StepStatusApi
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TargetDateRange as TargetDateRangeApi
 
@@ -43,15 +44,17 @@ internal class StepResourceMapperTest {
   }
 
   @Test
-  fun `should map from UpdateStepRequest model to domain`() {
+  fun `should map from UpdateStepRequest model to domain given existing step with reference number`() {
     // Given
+    val stepReference = UUID.randomUUID()
     val updateStepRequest = aValidUpdateStepRequest(
+      stepReference = stepReference,
       targetDateRange = TargetDateRangeApi.SIX_TO_TWELVE_MONTHS,
       status = StepStatusApi.COMPLETE,
     )
 
     val expectedStep = aValidStep(
-      reference = updateStepRequest.stepReference,
+      reference = stepReference,
       title = updateStepRequest.title,
       targetDateRange = TargetDateRange.SIX_TO_TWELVE_MONTHS,
       status = StepStatus.COMPLETE,
@@ -63,6 +66,30 @@ internal class StepResourceMapperTest {
 
     // Then
     assertThat(actual).usingRecursiveComparison().isEqualTo(expectedStep)
+  }
+
+  @Test
+  fun `should map from UpdateStepRequest model to domain given new step without reference number`() {
+    // Given
+    val updateStepRequest = aValidUpdateStepRequest(
+      stepReference = null,
+      targetDateRange = TargetDateRangeApi.SIX_TO_TWELVE_MONTHS,
+      status = StepStatusApi.COMPLETE,
+    )
+
+    val expectedStep = aValidStep(
+      title = updateStepRequest.title,
+      targetDateRange = TargetDateRange.SIX_TO_TWELVE_MONTHS,
+      status = StepStatus.COMPLETE,
+      sequenceNumber = updateStepRequest.sequenceNumber,
+    )
+
+    // When
+    val actual = mapper.fromModelToDomain(updateStepRequest)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().ignoringFields("reference").isEqualTo(expectedStep)
+    assertThat(actual.reference).isNotNull()
   }
 
   @Test

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateStepRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateStepRequestBuilder.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 import java.util.UUID
 
 fun aValidUpdateStepRequest(
-  stepReference: UUID = UUID.randomUUID(),
+  stepReference: UUID? = UUID.randomUUID(),
   title: String = "Book French course",
   targetDateRange: TargetDateRange = TargetDateRange.ZERO_TO_THREE_MONTHS,
   status: StepStatus = StepStatus.ACTIVE,


### PR DESCRIPTION
This PR fixes the `UpdateStepRequest` API object to support adding new steps as part of the Update Goal flow.

New steps in this context are those without a reference; so this PR corrects the API so that the `stepReference` field of `UpdateStepRequest` is optional. The mapper then generates a new reference UUID if one is not present on the request object.