### PR TITLE
RR-230 - Remove review date category

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ReviewDateCategory
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
@@ -125,7 +124,7 @@ class CreateActionPlanTest : IntegrationTestBase() {
     assertThat(actual)
       .hasStatus(HttpStatus.BAD_REQUEST.value())
       .hasUserMessageContaining("JSON parse error")
-      .hasUserMessageContaining("value failed for JSON property reviewDateCategory due to missing (therefore NULL) value for creator parameter reviewDateCategory")
+      .hasUserMessageContaining("value failed for JSON property goals due to missing (therefore NULL) value for creator parameter goals")
   }
 
   @Test
@@ -136,7 +135,6 @@ class CreateActionPlanTest : IntegrationTestBase() {
     val createStepRequest = aValidCreateStepRequest()
     val createGoalRequest = aValidCreateGoalRequest(steps = listOf(createStepRequest))
     val createActionPlanRequest = aValidCreateActionPlanRequest(goals = listOf(createGoalRequest))
-    val expectedReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE
     val expectedReviewDate = createActionPlanRequest.reviewDate!!
     val dpsUsername = "auser_gen"
     val displayName = "Albert User"
@@ -161,7 +159,6 @@ class CreateActionPlanTest : IntegrationTestBase() {
     val actionPlan = actionPlanRepository.findByPrisonNumber(prisonNumber)
     assertThat(actionPlan)
       .isForPrisonNumber(prisonNumber)
-      .hasReviewDateCategory(expectedReviewDateCategory)
       .hasReviewDate(expectedReviewDate)
       .hasNumberOfGoals(1)
       .wasCreatedBy(dpsUsername)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ReviewDateCategory
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
@@ -135,6 +136,8 @@ class CreateActionPlanTest : IntegrationTestBase() {
     val createStepRequest = aValidCreateStepRequest()
     val createGoalRequest = aValidCreateGoalRequest(steps = listOf(createStepRequest))
     val createActionPlanRequest = aValidCreateActionPlanRequest(goals = listOf(createGoalRequest))
+    val expectedReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE
+    val expectedReviewDate = createActionPlanRequest.reviewDate!!
     val dpsUsername = "auser_gen"
     val displayName = "Albert User"
 
@@ -158,6 +161,8 @@ class CreateActionPlanTest : IntegrationTestBase() {
     val actionPlan = actionPlanRepository.findByPrisonNumber(prisonNumber)
     assertThat(actionPlan)
       .isForPrisonNumber(prisonNumber)
+      .hasReviewDateCategory(expectedReviewDateCategory)
+      .hasReviewDate(expectedReviewDate)
       .hasNumberOfGoals(1)
       .wasCreatedBy(dpsUsername)
     val goal = actionPlan!!.goals!![0]

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -10,8 +10,11 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewA
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
@@ -78,7 +81,10 @@ class GetActionPlanTest : IntegrationTestBase() {
   fun `should get action plan for prisoner`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    createGoal(prisonNumber, aValidCreateGoalRequest())
+    val createActionPlanRequest = aValidCreateActionPlanRequest()
+    createActionPlan(prisonNumber, createActionPlanRequest)
+    val expectedReviewDateCategory = createActionPlanRequest.reviewDateCategory
+    val expectedReviewDate = createActionPlanRequest.reviewDate!!
 
     // When
     val response = webTestClient.get()
@@ -93,6 +99,8 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
+      .hasReviewDateCategory(expectedReviewDateCategory)
+      .hasReviewDate(expectedReviewDate)
       .goal(0) {
         it.wasCreatedBy("auser_gen")
           .hasCreatedByDisplayName("Albert User")
@@ -105,7 +113,12 @@ class GetActionPlanTest : IntegrationTestBase() {
   fun `should get action plan with multiple goals in order`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn German"))
+    val createActionPlanRequest = aValidCreateActionPlanRequest(
+      reviewDateCategory = ReviewDateCategory.SIX_MONTHS,
+      reviewDate = null,
+      goals = listOf(aValidCreateGoalRequest(title = "Learn German")),
+    )
+    createActionPlan(prisonNumber, createActionPlanRequest)
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn French"))
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn Spanish"))
 
@@ -122,6 +135,8 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
+      .hasReviewDateCategory(ReviewDateCategory.SIX_MONTHS)
+      .hasNoReviewDate()
       .goal(0) {
         it.hasTitle("Learn Spanish")
       }
@@ -132,6 +147,17 @@ class GetActionPlanTest : IntegrationTestBase() {
       .goal(2) {
         it.hasTitle("Learn German")
       }
+  }
+
+  private fun createActionPlan(prisonNumber: String, createActionPlanRequest: CreateActionPlanRequest) {
+    webTestClient.post()
+      .uri("$URI_TEMPLATE", prisonNumber)
+      .withBody(createActionPlanRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
   }
 
   private fun createGoal(prisonNumber: String, createGoalRequest: CreateGoalRequest) {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aVali
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
+import java.time.LocalDate
 
 class GetActionPlanTest : IntegrationTestBase() {
 
@@ -81,10 +82,9 @@ class GetActionPlanTest : IntegrationTestBase() {
   fun `should get action plan for prisoner`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val createActionPlanRequest = aValidCreateActionPlanRequest()
+    val createActionPlanRequest =
+      aValidCreateActionPlanRequest(reviewDateCategory = ReviewDateCategory.NO_DATE, reviewDate = null)
     createActionPlan(prisonNumber, createActionPlanRequest)
-    val expectedReviewDateCategory = createActionPlanRequest.reviewDateCategory
-    val expectedReviewDate = createActionPlanRequest.reviewDate!!
 
     // When
     val response = webTestClient.get()
@@ -99,8 +99,8 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
-      .hasReviewDateCategory(expectedReviewDateCategory)
-      .hasReviewDate(expectedReviewDate)
+      .hasReviewDateCategory(ReviewDateCategory.NO_DATE)
+      .hasNoReviewDate()
       .goal(0) {
         it.wasCreatedBy("auser_gen")
           .hasCreatedByDisplayName("Albert User")
@@ -121,6 +121,8 @@ class GetActionPlanTest : IntegrationTestBase() {
     createActionPlan(prisonNumber, createActionPlanRequest)
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn French"))
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn Spanish"))
+    val expectedReviewDateCategory = ReviewDateCategory.SIX_MONTHS
+    val expectedReviewDate = LocalDate.now().plusMonths(6)
 
     // When
     val response = webTestClient.get()
@@ -135,8 +137,8 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
-      .hasReviewDateCategory(ReviewDateCategory.SIX_MONTHS)
-      .hasNoReviewDate()
+      .hasReviewDateCategory(expectedReviewDateCategory)
+      .hasReviewDate(expectedReviewDate)
       .goal(0) {
         it.hasTitle("Learn Spanish")
       }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Actio
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
@@ -82,8 +81,7 @@ class GetActionPlanTest : IntegrationTestBase() {
   fun `should get action plan for prisoner`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val createActionPlanRequest =
-      aValidCreateActionPlanRequest(reviewDateCategory = ReviewDateCategory.NO_DATE, reviewDate = null)
+    val createActionPlanRequest = aValidCreateActionPlanRequest(reviewDate = null)
     createActionPlan(prisonNumber, createActionPlanRequest)
 
     // When
@@ -99,7 +97,6 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
-      .hasReviewDateCategory(ReviewDateCategory.NO_DATE)
       .hasNoReviewDate()
       .goal(0) {
         it.wasCreatedBy("auser_gen")
@@ -114,15 +111,13 @@ class GetActionPlanTest : IntegrationTestBase() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     val createActionPlanRequest = aValidCreateActionPlanRequest(
-      reviewDateCategory = ReviewDateCategory.SIX_MONTHS,
-      reviewDate = null,
+      reviewDate = LocalDate.now(),
       goals = listOf(aValidCreateGoalRequest(title = "Learn German")),
     )
     createActionPlan(prisonNumber, createActionPlanRequest)
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn French"))
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn Spanish"))
-    val expectedReviewDateCategory = ReviewDateCategory.SIX_MONTHS
-    val expectedReviewDate = LocalDate.now().plusMonths(6)
+    val expectedReviewDate = LocalDate.now()
 
     // When
     val response = webTestClient.get()
@@ -137,7 +132,6 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
-      .hasReviewDateCategory(expectedReviewDateCategory)
       .hasReviewDate(expectedReviewDate)
       .goal(0) {
         it.hasTitle("Learn Spanish")

--- a/src/integrationTest/resources/db/h2/V2023.08.15.0001__add_action_plan_fields.sql
+++ b/src/integrationTest/resources/db/h2/V2023.08.15.0001__add_action_plan_fields.sql
@@ -1,8 +1,6 @@
 ALTER TABLE action_plan ADD COLUMN reference UUID;
-ALTER TABLE action_plan ADD COLUMN review_date_category VARCHAR(50);
 ALTER TABLE action_plan ADD COLUMN review_date DATE;
 
-UPDATE action_plan SET reference = random_uuid(), review_date_category = 'NO_DATE' WHERE reference IS NULL;
+UPDATE action_plan SET reference = random_uuid() WHERE reference IS NULL;
 
 ALTER TABLE action_plan ALTER COLUMN reference SET NOT NULL;
-ALTER TABLE action_plan ALTER COLUMN review_date_category SET NOT NULL;

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanEntity.Companion.newActionPlanForPrisoner
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.GoalEntity
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ReviewDateCategory
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.GoalEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
@@ -29,7 +28,6 @@ class JpaGoalPersistenceAdapter(
       actionPlanEntity = newActionPlanForPrisoner(
         reference = UUID.randomUUID(),
         prisonNumber = prisonNumber,
-        reviewDateCategory = ReviewDateCategory.NO_DATE,
         reviewDate = null,
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntity.kt
@@ -4,8 +4,6 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
@@ -43,11 +41,6 @@ class ActionPlanEntity(
   var prisonNumber: String? = null,
 
   @Column
-  @Enumerated(value = EnumType.STRING)
-  @field:NotNull
-  var reviewDateCategory: ReviewDateCategory? = null,
-
-  @Column
   var reviewDate: LocalDate? = null,
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
@@ -78,11 +71,10 @@ class ActionPlanEntity(
     /**
      * Returns new un-persisted [ActionPlanEntity] for the specified prisoner with an empty collection of [GoalEntity]s
      */
-    fun newActionPlanForPrisoner(reference: UUID, prisonNumber: String, reviewDateCategory: ReviewDateCategory, reviewDate: LocalDate?): ActionPlanEntity =
+    fun newActionPlanForPrisoner(reference: UUID, prisonNumber: String, reviewDate: LocalDate?): ActionPlanEntity =
       ActionPlanEntity(
         reference = reference,
         prisonNumber = prisonNumber,
-        reviewDateCategory = reviewDateCategory,
         reviewDate = reviewDate,
         goals = mutableListOf(),
       )
@@ -116,12 +108,4 @@ class ActionPlanEntity(
   override fun toString(): String {
     return this::class.simpleName + "(id = $id, prisonNumber = $prisonNumber)"
   }
-}
-
-enum class ReviewDateCategory {
-  THREE_MONTHS,
-  SIX_MONTHS,
-  TWELVE_MONTHS,
-  NO_DATE,
-  SPECIFIC_DATE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
@@ -5,32 +5,16 @@ import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.NO_DATE
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.SIX_MONTHS
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.SPECIFIC_DATE
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.THREE_MONTHS
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.TWELVE_MONTHS
-import java.time.LocalDate
 
 @Mapper(
   uses = [
     GoalResourceMapper::class,
   ],
 )
-abstract class ActionPlanResourceMapper {
+interface ActionPlanResourceMapper {
 
   @Mapping(target = "reference", expression = "java(UUID.randomUUID())")
-  @Mapping(target = "reviewDate", expression = "java(populateReviewDate(request))")
-  abstract fun fromModelToDomain(prisonNumber: String, request: CreateActionPlanRequest): ActionPlan
+  fun fromModelToDomain(prisonNumber: String, request: CreateActionPlanRequest): ActionPlan
 
-  abstract fun fromDomainToModel(actionPlan: ActionPlan): ActionPlanResponse
-
-  fun populateReviewDate(request: CreateActionPlanRequest): LocalDate? =
-    when (request.reviewDateCategory) {
-      THREE_MONTHS -> LocalDate.now().plusMonths(3)
-      SIX_MONTHS -> LocalDate.now().plusMonths(6)
-      TWELVE_MONTHS -> LocalDate.now().plusMonths(12)
-      NO_DATE -> null
-      SPECIFIC_DATE -> request.reviewDate
-    }
+  fun fromDomainToModel(actionPlan: ActionPlan): ActionPlanResponse
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
@@ -5,16 +5,32 @@ import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.NO_DATE
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.SIX_MONTHS
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.SPECIFIC_DATE
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.THREE_MONTHS
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory.TWELVE_MONTHS
+import java.time.LocalDate
 
 @Mapper(
   uses = [
     GoalResourceMapper::class,
   ],
 )
-interface ActionPlanResourceMapper {
+abstract class ActionPlanResourceMapper {
 
   @Mapping(target = "reference", expression = "java(UUID.randomUUID())")
-  fun fromModelToDomain(prisonNumber: String, request: CreateActionPlanRequest): ActionPlan
+  @Mapping(target = "reviewDate", expression = "java(populateReviewDate(request))")
+  abstract fun fromModelToDomain(prisonNumber: String, request: CreateActionPlanRequest): ActionPlan
 
-  fun fromDomainToModel(actionPlan: ActionPlan): ActionPlanResponse
+  abstract fun fromDomainToModel(actionPlan: ActionPlan): ActionPlanResponse
+
+  fun populateReviewDate(request: CreateActionPlanRequest): LocalDate? =
+    when (request.reviewDateCategory) {
+      THREE_MONTHS -> LocalDate.now().plusMonths(3)
+      SIX_MONTHS -> LocalDate.now().plusMonths(6)
+      TWELVE_MONTHS -> LocalDate.now().plusMonths(12)
+      NO_DATE -> null
+      SPECIFIC_DATE -> request.reviewDate
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlan.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlan.kt
@@ -9,7 +9,6 @@ import java.util.UUID
 class ActionPlan(
   val reference: UUID,
   val prisonNumber: String,
-  val reviewDateCategory: ReviewDateCategory,
   val reviewDate: LocalDate?,
   goals: List<Goal> = emptyList(),
 ) {
@@ -35,14 +34,6 @@ class ActionPlan(
     goals.add(goal)
 
   override fun toString(): String {
-    return "ActionPlan(reference=$reference, prisonNumber='$prisonNumber', reviewDateCategory='$reviewDateCategory', reviewDate='$reviewDate', goals=$goals)"
+    return "ActionPlan(reference=$reference, prisonNumber='$prisonNumber', reviewDate='$reviewDate', goals=$goals)"
   }
-}
-
-enum class ReviewDateCategory {
-  THREE_MONTHS,
-  SIX_MONTHS,
-  TWELVE_MONTHS,
-  NO_DATE,
-  SPECIFIC_DATE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 import mu.KotlinLogging
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanAlreadyExistsException
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ReviewDateCategory
 import java.util.UUID
 
 private val log = KotlinLogging.logger {}
@@ -47,7 +46,6 @@ class ActionPlanService(
       ?: ActionPlan(
         reference = UUID.randomUUID(),
         prisonNumber = prisonNumber,
-        reviewDateCategory = ReviewDateCategory.NO_DATE,
         reviewDate = null,
         goals = emptyList(),
       )

--- a/src/main/resources/db/postgres/V2023.08.15.0001__add_action_plan_fields.sql
+++ b/src/main/resources/db/postgres/V2023.08.15.0001__add_action_plan_fields.sql
@@ -1,10 +1,8 @@
 ALTER TABLE action_plan ADD COLUMN reference UUID;
-ALTER TABLE action_plan ADD COLUMN review_date_category VARCHAR(50);
 ALTER TABLE action_plan ADD COLUMN review_date DATE;
 
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-UPDATE action_plan SET reference = uuid_generate_v4(), review_date_category = 'NO_DATE' WHERE reference IS NULL;
+UPDATE action_plan SET reference = uuid_generate_v4() WHERE reference IS NULL;
 
 ALTER TABLE action_plan ALTER COLUMN reference SET NOT NULL;
-ALTER TABLE action_plan ALTER COLUMN review_date_category SET NOT NULL;

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -159,8 +159,6 @@ components:
           type: string
           description: The ID of the prisoner
           example: 'A1234BC'
-        reviewDateCategory:
-          $ref: '#/components/schemas/ReviewDateCategory'
         reviewDate:
           type: string
           format: date
@@ -174,7 +172,6 @@ components:
       required:
         - reference
         - prisonNumber
-        - reviewDateCategory
         - goals
     GoalResponse:
       title: GoalResponse
@@ -278,8 +275,6 @@ components:
       type: object
       description: A request to create an  Action Plan with at least one or more Goals that a Prisoner aims to complete.
       properties:
-        reviewDateCategory:
-          $ref: '#/components/schemas/ReviewDateCategory'
         reviewDate:
           type: string
           format: date
@@ -292,7 +287,6 @@ components:
           items:
             $ref: '#/components/schemas/CreateGoalRequest'
       required:
-        - reviewDateCategory
         - goals
 
     CreateGoalRequest:
@@ -400,16 +394,6 @@ components:
       required:
         - status
 
-    ReviewDateCategory:
-      title: ReviewDateCategory
-      description: An enumerated set of values representing the chosen category for an Action Plan's review date.
-      type: string
-      enum:
-        - THREE_MONTHS
-        - SIX_MONTHS
-        - TWELVE_MONTHS
-        - NO_DATE
-        - SPECIFIC_DATE
     GoalStatus:
       title: GoalStatus
       description: Enum describing the various statuses of a Goal's lifecycle.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityTest.kt
@@ -16,7 +16,6 @@ class ActionPlanEntityTest {
     val actual = ActionPlanEntity.newActionPlanForPrisoner(
       reference = UUID.randomUUID(),
       prisonNumber = prisonNumber,
-      reviewDateCategory = ReviewDateCategory.NO_DATE,
       reviewDate = null,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
@@ -14,8 +14,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidGoalEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ReviewDateCategory as ReviewDateCategoryEntity
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ReviewDateCategory as ReviewDateCategoryDomain
 
 @ExtendWith(MockitoExtension::class)
 class ActionPlanEntityMapperTest {
@@ -37,7 +35,6 @@ class ActionPlanEntityMapperTest {
     val expected = aValidActionPlanEntity(
       reference = actionPlan.reference,
       prisonNumber = prisonNumber,
-      reviewDateCategory = ReviewDateCategoryEntity.SPECIFIC_DATE,
       reviewDate = actionPlan.reviewDate,
       goals = mutableListOf(expectedGoalEntity),
     )
@@ -61,7 +58,6 @@ class ActionPlanEntityMapperTest {
     val expected = aValidActionPlan(
       reference = actionPlanEntity.reference!!,
       prisonNumber = prisonNumber,
-      reviewDateCategory = ReviewDateCategoryDomain.SPECIFIC_DATE,
       reviewDate = actionPlanEntity.reviewDate,
       goals = mutableListOf(goalDomain),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
@@ -3,9 +3,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
@@ -19,10 +16,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidGoalResponse
-import java.time.LocalDate
-import java.util.stream.Stream
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ReviewDateCategory as ReviewDateCategoryDomain
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewDateCategory as ReviewDateCategoryModel
 
 @ExtendWith(MockitoExtension::class)
 internal class ActionPlanResourceMapperTest {
@@ -32,22 +25,15 @@ internal class ActionPlanResourceMapperTest {
   @Mock
   private lateinit var goalMapper: GoalResourceMapper
 
-  @ParameterizedTest
-  @MethodSource("reviewDateCriteria")
-  fun `should map from model to domain`(
-    sourceReviewDateCategory: ReviewDateCategoryModel,
-    sourceReviewDate: LocalDate?,
-    expectedReviewDateCategory: ReviewDateCategoryDomain,
-    expectedReviewDate: LocalDate?,
-  ) {
+  @Test
+  fun `should map from model to domain`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val request = aValidCreateActionPlanRequest(reviewDateCategory = sourceReviewDateCategory, reviewDate = sourceReviewDate)
+    val request = aValidCreateActionPlanRequest()
     val expectedGoal = aValidGoal()
     val expectedActionPlan = aValidActionPlan(
       prisonNumber = prisonNumber,
-      reviewDateCategory = expectedReviewDateCategory,
-      reviewDate = expectedReviewDate,
+      reviewDate = request.reviewDate,
       goals = listOf(expectedGoal),
     )
     given(goalMapper.fromModelToDomain(any<CreateGoalRequest>())).willReturn(expectedGoal)
@@ -68,7 +54,6 @@ internal class ActionPlanResourceMapperTest {
     val expectedActionPlan = aValidActionPlanResponse(
       reference = actionPlan.reference,
       prisonNumber = actionPlan.prisonNumber,
-      reviewDateCategory = ReviewDateCategoryModel.SPECIFIC_DATE,
       reviewDate = actionPlan.reviewDate,
       goals = mutableListOf(expectedGoal),
     )
@@ -80,19 +65,5 @@ internal class ActionPlanResourceMapperTest {
     // Then
     assertThat(actual).usingRecursiveComparison().isEqualTo(expectedActionPlan)
     verify(goalMapper).fromDomainToModel(actionPlan.goals[0])
-  }
-
-  companion object {
-    @JvmStatic
-    private fun reviewDateCriteria(): Stream<Arguments> {
-      val now = LocalDate.now()
-      return Stream.of(
-        Arguments.of(ReviewDateCategoryModel.THREE_MONTHS, null, ReviewDateCategoryDomain.THREE_MONTHS, now.plusMonths(3)),
-        Arguments.of(ReviewDateCategoryModel.SIX_MONTHS, null, ReviewDateCategoryDomain.SIX_MONTHS, now.plusMonths(6)),
-        Arguments.of(ReviewDateCategoryModel.TWELVE_MONTHS, null, ReviewDateCategoryDomain.TWELVE_MONTHS, now.plusMonths(12)),
-        Arguments.of(ReviewDateCategoryModel.NO_DATE, null, ReviewDateCategoryDomain.NO_DATE, null),
-        Arguments.of(ReviewDateCategoryModel.SPECIFIC_DATE, now.plusMonths(3), ReviewDateCategoryDomain.SPECIFIC_DATE, now.plusMonths(3)),
-      )
-    }
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityAssert.kt
@@ -2,7 +2,8 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.en
 
 import org.assertj.core.api.AbstractObjectAssert
 import java.time.Instant
-import java.util.UUID
+import java.time.LocalDate
+import java.util.*
 import java.util.function.Consumer
 
 fun assertThat(actual: ActionPlanEntity?) = ActionPlanEntityAssert(actual)
@@ -88,6 +89,26 @@ class ActionPlanEntityAssert(actual: ActionPlanEntity?) :
     with(actual!!) {
       if (prisonNumber != expected) {
         failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDateCategory(expected: ReviewDateCategory): ActionPlanEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDateCategory != expected) {
+        failWithMessage("Expected reviewDateCategory to be $expected, but was $reviewDateCategory")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDate(expected: LocalDate): ActionPlanEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDate != expected) {
+        failWithMessage("Expected reviewDate to be $expected, but was $reviewDate")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityAssert.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.en
 import org.assertj.core.api.AbstractObjectAssert
 import java.time.Instant
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 import java.util.function.Consumer
 
 fun assertThat(actual: ActionPlanEntity?) = ActionPlanEntityAssert(actual)
@@ -89,16 +89,6 @@ class ActionPlanEntityAssert(actual: ActionPlanEntity?) :
     with(actual!!) {
       if (prisonNumber != expected) {
         failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
-      }
-    }
-    return this
-  }
-
-  fun hasReviewDateCategory(expected: ReviewDateCategory): ActionPlanEntityAssert {
-    isNotNull
-    with(actual!!) {
-      if (reviewDateCategory != expected) {
-        failWithMessage("Expected reviewDateCategory to be $expected, but was $reviewDateCategory")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityBuilder.kt
@@ -7,7 +7,6 @@ fun aValidActionPlanEntity(
   id: UUID? = UUID.randomUUID(),
   reference: UUID? = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  reviewDateCategory: ReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE,
   reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<GoalEntity> = listOf(aValidGoalEntity()),
 ): ActionPlanEntity =
@@ -15,7 +14,6 @@ fun aValidActionPlanEntity(
     id = id,
     reference = reference,
     prisonNumber = prisonNumber,
-    reviewDateCategory = reviewDateCategory,
     reviewDate = reviewDate,
     goals = goals.toMutableList(),
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlanBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlanBuilder.kt
@@ -6,14 +6,12 @@ import java.util.UUID
 fun aValidActionPlan(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  reviewDateCategory: ReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE,
   reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<Goal> = mutableListOf(aValidGoal()),
 ): ActionPlan =
   ActionPlan(
     reference = reference,
     prisonNumber = prisonNumber,
-    reviewDateCategory = reviewDateCategory,
     reviewDate = reviewDate,
     goals = goals,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 
 import org.assertj.core.api.AbstractObjectAssert
+import java.time.LocalDate
 import java.util.function.Consumer
 
 fun assertThat(actual: ActionPlanResponse?) = ActionPlanResponseAssert(actual)
@@ -16,6 +17,36 @@ class ActionPlanResponseAssert(actual: ActionPlanResponse?) :
     with(actual!!) {
       if (prisonNumber != expected) {
         failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDateCategory(expected: ReviewDateCategory): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDateCategory != expected) {
+        failWithMessage("Expected reviewDateCategory to be $expected, but was $reviewDateCategory")
+      }
+    }
+    return this
+  }
+
+  fun hasReviewDate(expected: LocalDate): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDate != expected) {
+        failWithMessage("Expected reviewDate to be $expected, but was $reviewDate")
+      }
+    }
+    return this
+  }
+
+  fun hasNoReviewDate(): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewDate != null) {
+        failWithMessage("Expected reviewDate to be null, but was $reviewDate")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
@@ -22,16 +22,6 @@ class ActionPlanResponseAssert(actual: ActionPlanResponse?) :
     return this
   }
 
-  fun hasReviewDateCategory(expected: ReviewDateCategory): ActionPlanResponseAssert {
-    isNotNull
-    with(actual!!) {
-      if (reviewDateCategory != expected) {
-        failWithMessage("Expected reviewDateCategory to be $expected, but was $reviewDateCategory")
-      }
-    }
-    return this
-  }
-
   fun hasReviewDate(expected: LocalDate): ActionPlanResponseAssert {
     isNotNull
     with(actual!!) {

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseBuilder.kt
@@ -6,14 +6,12 @@ import java.util.UUID
 fun aValidActionPlanResponse(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  reviewDateCategory: ReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE,
   reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<GoalResponse> = listOf(aValidGoalResponse(), anotherValidGoalResponse()),
 ): ActionPlanResponse =
   ActionPlanResponse(
     reference = reference,
     prisonNumber = prisonNumber,
-    reviewDateCategory = reviewDateCategory,
     reviewDate = reviewDate,
     goals = goals,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateActionPlanRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateActionPlanRequestBuilder.kt
@@ -3,12 +3,10 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
 import java.time.LocalDate
 
 fun aValidCreateActionPlanRequest(
-  reviewDateCategory: ReviewDateCategory = ReviewDateCategory.SPECIFIC_DATE,
   reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<CreateGoalRequest> = listOf(aValidCreateGoalRequest()),
 ): CreateActionPlanRequest =
   CreateActionPlanRequest(
-    reviewDateCategory = reviewDateCategory,
     reviewDate = reviewDate,
     goals = goals,
   )


### PR DESCRIPTION
I've decided to remove `reviewDateCategory` as I think we're in danger of making this more complicated than it needs to be! As things stand, I reckon it will be unlikely we'll need to redisplay the previously chosen option (e.g. "3 months") when editing an Action Plan (and if we do then we can always add it back into the API, but let's not try and second guess that now).

My understanding is that the radio buttons to choose 3/6/12 months are just a convenient to set the `reviewDate` quickly, so the user doesn't have to manually type it in each time. In either case, we're still setting the `reviewDate` and I don't think we will care what the user previously choose when we come to edit it, perhaps months later. We might choose to default one of the radio buttons, but that's different to rendering the previously chosen value. This is fundamentally different to a Step's `targetDateRange`, which needs to be redisplayed each time.