### PR TITLE
RR-230 Add ReviewDateCategory to Action Plan

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -124,7 +124,7 @@ class CreateActionPlanTest : IntegrationTestBase() {
     assertThat(actual)
       .hasStatus(HttpStatus.BAD_REQUEST.value())
       .hasUserMessageContaining("JSON parse error")
-      .hasUserMessageContaining("value failed for JSON property goals due to missing (therefore NULL) value for creator parameter goals")
+      .hasUserMessageContaining("value failed for JSON property reviewDateCategory due to missing (therefore NULL) value for creator parameter reviewDateCategory")
   }
 
   @Test

--- a/src/integrationTest/resources/db/h2/V2023.08.15.0001__add_action_plan_fields.sql
+++ b/src/integrationTest/resources/db/h2/V2023.08.15.0001__add_action_plan_fields.sql
@@ -1,5 +1,8 @@
 ALTER TABLE action_plan ADD COLUMN reference UUID;
+ALTER TABLE action_plan ADD COLUMN review_date_category VARCHAR(50);
 ALTER TABLE action_plan ADD COLUMN review_date DATE;
 
-UPDATE action_plan SET reference = random_uuid() WHERE reference IS NULL;
+UPDATE action_plan SET reference = random_uuid(), review_date_category = 'NO_DATE' WHERE reference IS NULL;
+
 ALTER TABLE action_plan ALTER COLUMN reference SET NOT NULL;
+ALTER TABLE action_plan ALTER COLUMN review_date_category SET NOT NULL;

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanEntity.Companion.newActionPlanForPrisoner
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.GoalEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ReviewDateCategory
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.GoalEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
@@ -25,7 +26,12 @@ class JpaGoalPersistenceAdapter(
     // TODO RR-227 - throw 404 instead?
     if (actionPlanEntity == null) {
       log.info { "Creating new Action Plan for prisoner [$prisonNumber]" }
-      actionPlanEntity = newActionPlanForPrisoner(reference = UUID.randomUUID(), prisonNumber = prisonNumber, reviewDate = null)
+      actionPlanEntity = newActionPlanForPrisoner(
+        reference = UUID.randomUUID(),
+        prisonNumber = prisonNumber,
+        reviewDateCategory = ReviewDateCategory.NO_DATE,
+        reviewDate = null,
+      )
     }
 
     val goalEntity = goalMapper.fromDomainToEntity(goal)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntity.kt
@@ -4,6 +4,8 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
@@ -41,6 +43,11 @@ class ActionPlanEntity(
   var prisonNumber: String? = null,
 
   @Column
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var reviewDateCategory: ReviewDateCategory? = null,
+
+  @Column
   var reviewDate: LocalDate? = null,
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
@@ -71,8 +78,14 @@ class ActionPlanEntity(
     /**
      * Returns new un-persisted [ActionPlanEntity] for the specified prisoner with an empty collection of [GoalEntity]s
      */
-    fun newActionPlanForPrisoner(reference: UUID, prisonNumber: String, reviewDate: LocalDate?): ActionPlanEntity =
-      ActionPlanEntity(reference = reference, prisonNumber = prisonNumber, reviewDate = reviewDate, goals = mutableListOf())
+    fun newActionPlanForPrisoner(reference: UUID, prisonNumber: String, reviewDateCategory: ReviewDateCategory, reviewDate: LocalDate?): ActionPlanEntity =
+      ActionPlanEntity(
+        reference = reference,
+        prisonNumber = prisonNumber,
+        reviewDateCategory = reviewDateCategory,
+        reviewDate = reviewDate,
+        goals = mutableListOf(),
+      )
   }
 
   /**
@@ -103,4 +116,12 @@ class ActionPlanEntity(
   override fun toString(): String {
     return this::class.simpleName + "(id = $id, prisonNumber = $prisonNumber)"
   }
+}
+
+enum class ReviewDateCategory {
+  THREE_MONTHS,
+  SIX_MONTHS,
+  TWELVE_MONTHS,
+  NO_DATE,
+  SPECIFIC_DATE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlan.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlan.kt
@@ -9,6 +9,7 @@ import java.util.UUID
 class ActionPlan(
   val reference: UUID,
   val prisonNumber: String,
+  val reviewDateCategory: ReviewDateCategory,
   val reviewDate: LocalDate?,
   goals: List<Goal> = emptyList(),
 ) {
@@ -34,6 +35,14 @@ class ActionPlan(
     goals.add(goal)
 
   override fun toString(): String {
-    return "ActionPlan(reference=$reference, prisonNumber='$prisonNumber', reviewDate='$reviewDate', goals=$goals)"
+    return "ActionPlan(reference=$reference, prisonNumber='$prisonNumber', reviewDateCategory='$reviewDateCategory', reviewDate='$reviewDate', goals=$goals)"
   }
+}
+
+enum class ReviewDateCategory {
+  THREE_MONTHS,
+  SIX_MONTHS,
+  TWELVE_MONTHS,
+  NO_DATE,
+  SPECIFIC_DATE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Goal.kt
@@ -80,3 +80,9 @@ class Goal(
     return "Goal(reference=$reference, title='$title', reviewDate=$reviewDate, status=$status, createdBy='$createdBy', createdAt=$createdAt, lastUpdatedBy='$lastUpdatedBy', lastUpdatedAt=$lastUpdatedAt, steps=$steps)"
   }
 }
+
+enum class GoalStatus {
+  ACTIVE,
+  COMPLETED,
+  ARCHIVED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalStatus.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
-
-enum class GoalStatus {
-  ACTIVE,
-  COMPLETED,
-  ARCHIVED,
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Step.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Step.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
 
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus.NOT_STARTED
 import java.util.UUID
 
 /**
@@ -13,6 +12,19 @@ data class Step(
   val reference: UUID,
   val title: String,
   val targetDateRange: TargetDateRange,
-  val status: StepStatus = NOT_STARTED,
+  val status: StepStatus = StepStatus.NOT_STARTED,
   val sequenceNumber: Int,
 )
+
+enum class TargetDateRange {
+  ZERO_TO_THREE_MONTHS,
+  THREE_TO_SIX_MONTHS,
+  SIX_TO_TWELVE_MONTHS,
+  MORE_THAN_TWELVE_MONTHS,
+}
+
+enum class StepStatus {
+  NOT_STARTED,
+  ACTIVE,
+  COMPLETE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/StepStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/StepStatus.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
-
-enum class StepStatus {
-  NOT_STARTED,
-  ACTIVE,
-  COMPLETE,
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/TargetDateRange.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/TargetDateRange.kt
@@ -1,8 +1,0 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
-
-enum class TargetDateRange {
-  ZERO_TO_THREE_MONTHS,
-  THREE_TO_SIX_MONTHS,
-  SIX_TO_TWELVE_MONTHS,
-  MORE_THAN_TWELVE_MONTHS,
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 import mu.KotlinLogging
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanAlreadyExistsException
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ReviewDateCategory
 import java.util.UUID
 
 private val log = KotlinLogging.logger {}
@@ -43,6 +44,12 @@ class ActionPlanService(
     log.debug { "Retrieving Action Plan for prisoner [$prisonNumber]" }
     // RR-227 - return 404 if not found
     return persistenceAdapter.getActionPlan(prisonNumber)
-      ?: ActionPlan(reference = UUID.randomUUID(), prisonNumber = prisonNumber, reviewDate = null, goals = emptyList())
+      ?: ActionPlan(
+        reference = UUID.randomUUID(),
+        prisonNumber = prisonNumber,
+        reviewDateCategory = ReviewDateCategory.NO_DATE,
+        reviewDate = null,
+        goals = emptyList(),
+      )
   }
 }

--- a/src/main/resources/db/postgres/V2023.08.15.0001__add_action_plan_fields.sql
+++ b/src/main/resources/db/postgres/V2023.08.15.0001__add_action_plan_fields.sql
@@ -1,7 +1,10 @@
 ALTER TABLE action_plan ADD COLUMN reference UUID;
+ALTER TABLE action_plan ADD COLUMN review_date_category VARCHAR(50);
 ALTER TABLE action_plan ADD COLUMN review_date DATE;
 
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-UPDATE action_plan SET reference = uuid_generate_v4() WHERE reference IS NULL;
+UPDATE action_plan SET reference = uuid_generate_v4(), review_date_category = 'NO_DATE' WHERE reference IS NULL;
+
 ALTER TABLE action_plan ALTER COLUMN reference SET NOT NULL;
+ALTER TABLE action_plan ALTER COLUMN review_date_category SET NOT NULL;

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -159,6 +159,8 @@ components:
           type: string
           description: The ID of the prisoner
           example: 'A1234BC'
+        reviewDateCategory:
+          $ref: '#/components/schemas/ReviewDateCategory'
         reviewDate:
           type: string
           format: date
@@ -172,6 +174,7 @@ components:
       required:
         - reference
         - prisonNumber
+        - reviewDateCategory
         - goals
     GoalResponse:
       title: GoalResponse
@@ -275,6 +278,8 @@ components:
       type: object
       description: A request to create an  Action Plan with at least one or more Goals that a Prisoner aims to complete.
       properties:
+        reviewDateCategory:
+          $ref: '#/components/schemas/ReviewDateCategory'
         reviewDate:
           type: string
           format: date
@@ -287,6 +292,7 @@ components:
           items:
             $ref: '#/components/schemas/CreateGoalRequest'
       required:
+        - reviewDateCategory
         - goals
 
     CreateGoalRequest:
@@ -394,6 +400,16 @@ components:
       required:
         - status
 
+    ReviewDateCategory:
+      title: ReviewDateCategory
+      description: An enumerated set of values representing the chosen category for an Action Plan's review date.
+      type: string
+      enum:
+        - THREE_MONTHS
+        - SIX_MONTHS
+        - TWELVE_MONTHS
+        - NO_DATE
+        - SPECIFIC_DATE
     GoalStatus:
       title: GoalStatus
       description: Enum describing the various statuses of a Goal's lifecycle.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityTest.kt
@@ -13,7 +13,12 @@ class ActionPlanEntityTest {
     val prisonNumber = aValidPrisonNumber()
 
     // When
-    val actual = ActionPlanEntity.newActionPlanForPrisoner(reference = UUID.randomUUID(), prisonNumber = prisonNumber, reviewDate = null)
+    val actual = ActionPlanEntity.newActionPlanForPrisoner(
+      reference = UUID.randomUUID(),
+      prisonNumber = prisonNumber,
+      reviewDateCategory = ReviewDateCategory.NO_DATE,
+      reviewDate = null,
+    )
 
     // Then
     assertThat(actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
@@ -14,6 +14,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidGoalEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ReviewDateCategory as ReviewDateCategoryEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ReviewDateCategory as ReviewDateCategoryDomain
 
 @ExtendWith(MockitoExtension::class)
 class ActionPlanEntityMapperTest {
@@ -35,6 +37,7 @@ class ActionPlanEntityMapperTest {
     val expected = aValidActionPlanEntity(
       reference = actionPlan.reference,
       prisonNumber = prisonNumber,
+      reviewDateCategory = ReviewDateCategoryEntity.SPECIFIC_DATE,
       reviewDate = actionPlan.reviewDate,
       goals = mutableListOf(expectedGoalEntity),
     )
@@ -58,6 +61,7 @@ class ActionPlanEntityMapperTest {
     val expected = aValidActionPlan(
       reference = actionPlanEntity.reference!!,
       prisonNumber = prisonNumber,
+      reviewDateCategory = ReviewDateCategoryDomain.SPECIFIC_DATE,
       reviewDate = actionPlanEntity.reviewDate,
       goals = mutableListOf(goalDomain),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
@@ -16,7 +16,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidGoalResponse
-import java.util.*
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ReviewDateCategory as ReviewDateCategoryDomain
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory as ReviewDateCategoryModel
 
 @ExtendWith(MockitoExtension::class)
 internal class ActionPlanResourceMapperTest {
@@ -30,10 +31,12 @@ internal class ActionPlanResourceMapperTest {
   fun `should map from model to domain`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val request = aValidCreateActionPlanRequest()
+    val request = aValidCreateActionPlanRequest(reviewDateCategory = ReviewDateCategoryModel.NO_DATE, reviewDate = null)
     val expectedGoal = aValidGoal()
     val expectedActionPlan = aValidActionPlan(
       prisonNumber = prisonNumber,
+      reviewDateCategory = ReviewDateCategoryDomain.NO_DATE,
+      reviewDate = null,
       goals = listOf(expectedGoal),
     )
     given(goalMapper.fromModelToDomain(any<CreateGoalRequest>())).willReturn(expectedGoal)
@@ -54,6 +57,7 @@ internal class ActionPlanResourceMapperTest {
     val expectedActionPlan = aValidActionPlanResponse(
       reference = actionPlan.reference,
       prisonNumber = actionPlan.prisonNumber,
+      reviewDateCategory = ReviewDateCategoryModel.SPECIFIC_DATE,
       reviewDate = actionPlan.reviewDate,
       goals = mutableListOf(expectedGoal),
     )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityBuilder.kt
@@ -7,6 +7,7 @@ fun aValidActionPlanEntity(
   id: UUID? = UUID.randomUUID(),
   reference: UUID? = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
+  reviewDateCategory: ReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE,
   reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<GoalEntity> = listOf(aValidGoalEntity()),
 ): ActionPlanEntity =
@@ -14,6 +15,7 @@ fun aValidActionPlanEntity(
     id = id,
     reference = reference,
     prisonNumber = prisonNumber,
+    reviewDateCategory = reviewDateCategory,
     reviewDate = reviewDate,
     goals = goals.toMutableList(),
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlanBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlanBuilder.kt
@@ -6,12 +6,14 @@ import java.util.UUID
 fun aValidActionPlan(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
+  reviewDateCategory: ReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE,
   reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<Goal> = mutableListOf(aValidGoal()),
 ): ActionPlan =
   ActionPlan(
     reference = reference,
     prisonNumber = prisonNumber,
+    reviewDateCategory = reviewDateCategory,
     reviewDate = reviewDate,
     goals = goals,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseBuilder.kt
@@ -6,12 +6,14 @@ import java.util.UUID
 fun aValidActionPlanResponse(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
+  reviewDateCategory: ReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE,
   reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<GoalResponse> = listOf(aValidGoalResponse(), anotherValidGoalResponse()),
 ): ActionPlanResponse =
   ActionPlanResponse(
     reference = reference,
     prisonNumber = prisonNumber,
+    reviewDateCategory = reviewDateCategory,
     reviewDate = reviewDate,
     goals = goals,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateActionPlanRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateActionPlanRequestBuilder.kt
@@ -3,10 +3,12 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 import java.time.LocalDate
 
 fun aValidCreateActionPlanRequest(
+  reviewDateCategory: ReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE,
   reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<CreateGoalRequest> = listOf(aValidCreateGoalRequest()),
 ): CreateActionPlanRequest =
   CreateActionPlanRequest(
+    reviewDateCategory = reviewDateCategory,
     reviewDate = reviewDate,
     goals = goals,
   )


### PR DESCRIPTION
This PR adds a new enum `reviewDateCategory` to `ActionPlan`. This is to capture the possible options that the user can choose from in relation to setting the review "date", as shown here:

![image](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/assets/135589132/ebd262ed-2443-4290-803a-959e0f69ec1f)

This PR includes all the changes from the API to the DB.

Note that this PR will be merged into https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/pull/56, which in turn will be merged into https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/pull/55 for the overall _Create Action Plan_ endpoint. Because of this, I haven't bumped the version of the swagger spec and I'm able to use the same DB migration scripts, since they haven't been deployed yet.