### PR TITLE
RR-230 populate review date

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ReviewDateCategory
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
@@ -135,6 +136,8 @@ class CreateActionPlanTest : IntegrationTestBase() {
     val createStepRequest = aValidCreateStepRequest()
     val createGoalRequest = aValidCreateGoalRequest(steps = listOf(createStepRequest))
     val createActionPlanRequest = aValidCreateActionPlanRequest(goals = listOf(createGoalRequest))
+    val expectedReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE
+    val expectedReviewDate = createActionPlanRequest.reviewDate!!
     val dpsUsername = "auser_gen"
     val displayName = "Albert User"
 
@@ -158,6 +161,8 @@ class CreateActionPlanTest : IntegrationTestBase() {
     val actionPlan = actionPlanRepository.findByPrisonNumber(prisonNumber)
     assertThat(actionPlan)
       .isForPrisonNumber(prisonNumber)
+      .hasReviewDateCategory(expectedReviewDateCategory)
+      .hasReviewDate(expectedReviewDate)
       .hasNumberOfGoals(1)
       .wasCreatedBy(dpsUsername)
     val goal = actionPlan!!.goals!![0]

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -10,8 +10,11 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewA
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
@@ -78,7 +81,10 @@ class GetActionPlanTest : IntegrationTestBase() {
   fun `should get action plan for prisoner`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    createGoal(prisonNumber, aValidCreateGoalRequest())
+    val createActionPlanRequest = aValidCreateActionPlanRequest()
+    createActionPlan(prisonNumber, createActionPlanRequest)
+    val expectedReviewDateCategory = createActionPlanRequest.reviewDateCategory
+    val expectedReviewDate = createActionPlanRequest.reviewDate!!
 
     // When
     val response = webTestClient.get()
@@ -93,6 +99,8 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
+      .hasReviewDateCategory(expectedReviewDateCategory)
+      .hasReviewDate(expectedReviewDate)
       .goal(0) {
         it.wasCreatedBy("auser_gen")
           .hasCreatedByDisplayName("Albert User")
@@ -105,7 +113,12 @@ class GetActionPlanTest : IntegrationTestBase() {
   fun `should get action plan with multiple goals in order`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn German"))
+    val createActionPlanRequest = aValidCreateActionPlanRequest(
+      reviewDateCategory = ReviewDateCategory.SIX_MONTHS,
+      reviewDate = null,
+      goals = listOf(aValidCreateGoalRequest(title = "Learn German")),
+    )
+    createActionPlan(prisonNumber, createActionPlanRequest)
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn French"))
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn Spanish"))
 
@@ -122,6 +135,8 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
+      .hasReviewDateCategory(ReviewDateCategory.SIX_MONTHS)
+      .hasNoReviewDate()
       .goal(0) {
         it.hasTitle("Learn Spanish")
       }
@@ -132,6 +147,17 @@ class GetActionPlanTest : IntegrationTestBase() {
       .goal(2) {
         it.hasTitle("Learn German")
       }
+  }
+
+  private fun createActionPlan(prisonNumber: String, createActionPlanRequest: CreateActionPlanRequest) {
+    webTestClient.post()
+      .uri("$URI_TEMPLATE", prisonNumber)
+      .withBody(createActionPlanRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
   }
 
   private fun createGoal(prisonNumber: String, createGoalRequest: CreateGoalRequest) {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aVali
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
+import java.time.LocalDate
 
 class GetActionPlanTest : IntegrationTestBase() {
 
@@ -81,10 +82,9 @@ class GetActionPlanTest : IntegrationTestBase() {
   fun `should get action plan for prisoner`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val createActionPlanRequest = aValidCreateActionPlanRequest()
+    val createActionPlanRequest =
+      aValidCreateActionPlanRequest(reviewDateCategory = ReviewDateCategory.NO_DATE, reviewDate = null)
     createActionPlan(prisonNumber, createActionPlanRequest)
-    val expectedReviewDateCategory = createActionPlanRequest.reviewDateCategory
-    val expectedReviewDate = createActionPlanRequest.reviewDate!!
 
     // When
     val response = webTestClient.get()
@@ -99,8 +99,8 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
-      .hasReviewDateCategory(expectedReviewDateCategory)
-      .hasReviewDate(expectedReviewDate)
+      .hasReviewDateCategory(ReviewDateCategory.NO_DATE)
+      .hasNoReviewDate()
       .goal(0) {
         it.wasCreatedBy("auser_gen")
           .hasCreatedByDisplayName("Albert User")
@@ -121,6 +121,8 @@ class GetActionPlanTest : IntegrationTestBase() {
     createActionPlan(prisonNumber, createActionPlanRequest)
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn French"))
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn Spanish"))
+    val expectedReviewDateCategory = ReviewDateCategory.SIX_MONTHS
+    val expectedReviewDate = LocalDate.now().plusMonths(6)
 
     // When
     val response = webTestClient.get()
@@ -135,8 +137,8 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
-      .hasReviewDateCategory(ReviewDateCategory.SIX_MONTHS)
-      .hasNoReviewDate()
+      .hasReviewDateCategory(expectedReviewDateCategory)
+      .hasReviewDate(expectedReviewDate)
       .goal(0) {
         it.hasTitle("Learn Spanish")
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
@@ -5,16 +5,32 @@ import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.NO_DATE
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.SIX_MONTHS
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.SPECIFIC_DATE
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.THREE_MONTHS
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.TWELVE_MONTHS
+import java.time.LocalDate
 
 @Mapper(
   uses = [
     GoalResourceMapper::class,
   ],
 )
-interface ActionPlanResourceMapper {
+abstract class ActionPlanResourceMapper {
 
   @Mapping(target = "reference", expression = "java(UUID.randomUUID())")
-  fun fromModelToDomain(prisonNumber: String, request: CreateActionPlanRequest): ActionPlan
+  @Mapping(target = "reviewDate", expression = "java(populateReviewDate(request))")
+  abstract fun fromModelToDomain(prisonNumber: String, request: CreateActionPlanRequest): ActionPlan
 
-  fun fromDomainToModel(actionPlan: ActionPlan): ActionPlanResponse
+  abstract fun fromDomainToModel(actionPlan: ActionPlan): ActionPlanResponse
+
+  fun populateReviewDate(request: CreateActionPlanRequest): LocalDate? =
+    when (request.reviewDateCategory) {
+      THREE_MONTHS -> LocalDate.now().plusMonths(3)
+      SIX_MONTHS -> LocalDate.now().plusMonths(6)
+      TWELVE_MONTHS -> LocalDate.now().plusMonths(12)
+      NO_DATE -> null
+      SPECIFIC_DATE -> request.reviewDate
+    }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityAssert.kt
@@ -2,7 +2,8 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.en
 
 import org.assertj.core.api.AbstractObjectAssert
 import java.time.Instant
-import java.util.UUID
+import java.time.LocalDate
+import java.util.*
 import java.util.function.Consumer
 
 fun assertThat(actual: ActionPlanEntity?) = ActionPlanEntityAssert(actual)
@@ -88,6 +89,26 @@ class ActionPlanEntityAssert(actual: ActionPlanEntity?) :
     with(actual!!) {
       if (prisonNumber != expected) {
         failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDateCategory(expected: ReviewDateCategory): ActionPlanEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDateCategory != expected) {
+        failWithMessage("Expected reviewDateCategory to be $expected, but was $reviewDateCategory")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDate(expected: LocalDate): ActionPlanEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDate != expected) {
+        failWithMessage("Expected reviewDate to be $expected, but was $reviewDate")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 
 import org.assertj.core.api.AbstractObjectAssert
+import java.time.LocalDate
 import java.util.function.Consumer
 
 fun assertThat(actual: ActionPlanResponse?) = ActionPlanResponseAssert(actual)
@@ -16,6 +17,36 @@ class ActionPlanResponseAssert(actual: ActionPlanResponse?) :
     with(actual!!) {
       if (prisonNumber != expected) {
         failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDateCategory(expected: ReviewDateCategory): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDateCategory != expected) {
+        failWithMessage("Expected reviewDateCategory to be $expected, but was $reviewDateCategory")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDate(expected: LocalDate): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDate != expected) {
+        failWithMessage("Expected reviewDate to be $expected, but was $reviewDate")
+      }
+    }
+    return this
+  }
+
+  fun hasNoReviewDate(): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDate != null) {
+        failWithMessage("Expected reviewDate to be null, but was $reviewDate")
       }
     }
     return this


### PR DESCRIPTION
This PR populates an Action Plan's `reviewDate` based on the provided `reviewDateCategory`. This feels like a better approach than having no `reviewDate` at all - e.g. when the user selects "3 months" on the UI.

After further discussion with the business, the radio buttons are a quick way for the user to say in 3/6/12 months time, rather than having to manually enter a date each time.

<img width="588" alt="image" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/assets/135589132/5d2c1630-8eb8-4bf2-b29a-65f4df6f5ffc">

This PR also adds some additional checks and changes to the create/retrieve Action Plan integration tests, which I realised were missing.