### PR TITLE
RR-274 - Retrieve Action Plan Summaries - repository, service and mapper

### DIFF
--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlanSummary.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlanSummary.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
+
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * A subset of a Prisoner's 'Action Plan', which excludes the list of Goals (mainly for performance reasons so that a
+ * large number of these can be provided - e.g. in an HTTP response).
+ */
+data class ActionPlanSummary(
+  val reference: UUID,
+  val prisonNumber: String,
+  val reviewDate: LocalDate?,
+)

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanPersistenceAdapter.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanSummary
 
 /**
  * Persistence Adapter for [ActionPlan] instances.
@@ -21,4 +22,10 @@ interface ActionPlanPersistenceAdapter {
    * Returns an [ActionPlan] if found, otherwise `null`.
    */
   fun getActionPlan(prisonNumber: String): ActionPlan?
+
+  /**
+   * Returns a [List] of [ActionPlanSummary]s for each matching prisoner (in the provided [List] of prison numbers)
+   * that has an Action Plan. The list can be empty, but not null.
+   */
+  fun getActionPlanSummaries(prisonNumbers: List<String>): List<ActionPlanSummary>
 }

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 import mu.KotlinLogging
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanAlreadyExistsException
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanSummary
 import java.util.UUID
 
 private val log = KotlinLogging.logger {}
@@ -41,7 +42,7 @@ class ActionPlanService(
    */
   fun getActionPlan(prisonNumber: String): ActionPlan {
     log.debug { "Retrieving Action Plan for prisoner [$prisonNumber]" }
-    // RR-227 - return 404 if not found
+    // TODO RR-227 - return 404 if not found
     return persistenceAdapter.getActionPlan(prisonNumber)
       ?: ActionPlan(
         reference = UUID.randomUUID(),
@@ -49,5 +50,10 @@ class ActionPlanService(
         reviewDate = null,
         goals = emptyList(),
       )
+  }
+
+  fun getActionPlanSummaries(prisonNumbers: List<String>): List<ActionPlanSummary> {
+    log.debug { "Retrieving Action Plan Summaries for ${prisonNumbers.size} prisoners" }
+    return persistenceAdapter.getActionPlanSummaries(prisonNumbers)
   }
 }

--- a/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlanSummaryBuilder.kt
+++ b/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/ActionPlanSummaryBuilder.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
+
+import java.time.LocalDate
+import java.util.UUID
+
+fun aValidActionPlanSummary(
+  reference: UUID = UUID.randomUUID(),
+  prisonNumber: String = "A1234BC",
+  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
+): ActionPlanSummary =
+  ActionPlanSummary(
+    reference = reference,
+    prisonNumber = prisonNumber,
+    reviewDate = reviewDate,
+  )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ActionPlanServiceTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ActionPlanServiceTest.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.transaction.TestTransaction
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.anotherValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlanSummary
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanService
+
+@Deprecated("A temporary test until we have integration tests which use the relevant controller endpoints")
+class ActionPlanServiceTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var actionPlanService: ActionPlanService
+
+  @Test
+  @Transactional
+  fun `should get action plan summaries`() {
+    // Given
+    val prisonNumber1 = aValidPrisonNumber()
+    val prisonNumber2 = anotherValidPrisonNumber()
+    val actionPlan1 = aValidActionPlan(prisonNumber = prisonNumber1)
+    val actionPlan2 = aValidActionPlan(prisonNumber = prisonNumber2)
+    actionPlanService.createActionPlan(actionPlan1)
+    actionPlanService.createActionPlan(actionPlan2)
+    TestTransaction.flagForCommit()
+    TestTransaction.end()
+    TestTransaction.start()
+
+    val expected = listOf(
+      aValidActionPlanSummary(
+        reference = actionPlan1.reference,
+        prisonNumber = prisonNumber1,
+        reviewDate = actionPlan1.reviewDate,
+      ),
+      aValidActionPlanSummary(
+        reference = actionPlan2.reference,
+        prisonNumber = prisonNumber2,
+        reviewDate = actionPlan2.reviewDate,
+      ),
+    )
+
+    // When
+    val actionPlanSummaries = actionPlanService.getActionPlanSummaries(listOf(prisonNumber1, prisonNumber2))
+
+    // Then
+    assertThat(actionPlanSummaries).hasSize(2)
+    assertThat(actionPlanSummaries).containsExactlyInAnyOrderElementsOf(expected)
+  }
+
+  @Test
+  @Transactional
+  fun `should get an empty collection when no action plans exist for given prisoners`() {
+    // Given
+    val prisonNumber1 = aValidPrisonNumber()
+    val prisonNumber2 = anotherValidPrisonNumber()
+
+    // When
+    val actionPlanSummaries = actionPlanService.getActionPlanSummaries(listOf(prisonNumber1, prisonNumber2))
+
+    // Then
+    assertThat(actionPlanSummaries).isEmpty()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ActionPlanEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanSummary
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanPersistenceAdapter
 
 @Component
@@ -20,5 +21,10 @@ class JpaActionPlanPersistenceAdapter(
   override fun getActionPlan(prisonNumber: String): ActionPlan? =
     actionPlanRepository.findByPrisonNumber(prisonNumber)?.let {
       actionPlanMapper.fromEntityToDomain(it)
+    }
+
+  override fun getActionPlanSummaries(prisonNumbers: List<String>): List<ActionPlanSummary> =
+    actionPlanRepository.findByPrisonNumberIn(prisonNumbers).let {
+      actionPlanMapper.fromEntitySummariesToDomainSummaries(it)
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanSummaryProjection.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanSummaryProjection.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
+
+import java.time.LocalDate
+import java.util.UUID
+
+data class ActionPlanSummaryProjection(
+  val reference: UUID,
+  val prisonNumber: String,
+  val reviewDate: LocalDate?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapper.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 
 import org.mapstruct.Mapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanSummaryProjection
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanSummary
 
 @Mapper(
   uses = [
@@ -14,4 +16,5 @@ interface ActionPlanEntityMapper {
   fun fromDomainToEntity(actionPlan: ActionPlan): ActionPlanEntity
 
   fun fromEntityToDomain(actionPlanEntity: ActionPlanEntity): ActionPlan
+  fun fromEntitySummariesToDomainSummaries(actionPlanSummaryProjections: List<ActionPlanSummaryProjection>): List<ActionPlanSummary>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/ActionPlanRepository.kt
@@ -3,10 +3,13 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.re
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanSummaryProjection
 import java.util.UUID
 
 @Repository
 interface ActionPlanRepository : JpaRepository<ActionPlanEntity, UUID> {
+
+  fun findByPrisonNumberIn(prisonNumbers: List<String>): List<ActionPlanSummaryProjection>
 
   fun findByPrisonNumber(prisonNumber: String): ActionPlanEntity?
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
@@ -12,9 +12,11 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanSummaryProjection
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ActionPlanEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlanSummary
 
 @ExtendWith(MockitoExtension::class)
 class JpaActionPlanPersistenceAdapterTest {
@@ -64,5 +66,24 @@ class JpaActionPlanPersistenceAdapterTest {
     assertThat(actual).isEqualTo(expectedActionPlanDomain)
     verify(actionPlanRepository).findByPrisonNumber(prisonNumber)
     verify(actionPlanMapper).fromEntityToDomain(actionPlanEntity)
+  }
+
+  @Test
+  fun `should retrieve Action Plan Summaries`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val prisonNumbers = listOf(prisonNumber)
+    val actionPlanSummaryProjections = listOf(aValidActionPlanSummaryProjection(prisonNumber = prisonNumber))
+    val expectedActionPlanSummaries = listOf(aValidActionPlanSummary(prisonNumber = prisonNumber))
+    given(actionPlanRepository.findByPrisonNumberIn(any())).willReturn(actionPlanSummaryProjections)
+    given(actionPlanMapper.fromEntitySummariesToDomainSummaries(any())).willReturn(expectedActionPlanSummaries)
+
+    // When
+    val actual = persistenceAdapter.getActionPlanSummaries(prisonNumbers)
+
+    // Then
+    assertThat(actual).isEqualTo(expectedActionPlanSummaries)
+    verify(actionPlanRepository).findByPrisonNumberIn(prisonNumbers)
+    verify(actionPlanMapper).fromEntitySummariesToDomainSummaries(actionPlanSummaryProjections)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
@@ -10,9 +10,12 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.anotherValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanSummaryProjection
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidGoalEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlanSummary
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
 
 @ExtendWith(MockitoExtension::class)
@@ -68,5 +71,31 @@ class ActionPlanEntityMapperTest {
     // Then
     assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
     verify(goalMapper).fromEntityToDomain(actionPlanEntity.goals!![0])
+  }
+
+  @Test
+  fun `should map from entity summaries to domain summaries`() {
+    // Given
+    val summaryProjection1 = aValidActionPlanSummaryProjection(prisonNumber = aValidPrisonNumber())
+    val summaryProjection2 = aValidActionPlanSummaryProjection(prisonNumber = anotherValidPrisonNumber())
+    val expected = listOf(
+      aValidActionPlanSummary(
+        prisonNumber = summaryProjection1.prisonNumber,
+        reference = summaryProjection1.reference,
+        reviewDate = summaryProjection1.reviewDate,
+      ),
+      aValidActionPlanSummary(
+        prisonNumber = summaryProjection2.prisonNumber,
+        reference = summaryProjection2.reference,
+        reviewDate = summaryProjection2.reviewDate,
+      ),
+    )
+
+    // When
+    val actual = mapper.fromEntitySummariesToDomainSummaries(listOf(summaryProjection1, summaryProjection2))
+
+    // Then
+    assertThat(actual).hasSize(2)
+    assertThat(actual).isEqualTo(expected)
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/CommonBuilders.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/CommonBuilders.kt
@@ -9,4 +9,6 @@ import java.util.UUID
 
 fun aValidPrisonNumber() = "A1234BC"
 
+fun anotherValidPrisonNumber() = "B5678CD"
+
 fun aValidReference() = UUID.randomUUID()

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanSummaryProjectionBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanSummaryProjectionBuilder.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
+
+import java.time.LocalDate
+import java.util.UUID
+
+fun aValidActionPlanSummaryProjection(
+  reference: UUID = UUID.randomUUID(),
+  prisonNumber: String = "A1234BC",
+  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
+): ActionPlanSummaryProjection =
+  ActionPlanSummaryProjection(
+    reference = reference,
+    prisonNumber = prisonNumber,
+    reviewDate = reviewDate,
+  )


### PR DESCRIPTION
This PR adds the required changes to repository, service and mapper classes to retrieve a list of `ActionPlanSummary` instances.

Instead of retrieving the whole `ActionPlanEntity` and then returning a subset of the fields, I'm using a JPA class based projection - `ActionPlanSummaryProjection` (which I think is the right name given it's not a JPA entity!).