### PR TITLE
RR-237 - Removing trying to get custom dimensions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
 import com.microsoft.applicationinsights.TelemetryClient
-import io.opentelemetry.api.baggage.Baggage
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.trackEvent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
@@ -21,7 +20,7 @@ class TelemetryService(
   fun trackGoalCreateEvent(goal: Goal) {
     telemetryClient.trackEvent(
       GOAL_CREATE_EVENT,
-      getExistingCustomDimensions().plus(createEventCustomDimensions(goal)),
+      createEventCustomDimensions(goal),
     )
   }
 
@@ -35,14 +34,5 @@ class TelemetryService(
         "stepCount" to steps.size.toString(),
         "reference" to reference.toString(),
       )
-    }
-
-  /**
-   * Returns a map of data representing any custom dimensions already set via the opentelemetry API.
-   */
-  private fun getExistingCustomDimensions(): Map<String, String> =
-    Baggage.current().asMap().mapValues {
-      val baggageEntry = it.value
-      baggageEntry.value
     }
 }


### PR DESCRIPTION
Getting the previously set custom dimensions to use in `trackEvent` method calls was not working , so for the time being it can wait. We'll look at it again another time if it proves to be an issue/requirement