### PR TITLE
RR-236 - swagger spec to include prison ID on createGoal, updateGoal and getGoal

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
@@ -43,5 +43,7 @@ interface GoalResourceMapper {
   @Mapping(target = "updatedBy", source = "lastUpdatedBy")
   @Mapping(target = "updatedByDisplayName", source = "lastUpdatedByDisplayName")
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
+  @Mapping(target = "createdAtPrison", constant = "BXI") // TODO RR-236 map from the domain object
+  @Mapping(target = "updatedAtPrison", constant = "BXI") // TODO RR-236 map from the domain object
   fun fromDomainToModel(goalDomain: Goal): GoalResponse
 }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.1.6'
+  version: '1.2.0'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -269,6 +269,10 @@ components:
           format: date-time
           description: An ISO-8601 timestamp representing when the Goal was created.
           example: '2023-06-19T09:39:44Z'
+        createdAtPrison:
+          type: string
+          description: The identifier of the prison that the prisoner was resident at when the Goal was created.
+          example: 'BXI'
         updatedBy:
           type: string
           description: The DPS username of the person who last updated the goal.
@@ -282,6 +286,10 @@ components:
           format: date-time
           description: An ISO-8601 timestamp representing when the Goal was last updated. This will be the same as the created date if it has not yet been updated.
           example: '2023-06-19T09:39:44Z'
+        updatedAtPrison:
+          type: string
+          description: The identifier of the prison that the prisoner was resident at when the Goal was updated.
+          example: 'BXI'
       required:
         - goalReference
         - title
@@ -290,9 +298,11 @@ components:
         - createdBy
         - createdByDisplayName
         - createdAt
+        - createdAtPrison
         - updatedBy
         - updatedByDisplayName
         - updatedAt
+        - updatedAtPrison
     StepResponse:
       title: StepResponse
       type: object
@@ -381,9 +391,14 @@ components:
           type: string
           description: Some additional notes related to the Goal.
           example: Pay close attention to Peter's behaviour.
+        prisonId:
+          type: string
+          description: The identifier of the prison that the prisoner is currently resident at.
+          example: BXI
       required:
         - title
         - steps
+        - prisonId
 
     UpdateGoalRequest:
       title: UpdateGoalRequest
@@ -416,11 +431,16 @@ components:
           type: string
           description: Some additional notes related to the Goal.
           example: Pay close attention to Peter's behaviour.
+        prisonId:
+          type: string
+          description: The identifier of the prison that the prisoner is currently resident at.
+          example: BXI
       required:
         - goalReference
         - title
         - status
         - steps
+        - prisonId
 
     CreateStepRequest:
       title: CreateStepRequest

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateGoalRequestBuilder.kt
@@ -7,12 +7,14 @@ fun aValidCreateGoalRequest(
   reviewDate: LocalDate? = null,
   steps: List<CreateStepRequest> = listOf(aValidCreateStepRequest(), anotherValidCreateStepRequest()),
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
+  prisonId: String = "BXI",
 ): CreateGoalRequest =
   CreateGoalRequest(
     title = title,
     reviewDate = reviewDate,
     steps = steps,
     notes = notes,
+    prisonId = prisonId,
   )
 
 fun anotherValidCreateGoalRequest(
@@ -20,10 +22,12 @@ fun anotherValidCreateGoalRequest(
   reviewDate: LocalDate = LocalDate.now().plusMonths(6),
   steps: List<CreateStepRequest> = listOf(aValidCreateStepRequest("Attend in house bricklaying course")),
   notes: String? = "",
+  prisonId: String = "BXI",
 ): CreateGoalRequest =
   CreateGoalRequest(
     title = title,
     reviewDate = reviewDate,
     steps = steps,
     notes = notes,
+    prisonId = prisonId,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseBuilder.kt
@@ -14,9 +14,11 @@ fun aValidGoalResponse(
   createdBy: String = "asmith_gen",
   createdByDisplayName: String = "Alex Smith",
   createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
   updatedBy: String = "asmith_gen",
   updatedByDisplayName: String = "Alex Smith",
   updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
 ): GoalResponse =
   GoalResponse(
     goalReference = reference,
@@ -28,9 +30,11 @@ fun aValidGoalResponse(
     createdBy = createdBy,
     createdByDisplayName = createdByDisplayName,
     createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
     updatedBy = updatedBy,
     updatedByDisplayName = updatedByDisplayName,
     updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
   )
 
 fun anotherValidGoalResponse(
@@ -43,9 +47,11 @@ fun anotherValidGoalResponse(
   createdBy: String = "bjones_gen",
   createdByDisplayName: String = "Barry Jones",
   createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
   updatedBy: String = "bjones_gen",
   updatedByDisplayName: String = "Barry Jones",
   updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
 ): GoalResponse =
   GoalResponse(
     goalReference = reference,
@@ -57,7 +63,9 @@ fun anotherValidGoalResponse(
     createdBy = createdBy,
     createdByDisplayName = createdByDisplayName,
     createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
     updatedBy = updatedBy,
     updatedAt = updatedAt,
     updatedByDisplayName = updatedByDisplayName,
+    updatedAtPrison = updatedAtPrison,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/UpdateGoalRequestBuilder.kt
@@ -11,6 +11,7 @@ fun aValidUpdateGoalRequest(
   status: GoalStatus = GoalStatus.ACTIVE,
   steps: List<UpdateStepRequest> = listOf(aValidUpdateStepRequest()),
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
+  prisonId: String = "BXI",
 ): UpdateGoalRequest =
   UpdateGoalRequest(
     goalReference = goalReference,
@@ -19,4 +20,5 @@ fun aValidUpdateGoalRequest(
     status = status,
     steps = steps,
     notes = notes,
+    prisonId = prisonId,
   )


### PR DESCRIPTION
This PR updates the swagger spec to include the prison ID in createGoal and updateGoal requests; and the response object for a Goal

### Update Goal Request
![Screenshot 2023-08-31 at 15 54 37](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/assets/94835226/c498fe85-d38e-4c3c-bd16-c87d203022b7)

### Create Goal Request
![Screenshot 2023-08-31 at 15 54 52](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/assets/94835226/a8a89751-eed2-4fe5-a805-02222f8ce017)

### Goal Response
![Screenshot 2023-08-31 at 15 55 30](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/assets/94835226/2e26eb9e-8711-4968-81d5-69527f23b402)
