### PR TITLE
RR-228 - Endpoint to create an Action Plan with a reviewDate

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/GoalServiceTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/GoalServiceTest.kt
@@ -23,7 +23,7 @@ class GoalServiceTest : IntegrationTestBase() {
     val goal = aValidGoal()
 
     // When
-    goalService.createGoal(goal, prisonNumber)
+    goalService.createGoal(prisonNumber, goal)
 
     // Then
     TestTransaction.flagForCommit()
@@ -43,14 +43,14 @@ class GoalServiceTest : IntegrationTestBase() {
     val goal = aValidGoal(
       title = "Goal 1",
     )
-    goalService.createGoal(goal, prisonNumber)
+    goalService.createGoal(prisonNumber, goal)
 
     val newGoal = aValidGoal(
       title = "Goal 2",
     )
 
     // When
-    goalService.createGoal(newGoal, prisonNumber)
+    goalService.createGoal(prisonNumber, newGoal)
 
     // Then
     TestTransaction.flagForCommit()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -1,0 +1,211 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.context.transaction.TestTransaction
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TargetDateRange as TargetDateRangeEntity
+
+class CreateActionPlanTest : IntegrationTestBase() {
+
+  companion object {
+    private const val URI_TEMPLATE = "/action-plans/{prisonNumber}"
+  }
+
+  @Test
+  fun `should return unauthorized given no bearer token`() {
+    webTestClient.post()
+      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `should return forbidden given bearer token with view only role`() {
+    webTestClient.post()
+      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .withBody(aValidCreateActionPlanRequest())
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should fail to create action plan given no goals provided`() {
+    val prisonNumber = aValidPrisonNumber()
+    val createRequest = aValidCreateActionPlanRequest(goals = emptyList())
+
+    // When
+    val response = webTestClient.post()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(createRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(BAD_REQUEST.value())
+      .hasUserMessage("Validation failed for object='createActionPlanRequest'. Error count: 1")
+      .hasDeveloperMessageContaining("Goals cannot be empty when creating an Action Plan")
+  }
+
+  @Test
+  fun `should fail to create action plan given a goal with no steps provided`() {
+    val prisonNumber = aValidPrisonNumber()
+    val goalWithNoSteps = aValidCreateGoalRequest(steps = emptyList())
+    val createRequest = aValidCreateActionPlanRequest(goals = listOf(goalWithNoSteps))
+
+    // When
+    val response = webTestClient.post()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(createRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(BAD_REQUEST.value())
+      .hasUserMessage("Validation failed for object='createActionPlanRequest'. Error count: 1")
+      .hasDeveloperMessageContaining("Error on field 'goals[0].steps': rejected value [[]], size must be between 1 and 2147483647")
+  }
+
+  @Test
+  fun `should fail to create action plan given null fields`() {
+    val prisonNumber = aValidPrisonNumber()
+
+    // When
+    val response = webTestClient.post()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .bodyValue(
+        """
+          { }
+        """.trimIndent(),
+      )
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.BAD_REQUEST.value())
+      .hasUserMessageContaining("JSON parse error")
+      .hasUserMessageContaining("value failed for JSON property goals due to missing (therefore NULL) value for creator parameter goals")
+  }
+
+  @Test
+  @Transactional
+  fun `should create a new action plan given prisoner does not have an action plan`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val createStepRequest = aValidCreateStepRequest()
+    val createGoalRequest = aValidCreateGoalRequest(steps = listOf(createStepRequest))
+    val createActionPlanRequest = aValidCreateActionPlanRequest(goals = listOf(createGoalRequest))
+    val expectedReviewDate = createActionPlanRequest.reviewDate!!
+    val dpsUsername = "auser_gen"
+    val displayName = "Albert User"
+
+    // When
+    webTestClient.post()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(createActionPlanRequest)
+      .bearerToken(
+        aValidTokenWithEditAuthority(
+          username = dpsUsername,
+          displayName = displayName,
+          privateKey = keyPair.private,
+        ),
+      )
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
+
+    // Then
+    val actionPlan = actionPlanRepository.findByPrisonNumber(prisonNumber)
+    assertThat(actionPlan)
+      .isForPrisonNumber(prisonNumber)
+      .hasReviewDate(expectedReviewDate)
+      .hasNumberOfGoals(1)
+      .wasCreatedBy(dpsUsername)
+    val goal = actionPlan!!.goals!![0]
+    assertThat(goal)
+      .hasTitle(createGoalRequest.title)
+      .hasNumberOfSteps(createGoalRequest.steps.size)
+      .wasCreatedBy(dpsUsername)
+      .hasCreatedByDisplayName(displayName)
+      .wasUpdatedBy(dpsUsername)
+      .hasUpdatedByDisplayName(displayName)
+    val step = goal.steps!![0]
+    assertThat(step)
+      .hasTitle(createStepRequest.title)
+      .hasTargetDateRange(TargetDateRangeEntity.ZERO_TO_THREE_MONTHS)
+      .hasStatus(StepStatus.NOT_STARTED)
+      .wasCreatedBy(dpsUsername)
+  }
+
+  @Test
+  @Transactional
+  fun `should fail to create action plan given action plan already exists`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val actionPlan = aValidActionPlanEntity(prisonNumber = prisonNumber)
+    actionPlanRepository.save(actionPlan)
+    TestTransaction.flagForCommit()
+    TestTransaction.end()
+    TestTransaction.start()
+    assertThat(actionPlan).hasNumberOfGoals(1)
+    val createRequest = aValidCreateActionPlanRequest()
+
+    // When
+    val response = webTestClient.post()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(createRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isForbidden
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(FORBIDDEN.value())
+      .hasUserMessage("An Action Plan already exists for prisoner $prisonNumber.")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
@@ -11,6 +11,12 @@ class JpaActionPlanPersistenceAdapter(
   private val actionPlanRepository: ActionPlanRepository,
   private val actionPlanMapper: ActionPlanEntityMapper,
 ) : ActionPlanPersistenceAdapter {
+
+  override fun createActionPlan(actionPlan: ActionPlan): ActionPlan {
+    val persistedEntity = actionPlanRepository.save(actionPlanMapper.fromDomainToEntity(actionPlan))
+    return actionPlanMapper.fromEntityToDomain(persistedEntity)
+  }
+
   override fun getActionPlan(prisonNumber: String): ActionPlan? =
     actionPlanRepository.findByPrisonNumber(prisonNumber)?.let {
       actionPlanMapper.fromEntityToDomain(it)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
@@ -25,7 +25,11 @@ class JpaGoalPersistenceAdapter(
     // TODO RR-227 - throw 404 instead?
     if (actionPlanEntity == null) {
       log.info { "Creating new Action Plan for prisoner [$prisonNumber]" }
-      actionPlanEntity = newActionPlanForPrisoner(reference = UUID.randomUUID(), prisonNumber = prisonNumber, reviewDate = null)
+      actionPlanEntity = newActionPlanForPrisoner(
+        reference = UUID.randomUUID(),
+        prisonNumber = prisonNumber,
+        reviewDate = null,
+      )
     }
 
     val goalEntity = goalMapper.fromDomainToEntity(goal)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntity.kt
@@ -72,7 +72,12 @@ class ActionPlanEntity(
      * Returns new un-persisted [ActionPlanEntity] for the specified prisoner with an empty collection of [GoalEntity]s
      */
     fun newActionPlanForPrisoner(reference: UUID, prisonNumber: String, reviewDate: LocalDate?): ActionPlanEntity =
-      ActionPlanEntity(reference = reference, prisonNumber = prisonNumber, reviewDate = reviewDate, goals = mutableListOf())
+      ActionPlanEntity(
+        reference = reference,
+        prisonNumber = prisonNumber,
+        reviewDate = reviewDate,
+        goals = mutableListOf(),
+      )
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapper.kt
@@ -10,5 +10,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPl
   ],
 )
 interface ActionPlanEntityMapper {
+  @ExcludeJpaManagedFields
+  fun fromDomainToEntity(actionPlan: ActionPlan): ActionPlanEntity
+
   fun fromEntityToDomain(actionPlanEntity: ActionPlanEntity): ActionPlan
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
@@ -1,29 +1,45 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.ActionPlanResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 
 @RestController
 @RequestMapping(value = ["/action-plans/{prisonNumber}"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ActionPlanController(
   private val actionPlanService: ActionPlanService,
-  private val actionPlanResourceMapper: ActionPlanResourceMapper,
+  private val actionPlanMapper: ActionPlanResourceMapper,
 ) {
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  @PreAuthorize(HAS_EDIT_AUTHORITY)
+  fun createActionPlan(
+    @Valid
+    @RequestBody
+    request: CreateActionPlanRequest,
+    @PathVariable prisonNumber: String,
+  ) {
+    actionPlanService.createActionPlan(actionPlanMapper.fromModelToDomain(prisonNumber, request))
+  }
 
   @GetMapping
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize(HAS_VIEW_AUTHORITY)
   fun getActionPlan(@PathVariable prisonNumber: String): ActionPlanResponse =
     with(actionPlanService.getActionPlan(prisonNumber)) {
-      actionPlanResourceMapper.fromDomainToModel(this)
+      actionPlanMapper.fromDomainToModel(this)
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GlobalExceptionHandler.kt
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanAlreadyExistsException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalNotFoundException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
@@ -51,14 +52,14 @@ class GlobalExceptionHandler(
 ) : ResponseEntityExceptionHandler() {
 
   /**
-   * Exception handler to return a 403 Forbidden ErrorResponse
+   * Exception handler to return a 403 Forbidden ErrorResponse for an AccessDeniedException.
    */
   @ExceptionHandler(
     value = [
       AccessDeniedException::class,
     ],
   )
-  protected fun handleExceptionReturnForbiddenErrorResponse(
+  protected fun handleAccessDeniedExceptionReturnForbiddenErrorResponse(
     e: RuntimeException,
     request: WebRequest,
   ): ResponseEntity<Any> {
@@ -70,6 +71,29 @@ class GlobalExceptionHandler(
           status = FORBIDDEN.value(),
           userMessage = e.message,
           developerMessage = "Access denied on ${request.getDescription(false)}",
+        ),
+      )
+  }
+
+  /**
+   * Exception handler to return a 403 Forbidden ErrorResponse for a prohibited action (e.g. a business rule violation).
+   */
+  @ExceptionHandler(
+    value = [
+      ActionPlanAlreadyExistsException::class,
+    ],
+  )
+  protected fun handleExceptionReturnForbiddenErrorResponse(
+    e: RuntimeException,
+    request: WebRequest,
+  ): ResponseEntity<Any> {
+    log.info("Forbidden request: {}", e.message)
+    return ResponseEntity
+      .status(FORBIDDEN)
+      .body(
+        ErrorResponse(
+          status = FORBIDDEN.value(),
+          userMessage = e.message,
         ),
       )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 
 import org.mapstruct.Mapper
+import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 
 @Mapper(
   uses = [
@@ -10,5 +12,9 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Actio
   ],
 )
 interface ActionPlanResourceMapper {
+
+  @Mapping(target = "reference", expression = "java(UUID.randomUUID())")
+  fun fromModelToDomain(prisonNumber: String, request: CreateActionPlanRequest): ActionPlan
+
   fun fromDomainToModel(actionPlan: ActionPlan): ActionPlanResponse
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlan.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlan.kt
@@ -20,6 +20,10 @@ class ActionPlan(
     get() = field.also { goals -> goals.sortByDescending { it.createdAt } }
 
   init {
+    // TODO - RR-227 enable once we are returning a 404, rather than a "dummy" Action Plan
+    // if (goals.isEmpty()) {
+    //  throw InvalidActionPlanException("Cannot create ActionPlan with reference [$reference]. At least one Goal is required.")
+    // }
     this.goals = goals.toMutableList()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Exceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Exceptions.kt
@@ -3,6 +3,11 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
 import java.util.UUID
 
 /**
+ * Thrown when an Action Plan cannot be created, for example because it is missing mandatory data.
+ */
+class InvalidActionPlanException(message: String) : RuntimeException(message)
+
+/**
  * Thrown when a Goal cannot be created, for example because it is missing mandatory data.
  */
 class InvalidGoalException(message: String) : RuntimeException(message)
@@ -11,6 +16,11 @@ class InvalidGoalException(message: String) : RuntimeException(message)
  * Thrown when an ActionPlan cannot be found.
  */
 class ActionPlanNotFoundException(message: String) : RuntimeException(message)
+
+/**
+ * Thrown when an Attempt is made to create an ActionPlan for a prisoner who already has one.
+ */
+class ActionPlanAlreadyExistsException(message: String) : RuntimeException(message)
 
 /**
  * Thrown when a specified Goal cannot be found.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
@@ -80,3 +80,9 @@ class Goal(
     return "Goal(reference=$reference, title='$title', reviewDate=$reviewDate, status=$status, createdBy='$createdBy', createdAt=$createdAt, lastUpdatedBy='$lastUpdatedBy', lastUpdatedAt=$lastUpdatedAt, steps=$steps)"
   }
 }
+
+enum class GoalStatus {
+  ACTIVE,
+  COMPLETED,
+  ARCHIVED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalStatus.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
-
-enum class GoalStatus {
-  ACTIVE,
-  COMPLETED,
-  ARCHIVED,
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Step.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Step.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
 
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus.NOT_STARTED
 import java.util.UUID
 
 /**
@@ -13,6 +12,19 @@ data class Step(
   val reference: UUID,
   val title: String,
   val targetDateRange: TargetDateRange,
-  val status: StepStatus = NOT_STARTED,
+  val status: StepStatus = StepStatus.NOT_STARTED,
   val sequenceNumber: Int,
 )
+
+enum class TargetDateRange {
+  ZERO_TO_THREE_MONTHS,
+  THREE_TO_SIX_MONTHS,
+  SIX_TO_TWELVE_MONTHS,
+  MORE_THAN_TWELVE_MONTHS,
+}
+
+enum class StepStatus {
+  NOT_STARTED,
+  ACTIVE,
+  COMPLETE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/StepStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/StepStatus.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
-
-enum class StepStatus {
-  NOT_STARTED,
-  ACTIVE,
-  COMPLETE,
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/TargetDateRange.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/TargetDateRange.kt
@@ -1,8 +1,0 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
-
-enum class TargetDateRange {
-  ZERO_TO_THREE_MONTHS,
-  THREE_TO_SIX_MONTHS,
-  SIX_TO_TWELVE_MONTHS,
-  MORE_THAN_TWELVE_MONTHS,
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanPersistenceAdapter.kt
@@ -13,6 +13,11 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPl
 interface ActionPlanPersistenceAdapter {
 
   /**
+   * Creates a new [ActionPlan] and returns persisted instance.
+   */
+  fun createActionPlan(actionPlan: ActionPlan): ActionPlan
+
+  /**
    * Returns an [ActionPlan] if found, otherwise `null`.
    */
   fun getActionPlan(prisonNumber: String): ActionPlan?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 
 import mu.KotlinLogging
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanAlreadyExistsException
 import java.util.UUID
 
 private val log = KotlinLogging.logger {}
@@ -20,6 +21,21 @@ class ActionPlanService(
 ) {
 
   /**
+   * Creates an [ActionPlan] for a prisoner, containing at least one or more Goals.
+   */
+  fun createActionPlan(actionPlan: ActionPlan): ActionPlan {
+    with(actionPlan) {
+      log.info { "Saving ActionPlan [$reference] for prisoner [$prisonNumber]" }
+
+      if (persistenceAdapter.getActionPlan(prisonNumber) != null) {
+        throw ActionPlanAlreadyExistsException("An Action Plan already exists for prisoner $prisonNumber.")
+      }
+
+      return persistenceAdapter.createActionPlan(actionPlan)
+    }
+  }
+
+  /**
    * Retrieves a Prisoner's [ActionPlan] based on their prison number.
    * Returns a new [ActionPlan] if the [ActionPlan] cannot be found.
    */
@@ -27,6 +43,11 @@ class ActionPlanService(
     log.debug { "Retrieving Action Plan for prisoner [$prisonNumber]" }
     // RR-227 - return 404 if not found
     return persistenceAdapter.getActionPlan(prisonNumber)
-      ?: ActionPlan(reference = UUID.randomUUID(), prisonNumber = prisonNumber, reviewDate = null, goals = emptyList())
+      ?: ActionPlan(
+        reference = UUID.randomUUID(),
+        prisonNumber = prisonNumber,
+        reviewDate = null,
+        goals = emptyList(),
+      )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalService.kt
@@ -24,7 +24,7 @@ class GoalService(
   /**
    * Creates a new [Goal] for the prisoner identified by their prison number.
    */
-  fun createGoal(goal: Goal, prisonNumber: String): Goal {
+  fun createGoal(prisonNumber: String, goal: Goal): Goal {
     log.info { "Saving Goal [${goal.reference}] for prisoner [$prisonNumber]" }
     return persistenceAdapter.createGoal(goal, prisonNumber)
   }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,2 +1,3 @@
+Size.createActionPlanRequest.goals=Goals cannot be empty when creating an Action Plan
 Size.createGoalRequest.steps=Steps cannot be empty when creating a Goal
 Size.updateGoalRequest.steps=Steps cannot be empty when updating a Goal

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -37,7 +37,7 @@ paths:
         - Action Plan
       responses:
         '201':
-          $ref: '#/components/responses/ActionPlan'
+          description: The Action Plan was created successfully.
         '400':
           $ref: '#/components/responses/400ErrorResponse'
         '404':
@@ -71,7 +71,7 @@ paths:
         - Action Plan - Single Goal
       responses:
         '201':
-          $ref: '#/components/responses/Goal'
+          description: The Goal was created successfully.
         '400':
           $ref: '#/components/responses/400ErrorResponse'
         '404':
@@ -282,7 +282,8 @@ components:
           example: '2023-12-19'
         goals:
           type: array
-          description: A List of at least one or more Goals.
+          minItems: 1
+          description: A List of at least one Goal.
           items:
             $ref: '#/components/schemas/CreateGoalRequest'
       required:

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.1.3'
+  version: '1.1.4'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -30,6 +30,21 @@ paths:
         example: 'A1234BC'
         in: path
         required: true
+    post:
+      summary: Creates an Action Plan.
+      description: Creates an Action Plan with at least one or more Goals.
+      tags:
+        - Action Plan
+      responses:
+        '201':
+          $ref: '#/components/responses/ActionPlan'
+        '400':
+          $ref: '#/components/responses/400ErrorResponse'
+        '404':
+          $ref: '#/components/responses/404ErrorResponse'
+      operationId: create-action-plan
+      requestBody:
+        $ref: '#/components/requestBodies/CreateActionPlan'
     get:
       summary: Return a Prisoner's Action Plan
       description: Return a Prisoner's Action Plan with the goals ordered in chronological order (oldest first). If the prisoner does not yet have any goals set, then an Action Plan with no goals (empty array) is returned.
@@ -135,16 +150,27 @@ components:
       type: object
       description: A Prisoner's Action Plan containing a list of one or more Goals.
       properties:
+        reference:
+          type: string
+          format: uuid
+          description: The Action Plan's unique reference
+          example: 814ade0a-a3b2-46a3-862f-79211ba13f7b
         prisonNumber:
           type: string
           description: The ID of the prisoner
           example: 'A1234BC'
+        reviewDate:
+          type: string
+          format: date
+          description: An optional ISO-8601 date representing when the Action Plan is up for review.
+          example: '2023-12-19'
         goals:
           type: array
           description: A List of at least one or more Goals.
           items:
             $ref: '#/components/schemas/GoalResponse'
       required:
+        - reference
         - prisonNumber
         - goals
     GoalResponse:
@@ -243,6 +269,29 @@ components:
         - targetDateRange
         - status
         - sequenceNumber
+
+    CreateActionPlanRequest:
+      title: CreateActionPlanRequest
+      type: object
+      description: A request to create an  Action Plan with at least one or more Goals that a Prisoner aims to complete.
+      properties:
+        prisonNumber:
+          type: string
+          description: The ID of the prisoner
+          example: 'A1234BC'
+        reviewDate:
+          type: string
+          format: date
+          description: An optional ISO-8601 date representing when the Action Plan is up for review.
+          example: '2023-12-19'
+        goals:
+          type: array
+          description: A List of at least one or more Goals.
+          items:
+            $ref: '#/components/schemas/CreateGoalRequest'
+      required:
+        - prisonNumber
+        - goals
 
     CreateGoalRequest:
       title: CreateGoalRequest
@@ -475,6 +524,12 @@ components:
   # Request Body Definitions
   # --------------------------------------------------------------------------------
   requestBodies:
+    CreateActionPlan:
+      description: Request body to create an Action Plan with at least one or more Goals.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateActionPlanRequest'
     CreateGoal:
       description: Request body to create a single Goal.
       content:

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -275,10 +275,6 @@ components:
       type: object
       description: A request to create an  Action Plan with at least one or more Goals that a Prisoner aims to complete.
       properties:
-        prisonNumber:
-          type: string
-          description: The ID of the prisoner
-          example: 'A1234BC'
         reviewDate:
           type: string
           format: date
@@ -290,7 +286,6 @@ components:
           items:
             $ref: '#/components/schemas/CreateGoalRequest'
       required:
-        - prisonNumber
         - goals
 
     CreateGoalRequest:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ActionPlanEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
@@ -26,6 +27,26 @@ class JpaActionPlanPersistenceAdapterTest {
 
   @Mock
   private lateinit var actionPlanMapper: ActionPlanEntityMapper
+
+  @Test
+  fun `should save Action Plan`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val actionPlanDomain = aValidActionPlan(prisonNumber = prisonNumber)
+    val actionPlanEntity = aValidActionPlanEntity(prisonNumber = prisonNumber)
+    given(actionPlanMapper.fromDomainToEntity(any())).willReturn(actionPlanEntity)
+    given(actionPlanRepository.save(any<ActionPlanEntity>())).willReturn(actionPlanEntity)
+    given(actionPlanMapper.fromEntityToDomain(any())).willReturn(actionPlanDomain)
+
+    // When
+    val actual = persistenceAdapter.createActionPlan(actionPlanDomain)
+
+    // Then
+    assertThat(actual).isEqualTo(actionPlanDomain)
+    verify(actionPlanRepository).save(actionPlanEntity)
+    verify(actionPlanMapper).fromDomainToEntity(actionPlanDomain)
+    verify(actionPlanMapper).fromEntityToDomain(actionPlanEntity)
+  }
 
   @Test
   fun `should retrieve Action Plan`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityTest.kt
@@ -13,7 +13,11 @@ class ActionPlanEntityTest {
     val prisonNumber = aValidPrisonNumber()
 
     // When
-    val actual = ActionPlanEntity.newActionPlanForPrisoner(reference = UUID.randomUUID(), prisonNumber = prisonNumber, reviewDate = null)
+    val actual = ActionPlanEntity.newActionPlanForPrisoner(
+      reference = UUID.randomUUID(),
+      prisonNumber = prisonNumber,
+      reviewDate = null,
+    )
 
     // Then
     assertThat(actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidGoalEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
 
@@ -22,6 +23,30 @@ class ActionPlanEntityMapperTest {
 
   @Mock
   private lateinit var goalMapper: GoalEntityMapper
+
+  @Test
+  fun `should map from domain to entity`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val actionPlan = aValidActionPlan(
+      prisonNumber = prisonNumber,
+    )
+    val expectedGoalEntity = aValidGoalEntity()
+    val expected = aValidActionPlanEntity(
+      reference = actionPlan.reference,
+      prisonNumber = prisonNumber,
+      reviewDate = actionPlan.reviewDate,
+      goals = mutableListOf(expectedGoalEntity),
+    )
+    given(goalMapper.fromDomainToEntity(any())).willReturn(expectedGoalEntity)
+
+    // When
+    val actual = mapper.fromDomainToEntity(actionPlan)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().ignoringFields("id").isEqualTo(expected)
+    verify(goalMapper).fromDomainToEntity(actionPlan.goals[0])
+  }
 
   @Test
   fun `should map from entity to domain`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
@@ -27,7 +27,9 @@ internal class ActionPlanResourceMapperTest {
     val actionPlan = aValidActionPlan()
     val expectedGoal = aValidGoalResponse()
     val expectedActionPlan = aValidActionPlanResponse(
+      reference = actionPlan.reference,
       prisonNumber = actionPlan.prisonNumber,
+      reviewDate = actionPlan.reviewDate,
       goals = mutableListOf(expectedGoal),
     )
     given(goalMapper.fromDomainToModel(any())).willReturn(expectedGoal)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
@@ -9,8 +9,12 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidActionPlanResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidGoalResponse
 
 @ExtendWith(MockitoExtension::class)
@@ -20,6 +24,27 @@ internal class ActionPlanResourceMapperTest {
 
   @Mock
   private lateinit var goalMapper: GoalResourceMapper
+
+  @Test
+  fun `should map from model to domain`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val request = aValidCreateActionPlanRequest()
+    val expectedGoal = aValidGoal()
+    val expectedActionPlan = aValidActionPlan(
+      prisonNumber = prisonNumber,
+      reviewDate = request.reviewDate,
+      goals = listOf(expectedGoal),
+    )
+    given(goalMapper.fromModelToDomain(any<CreateGoalRequest>())).willReturn(expectedGoal)
+
+    // When
+    val actual = mapper.fromModelToDomain(prisonNumber, request)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().ignoringFields("reference").isEqualTo(expectedActionPlan)
+    verify(goalMapper).fromModelToDomain(request.goals[0])
+  }
 
   @Test
   fun `should map from domain to model`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
@@ -32,7 +32,7 @@ class GoalServiceTest {
     val prisonNumber = aValidPrisonNumber()
 
     // When
-    service.createGoal(goal, prisonNumber)
+    service.createGoal(prisonNumber, goal)
 
     // Then
     verify(persistenceAdapter).createGoal(goal, prisonNumber)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityAssert.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.en
 
 import org.assertj.core.api.AbstractObjectAssert
 import java.time.Instant
+import java.time.LocalDate
 import java.util.UUID
 import java.util.function.Consumer
 
@@ -88,6 +89,16 @@ class ActionPlanEntityAssert(actual: ActionPlanEntity?) :
     with(actual!!) {
       if (prisonNumber != expected) {
         failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDate(expected: LocalDate): ActionPlanEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDate != expected) {
+        failWithMessage("Expected reviewDate to be $expected, but was $reviewDate")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 
 import org.assertj.core.api.AbstractObjectAssert
+import java.time.LocalDate
 import java.util.function.Consumer
 
 fun assertThat(actual: ActionPlanResponse?) = ActionPlanResponseAssert(actual)
@@ -16,6 +17,26 @@ class ActionPlanResponseAssert(actual: ActionPlanResponse?) :
     with(actual!!) {
       if (prisonNumber != expected) {
         failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDate(expected: LocalDate): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDate != expected) {
+        failWithMessage("Expected reviewDate to be $expected, but was $reviewDate")
+      }
+    }
+    return this
+  }
+
+  fun hasNoReviewDate(): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDate != null) {
+        failWithMessage("Expected reviewDate to be null, but was $reviewDate")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseBuilder.kt
@@ -1,10 +1,17 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 
+import java.time.LocalDate
+import java.util.UUID
+
 fun aValidActionPlanResponse(
+  reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
+  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<GoalResponse> = listOf(aValidGoalResponse(), anotherValidGoalResponse()),
 ): ActionPlanResponse =
   ActionPlanResponse(
+    reference = reference,
     prisonNumber = prisonNumber,
+    reviewDate = reviewDate,
     goals = goals,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateActionPlanRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateActionPlanRequestBuilder.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
+
+import java.time.LocalDate
+
+fun aValidCreateActionPlanRequest(
+  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
+  goals: List<CreateGoalRequest> = listOf(aValidCreateGoalRequest()),
+): CreateActionPlanRequest =
+  CreateActionPlanRequest(
+    reviewDate = reviewDate,
+    goals = goals,
+  )


### PR DESCRIPTION
This PR adds the swagger definition and endpoint to an **Action Plan**, with a list of one or more **Goals**.

As part of this change, I've added the new `reference` and `reviewDate` fields to the GET Action Plan response.

It is the end result of a series of previously reviewed and merged PRs into this branch.