### PR TITLE
POC to show how we might capture the CIAG's current prison (activeCaseLoadId)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ ext["mapstruct.version"] = "1.5.5.Final"
 ext["postgresql.version"] = "42.6.0"
 ext["kotlin.logging.version"] = "3.0.5"
 ext["springdoc.openapi.version"] = "2.1.0"
+ext["wiremock.version"] = "3.0.0-beta-10"
 
 allOpen {
   annotations(
@@ -67,6 +68,7 @@ dependencies {
 
   // Integration test dependencies
   integrationTestImplementation("com.h2database:h2")
+  integrationTestImplementation("com.github.tomakehurst:wiremock:${property("wiremock.version")}")
   integrationTestImplementation(testFixtures(project("domain:goal")))
   integrationTestImplementation(testFixtures(project("domain:timeline")))
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.WiremockService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import java.security.KeyPair
 
@@ -23,8 +24,19 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var keyPair: KeyPair
 
+  @Autowired
+  lateinit var wireMockService: WiremockService
+
   @BeforeEach
   fun clearDatabase() {
     actionPlanRepository.deleteAll() // Will also remove all Goals and Steps due to cascade
+  }
+
+  @BeforeEach
+  fun resetWireMock() {
+    with(wireMockService) {
+      resetAllStubsAndMappings()
+      stubHmppsAuthUserMe()
+    }
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/WiremockConfiguration.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/WiremockConfiguration.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import com.github.tomakehurst.wiremock.http.Request
+import com.github.tomakehurst.wiremock.http.Response
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.util.TestPropertyValues
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+private val logger = KotlinLogging.logger {}
+
+@Configuration
+class WiremockConfiguration {
+
+  @Bean
+  fun wireMockServer(
+    applicationContext: ConfigurableApplicationContext,
+    @Value("\${logWiremockRequests:false}") logWiremockRequests: Boolean,
+  ): WireMockServer =
+    WireMockServer(
+      options()
+        .dynamicPort(),
+    ).apply {
+      if (logWiremockRequests) {
+        addMockServiceRequestListener { request: Request, _: Response ->
+          val formattedHeaders = request.headers.all().joinToString("\n") {
+            "${it.key()}: ${it.values().joinToString(", ")}"
+          }
+          val logMessage = StringBuilder()
+            .appendLine("Request sent to wiremock:")
+            .appendLine("${request.method} ${request.absoluteUrl}")
+            .appendLine(formattedHeaders)
+            .appendLine()
+            .appendLine(request.bodyAsString)
+          logger.info { logMessage }
+        }
+      }
+      start()
+      TestPropertyValues.of(
+        "api.hmpps-auth.url=http://localhost:${this.port()}/auth",
+      ).applyTo(applicationContext)
+    }
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/WiremockService.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/WiremockService.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
+import com.github.tomakehurst.wiremock.client.WireMock
+import org.springframework.stereotype.Service
+
+@Service
+class WiremockService(private val wireMockServer: WireMockServer) {
+
+  fun resetAllStubsAndMappings() {
+    wireMockServer.resetAll()
+  }
+
+  fun stubHmppsAuthUserMe(
+    username: String = "auser_gen",
+    displayName: String = "Albert User",
+    activeCaseLoadId: String = "BXI",
+  ) {
+    wireMockServer.stubFor(
+      WireMock.get(WireMock.urlPathMatching("/auth/api/user/me"))
+        .willReturn(
+          ResponseDefinitionBuilder.responseDefinition()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+                {
+                    "username": "$username",
+                    "active": true,
+                    "name": "$displayName",
+                    "authSource": "nomis",
+                    "staffId": 486572,
+                    "activeCaseLoadId": "$activeCaseLoadId",
+                    "userId": "486572",
+                    "uuid": "9d125413-9222-4bc7-ad08-24c26d64bb90"
+                }
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+}

--- a/src/integrationTest/resources/application-integration-test.yml
+++ b/src/integrationTest/resources/application-integration-test.yml
@@ -24,3 +24,7 @@ spring:
       resourceserver:
         jwt:
           public-key-location: classpath:local-public-key.pub
+
+api:
+  hmpps-auth:
+    url: http://replaced-by-wireMockServer-bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/HmppsAuthClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/HmppsAuthClient.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client
+
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.bearerToken
+
+/**
+ * Client class for interacting with `hmpps-auth`s REST API
+ */
+@Component
+class HmppsAuthClient(private val hmppsAuthWebClient: WebClient) {
+
+  /**
+   * Calls the `/user/me` endpoint with the given user token, and returns the user's active caseload ID from the response.
+   */
+  fun getUserActiveCaseLoadId(userToken: String): String? {
+    val userProfile = hmppsAuthWebClient
+      .get()
+      .uri("/api/user/me")
+      .bearerToken(userToken)
+      .retrieve()
+      .bodyToMono(Map::class.java)
+      .block()
+
+    return userProfile?.get("activeCaseLoadId")?.toString()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/ResourceServerConfiguration.kt
@@ -15,7 +15,7 @@ import org.springframework.security.web.SecurityFilterChain
 class ResourceServerConfiguration {
 
   @Bean
-  fun filterChain(http: HttpSecurity): SecurityFilterChain {
+  fun filterChain(http: HttpSecurity, tokenConverter: AuthAwareTokenConverter): SecurityFilterChain {
     http {
       sessionManagement { SessionCreationPolicy.STATELESS }
       headers { frameOptions { sameOrigin = true } }
@@ -35,7 +35,7 @@ class ResourceServerConfiguration {
         ).forEach { authorize(it, permitAll) }
         authorize(anyRequest, authenticated)
       }
-      oauth2ResourceServer { jwt { jwtAuthenticationConverter = AuthAwareTokenConverter() } }
+      oauth2ResourceServer { jwt { jwtAuthenticationConverter = tokenConverter } }
     }
 
     return http.build()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/WebClientConfiguration.kt
@@ -9,9 +9,9 @@ import org.springframework.web.reactive.function.client.WebClient
 class WebClientConfiguration {
 
   @Bean
-  fun hmppsAuthWebClient(@Value("\${api.hmpps-auth.url}") eroManagementApiUrl: String): WebClient =
+  fun hmppsAuthWebClient(@Value("\${api.hmpps-auth.url}") hmppsAuthApiUrl: String): WebClient =
     WebClient.builder()
-      .baseUrl(eroManagementApiUrl)
+      .baseUrl(hmppsAuthApiUrl)
       .build()
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/WebClientConfiguration.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class WebClientConfiguration {
+
+  @Bean
+  fun hmppsAuthWebClient(@Value("\${api.hmpps-auth.url}") eroManagementApiUrl: String): WebClient =
+    WebClient.builder()
+      .baseUrl(eroManagementApiUrl)
+      .build()
+}
+
+fun WebClient.RequestHeadersSpec<*>.bearerToken(bearerToken: String): WebClient.RequestBodySpec =
+  header("authorization", "Bearer $bearerToken") as WebClient.RequestBodySpec

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/LocationAuditingEntityListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/LocationAuditingEntityListener.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
+
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import java.lang.reflect.Field
+
+/**
+ * JPA Entity Listener that sets fields annotated with [CreatedLocation] or [LastModifiedLocation]] with the authenticated
+ * user's location, typically the prison in which they are working taken from their active caseload ID.
+ */
+class LocationAuditingEntityListener {
+
+  /**
+   * Entity lifecycle hook to update fields annotated with [CreatedLocation] or [LastModifiedLocation]
+   * on new entity creation (pre-persist)
+   */
+  @PrePersist
+  fun updateAuditDisplayNameFieldsOnEntityCreate(target: Any) {
+    val currentUserLocation = UserPrincipalAuditorAware.getCurrentAuditorLocation()
+    target.javaClass.declaredFields
+      .filter { field -> field.shouldBeUpdatedOnEntityCreate() }
+      .onEach { field ->
+        field.isAccessible = true
+        field.set(target, currentUserLocation)
+      }
+  }
+
+  /**
+   * Entity lifecycle hook to update fields annotated with [LastModifiedLocation]
+   * on entity update (pre-update)
+   */
+  @PreUpdate
+  fun updateAuditDisplayNameFieldsOnEntityUpdate(target: Any) {
+    val currentUserLocation = UserPrincipalAuditorAware.getCurrentAuditorLocation()
+    target.javaClass.declaredFields
+      .filter { field -> field.shouldBeUpdatedOnEntityUpdate() }
+      .onEach { field ->
+        field.isAccessible = true
+        field.set(target, currentUserLocation)
+      }
+  }
+
+  private fun Field.shouldBeUpdatedOnEntityCreate(): Boolean =
+    this.isAnnotationPresent(CreatedLocation::class.java) || this.isAnnotationPresent(LastModifiedLocation::class.java)
+
+  private fun Field.shouldBeUpdatedOnEntityUpdate(): Boolean =
+    this.isAnnotationPresent(LastModifiedLocation::class.java)
+
+  /**
+   * Simple marker annotation to mark an entity field as containing the location of the user who created the entity.
+   */
+  @Target(AnnotationTarget.FIELD)
+  @Retention(AnnotationRetention.RUNTIME)
+  @MustBeDocumented
+  annotation class CreatedLocation
+
+  /**
+   * Simple marker annotation to mark an entity field as containing the location of the user who last modified the entity.
+   */
+  @Target(AnnotationTarget.FIELD)
+  @Retention(AnnotationRetention.RUNTIME)
+  @MustBeDocumented
+  annotation class LastModifiedLocation
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAware.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAware.kt
@@ -11,6 +11,8 @@ class UserPrincipalAuditorAware : AuditorAware<String> {
 
   companion object {
     fun getCurrentAuditorDisplayName(): String = CurrentUser().displayName
+
+    fun getCurrentAuditorLocation(): String = CurrentUser().activeCaseLoadId
   }
 
   override fun getCurrentAuditor(): Optional<String> = Optional.of(CurrentUser().username)
@@ -23,6 +25,7 @@ class CurrentUser {
 
   val username: String
   val displayName: String
+  val activeCaseLoadId: String
 
   init {
     with(SecurityContextHolder.getContext()?.authentication) {
@@ -30,9 +33,11 @@ class CurrentUser {
         val principal = this.principal as DpsPrincipal
         username = principal.name
         displayName = principal.displayName
+        activeCaseLoadId = principal.activeCaseLoadId
       } else {
         username = SYSTEM
         displayName = SYSTEM
+        activeCaseLoadId = SYSTEM
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
@@ -12,6 +12,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import jakarta.persistence.Transient
 import jakarta.validation.constraints.NotNull
 import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
@@ -23,13 +24,15 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.LocationAuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.LocationAuditingEntityListener.LastModifiedLocation
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
 @Table(name = "goal")
 @Entity
-@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class])
+@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class, LocationAuditingEntityListener::class])
 class GoalEntity(
   @Id
   @GeneratedValue
@@ -72,6 +75,10 @@ class GoalEntity(
   @CreatedByDisplayName
   var createdByDisplayName: String? = null,
 
+  @Transient
+  @LocationAuditingEntityListener.CreatedLocation
+  var createdLocation: String? = null,
+
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
@@ -83,6 +90,10 @@ class GoalEntity(
   @Column
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
+
+  @Transient
+  @LastModifiedLocation
+  var updatedLocation: String? = null,
 ) {
 
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.Dis
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.LocationAuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.LocationAuditingEntityListener.CreatedLocation
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.LocationAuditingEntityListener.LastModifiedLocation
 import java.time.Instant
 import java.time.LocalDate
@@ -76,7 +77,7 @@ class GoalEntity(
   var createdByDisplayName: String? = null,
 
   @Transient
-  @LocationAuditingEntityListener.CreatedLocation
+  @CreatedLocation
   var createdLocation: String? = null,
 
   @Column

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,3 +76,7 @@ springdoc:
   # swagger specification file served via /swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config
   swagger-ui:
     url: '/openapi/EducationAndWorkPlanAPI.yml'
+
+api:
+  hmpps-auth:
+    url: ${HMPPS_AUTH_URL}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAwareTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAwareTest.kt
@@ -14,9 +14,10 @@ class UserPrincipalAuditorAwareTest {
   companion object {
     private const val USERNAME = "auser_gen"
     private const val DISPLAY_NAME = "Albert User"
+    private const val ACTIVE_CASELOAD_ID = "BXI"
     private val ROLES = emptyList<GrantedAuthority>()
 
-    private val PRINCIPAL = DpsPrincipal(USERNAME, DISPLAY_NAME)
+    private val PRINCIPAL = DpsPrincipal(USERNAME, DISPLAY_NAME, ACTIVE_CASELOAD_ID)
     private val AUTHENTICATION = TestingAuthenticationToken(PRINCIPAL, null, ROLES)
   }
 


### PR DESCRIPTION
This PR is draft and is not intended to be merged (yet / in it's current form), and is to serve as a discussion document.

This PR is a POC to show how we might capture the CIAG's current prison (activeCaseLoadId) and store it against the Goal when we save it to the database.

It's not 100% complete yet, in that I've not done the database DDL changes yet to add the new columns, so therefore the CIAGs location isn't actually persisted yet. And there are a few tests missing!

### How it works
The way it works is that is hooks into Spring Security (which already do anyway). Currently we have a custom `Principal` object called `DpsPrincipal` that contains their username (eg: `NRUSSELL_GEN`) and their display name (eg: `Nathan Russell`). The `DpsPrinicpal` is instantiated by `AuthAwareTokenConverter`, where both fields are taken from the JWT (because they are claims in the JWT 👍 )
We then subsequently use these fields at the JPA layer via the annotations `@CreatedBy` and `@LastModifiedBy` (standard annotations) and our custom annotations `@CreatedByDisplayName` and `@LastModifiedByDisplayName`. These last 2 annotations are processed by `DisplayNameAuditingEntityListener` which sets the field values from the fields in the `DpsPrincipal`

What I'm proposing here is that our `DpsPrincipal` contains a new field - `activeCaseLoadId` and that is populated by `AuthAwareTokenConverter`. The active caseload ID is unfortunately not a claim in the JWT, so `AuthAwareTokenConverter` needs to use a new client class `HmppsAuthClient` to call HMPPS Auth's `/api/user/me` endpoint. This returns a small object that contains the field `activeCaseLoadId`

Now that `DpsPrincipal` contains the active case load ID, it can be used at the JPA layer via some new annotations and a new entity listener class.

Thats basically it 👍 

### Things missing / considerations
* There are a handful of unit tests missing - its a POC after all 😁 (though integration test support is provided for via the introduction of wiremock)
* The DDL to add the new columns to the `Goal` table is missing; I've not done that yet. But I have got as far as adding the new fields to the entity class with the new annotations; but I've annotated them as `@Transient` so that JPA does not try to write them to a column that doesn't exist yet 😁 
* Performance .... hmmmm ... I think we're going to need to put a caching abstraction over the new `HmppsAuthClient`. This is because now every single request, even a `GET` request, will go off to HMPPS Auth to get the active caseload ID. 
Using this approach, if we don't implement caching, we are going to be making a lot of calls to HMPPS Auth, and the reality is that the data for each user wont change frequently. So caching it makes sense.
