### PR TITLE
RR-236 - Refactored to use a DTO when creating an action plan and goal 

### DIFF
--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateActionPlanDto.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateActionPlanDto.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto
+
+import java.time.LocalDate
+
+data class CreateActionPlanDto(
+  val prisonNumber: String,
+  val reviewDate: LocalDate?,
+  val goals: List<CreateGoalDto>,
+)

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateActionPlanDto.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateActionPlanDto.kt
@@ -2,6 +2,9 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto
 
 import java.time.LocalDate
 
+/**
+ * A DTO class that contains the data required to create a new Action Plan domain object
+ */
 data class CreateActionPlanDto(
   val prisonNumber: String,
   val reviewDate: LocalDate?,

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateGoalDto.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateGoalDto.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus
+import java.time.LocalDate
+
+/**
+ * A DTO class that contains the data required to create a new Goal domain object
+ */
+class CreateGoalDto(
+  val title: String,
+  val reviewDate: LocalDate?,
+  var status: GoalStatus = GoalStatus.ACTIVE,
+  val notes: String? = null,
+  steps: List<CreateStepDto>,
+) {
+  val steps: List<CreateStepDto>
+
+  init {
+    this.steps = steps
+      .sortedBy { it.sequenceNumber } // sort by current sequence number (that may include gaps if steps have been removed)
+      .mapIndexed { idx, step -> step.copy(sequenceNumber = idx + 1) } // map each step to a copy of itself with the sequential sequence number
+  }
+}

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateStepDto.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateStepDto.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDateRange
+
+/**
+ * A DTO class that contains the data required to create a new Step domain object
+ */
+data class CreateStepDto(
+  val title: String,
+  val targetDateRange: TargetDateRange,
+  val status: StepStatus = StepStatus.NOT_STARTED,
+  val sequenceNumber: Int,
+)

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanPersistenceAdapter.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanPersistenceAdapter.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanSummary
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateActionPlanDto
 
 /**
  * Persistence Adapter for [ActionPlan] instances.
@@ -16,7 +17,7 @@ interface ActionPlanPersistenceAdapter {
   /**
    * Creates a new [ActionPlan] and returns persisted instance.
    */
-  fun createActionPlan(actionPlan: ActionPlan): ActionPlan
+  fun createActionPlan(createActionPlanDto: CreateActionPlanDto): ActionPlan
 
   /**
    * Returns an [ActionPlan] if found, otherwise `null`.

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
@@ -25,7 +25,6 @@ class ActionPlanService(
   /**
    * Creates an [ActionPlan] for a prisoner, containing at least one or more Goals.
    */
-  // TODO - write unit tests for this function
   fun createActionPlan(createActionPlanDto: CreateActionPlanDto): ActionPlan {
     with(createActionPlanDto) {
       log.info { "Creating ActionPlan for prisoner [$prisonNumber]" }

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanService.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanAlreadyExistsException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanSummary
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateActionPlanDto
 import java.util.UUID
 
 private val log = KotlinLogging.logger {}
@@ -24,15 +25,16 @@ class ActionPlanService(
   /**
    * Creates an [ActionPlan] for a prisoner, containing at least one or more Goals.
    */
-  fun createActionPlan(actionPlan: ActionPlan): ActionPlan {
-    with(actionPlan) {
-      log.info { "Saving ActionPlan [$reference] for prisoner [$prisonNumber]" }
+  // TODO - write unit tests for this function
+  fun createActionPlan(createActionPlanDto: CreateActionPlanDto): ActionPlan {
+    with(createActionPlanDto) {
+      log.info { "Creating ActionPlan for prisoner [$prisonNumber]" }
 
       if (persistenceAdapter.getActionPlan(prisonNumber) != null) {
         throw ActionPlanAlreadyExistsException("An Action Plan already exists for prisoner $prisonNumber.")
       }
 
-      return persistenceAdapter.createActionPlan(actionPlan)
+      return persistenceAdapter.createActionPlan(createActionPlanDto)
     }
   }
 

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalPersistenceAdapter.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateGoalDto
 import java.util.UUID
 
 /**
@@ -16,7 +17,7 @@ interface GoalPersistenceAdapter {
   /**
    * Creates a new [Goal] for the prisoner identified by their prison number.
    */
-  fun createGoal(goal: Goal, prisonNumber: String): Goal
+  fun createGoal(prisonNumber: String, createGoalDto: CreateGoalDto): Goal
 
   /**
    * Returns a [Goal] identified by its `prisonNumber` and `goalReference` if found, otherwise `null`.

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalService.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 import mu.KotlinLogging
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalNotFoundException
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateGoalDto
 import java.util.UUID
 
 private val log = KotlinLogging.logger {}
@@ -22,11 +23,11 @@ class GoalService(
 ) {
 
   /**
-   * Creates a new [Goal] for the prisoner identified by their prison number.
+   * Creates a new [Goal] for the prisoner identified by their prison number, with the data in the specified [CreateGoalDto]
    */
-  fun createGoal(prisonNumber: String, goal: Goal): Goal {
-    log.info { "Saving Goal [${goal.reference}] for prisoner [$prisonNumber]" }
-    return persistenceAdapter.createGoal(goal, prisonNumber)
+  fun createGoal(prisonNumber: String, createGoalDto: CreateGoalDto): Goal {
+    log.info { "Creating new Goal for prisoner [$prisonNumber]" }
+    return persistenceAdapter.createGoal(prisonNumber, createGoalDto)
   }
 
   /**

--- a/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanServiceTest.kt
+++ b/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanServiceTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -10,7 +12,11 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.anotherValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanAlreadyExistsException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlanSummary
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateActionPlanDto
 
 @ExtendWith(MockitoExtension::class)
 class ActionPlanServiceTest {
@@ -20,33 +26,103 @@ class ActionPlanServiceTest {
   @Mock
   private lateinit var persistenceAdapter: ActionPlanPersistenceAdapter
 
-  @Test
-  fun `should retrieve action plan by prison number`() {
-    // Given
-    val actionPlan = aValidActionPlan()
-    val prisonNumber = aValidPrisonNumber()
-    given(persistenceAdapter.getActionPlan(any())).willReturn(actionPlan)
+  @Nested
+  inner class CreateActionPlan {
+    @Test
+    fun `should create action plan given prisoner does not already have an action plan`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      given(persistenceAdapter.getActionPlan(any())).willReturn(null)
 
-    // When
-    val retrievedActionPlan = service.getActionPlan(prisonNumber)
+      val expectedActionPlan = aValidActionPlan(prisonNumber = prisonNumber)
+      given(persistenceAdapter.createActionPlan(any())).willReturn(expectedActionPlan)
 
-    // Then
-    assertThat(retrievedActionPlan).isEqualTo(actionPlan)
-    verify(persistenceAdapter).getActionPlan(prisonNumber)
+      val createActionPlanDto = aValidCreateActionPlanDto(prisonNumber = prisonNumber)
+
+      // When
+      val actual = service.createActionPlan(createActionPlanDto)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedActionPlan)
+      verify(persistenceAdapter).getActionPlan(prisonNumber)
+      verify(persistenceAdapter).createActionPlan(createActionPlanDto)
+    }
+
+    @Test
+    fun `should not create action plan given prisoner already has an action plan`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+
+      val actionPlan = aValidActionPlan(prisonNumber = prisonNumber)
+      given(persistenceAdapter.getActionPlan(any())).willReturn(actionPlan)
+
+      val createActionPlanDto = aValidCreateActionPlanDto(prisonNumber = prisonNumber)
+
+      // When
+      val exception = catchThrowableOfType(
+        { service.createActionPlan(createActionPlanDto) },
+        ActionPlanAlreadyExistsException::class.java
+      )
+
+      // Then
+      assertThat(exception)
+        .hasMessage("An Action Plan already exists for prisoner $prisonNumber.")
+      verify(persistenceAdapter).getActionPlan(prisonNumber)
+    }
   }
 
-  @Test
-  fun `should fail to get action plan given no action plan exists`() {
-    // Given
-    val prisonNumber = aValidPrisonNumber()
-    given(persistenceAdapter.getActionPlan(any())).willReturn(null)
+  @Nested
+  inner class GetActionPlan {
+    @Test
+    fun `should retrieve action plan by prison number`() {
+      // Given
+      val actionPlan = aValidActionPlan()
+      val prisonNumber = aValidPrisonNumber()
+      given(persistenceAdapter.getActionPlan(any())).willReturn(actionPlan)
 
-    // When
-    val retrievedActionPlan = service.getActionPlan(prisonNumber)
+      // When
+      val retrievedActionPlan = service.getActionPlan(prisonNumber)
 
-    // Then
-    assertThat(retrievedActionPlan.prisonNumber).isEqualTo(prisonNumber)
-    assertThat(retrievedActionPlan.goals).isEmpty()
-    verify(persistenceAdapter).getActionPlan(prisonNumber)
+      // Then
+      assertThat(retrievedActionPlan).isEqualTo(actionPlan)
+      verify(persistenceAdapter).getActionPlan(prisonNumber)
+    }
+
+    @Test
+    fun `should fail to get action plan given no action plan exists`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      given(persistenceAdapter.getActionPlan(any())).willReturn(null)
+
+      // When
+      val retrievedActionPlan = service.getActionPlan(prisonNumber)
+
+      // Then
+      assertThat(retrievedActionPlan.prisonNumber).isEqualTo(prisonNumber)
+      assertThat(retrievedActionPlan.goals).isEmpty()
+      verify(persistenceAdapter).getActionPlan(prisonNumber)
+    }
+  }
+
+  @Nested
+  inner class GetActionPlanSummaries {
+    @Test
+    fun `should get action plan summaries`() {
+      // Given
+      val prisonNumbers = listOf(aValidPrisonNumber(), anotherValidPrisonNumber())
+
+      val expectedActionPlanSummaries = listOf(
+        aValidActionPlanSummary(prisonNumber = prisonNumbers[0]),
+        aValidActionPlanSummary(prisonNumber = prisonNumbers[1]),
+      )
+      given(persistenceAdapter.getActionPlanSummaries(any())).willReturn(expectedActionPlanSummaries)
+
+      // When
+      val actual = service.getActionPlanSummaries(prisonNumbers)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedActionPlanSummaries)
+      verify(persistenceAdapter).getActionPlanSummaries(prisonNumbers)
+    }
   }
 }

--- a/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanServiceTest.kt
+++ b/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/ActionPlanServiceTest.kt
@@ -61,7 +61,7 @@ class ActionPlanServiceTest {
       // When
       val exception = catchThrowableOfType(
         { service.createActionPlan(createActionPlanDto) },
-        ActionPlanAlreadyExistsException::class.java
+        ActionPlanAlreadyExistsException::class.java,
       )
 
       // Then

--- a/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
+++ b/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalNotFoundException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateGoalDto
 
 @ExtendWith(MockitoExtension::class)
 class GoalServiceTest {
@@ -31,11 +32,14 @@ class GoalServiceTest {
 
     val prisonNumber = aValidPrisonNumber()
 
+    val createGoalDto = aValidCreateGoalDto()
+
     // When
-    service.createGoal(prisonNumber, goal)
+    val actual = service.createGoal(prisonNumber, createGoalDto)
 
     // Then
-    verify(persistenceAdapter).createGoal(goal, prisonNumber)
+    assertThat(actual).isEqualTo(goal)
+    verify(persistenceAdapter).createGoal(prisonNumber, createGoalDto)
   }
 
   @Test

--- a/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/CommonBuilders.kt
+++ b/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/CommonBuilders.kt
@@ -9,4 +9,6 @@ import java.util.UUID
 
 fun aValidPrisonNumber() = "A1234BC"
 
+fun anotherValidPrisonNumber() = "B5678CD"
+
 fun aValidReference() = UUID.randomUUID()

--- a/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateActionPlanDtoBuilder.kt
+++ b/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateActionPlanDtoBuilder.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto
+
+import java.time.LocalDate
+
+fun aValidCreateActionPlanDto(
+  prisonNumber: String = "A1234BC",
+  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
+  goals: List<CreateGoalDto> = mutableListOf(aValidCreateGoalDto()),
+): CreateActionPlanDto =
+  CreateActionPlanDto(
+    prisonNumber = prisonNumber,
+    reviewDate = reviewDate,
+    goals = goals,
+  )

--- a/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateGoalDtoBuilder.kt
+++ b/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateGoalDtoBuilder.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE
+import java.time.LocalDate
+
+fun aValidCreateGoalDto(
+  title: String = "Improve communication skills",
+  reviewDate: LocalDate? = null,
+  steps: List<CreateStepDto> = listOf(aValidCreateStepDto(), anotherValidCreateStepDto()),
+  status: GoalStatus = ACTIVE,
+  notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
+): CreateGoalDto =
+  CreateGoalDto(
+    title = title,
+    reviewDate = reviewDate,
+    steps = steps,
+    status = status,
+    notes = notes,
+  )

--- a/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateStepDtoBuilder.kt
+++ b/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateStepDtoBuilder.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus.NOT_STARTED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDateRange
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDateRange.THREE_TO_SIX_MONTHS
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDateRange.ZERO_TO_THREE_MONTHS
+
+fun aValidCreateStepDto(
+  title: String = "Book communication skills course",
+  targetDateRange: TargetDateRange = ZERO_TO_THREE_MONTHS,
+  status: StepStatus = NOT_STARTED,
+  sequenceNumber: Int = 1,
+): CreateStepDto =
+  CreateStepDto(
+    title = title,
+    targetDateRange = targetDateRange,
+    status = status,
+    sequenceNumber = sequenceNumber,
+  )
+
+fun anotherValidCreateStepDto(
+  title: String = "Complete communication skills course",
+  targetDateRange: TargetDateRange = THREE_TO_SIX_MONTHS,
+  status: StepStatus = NOT_STARTED,
+  sequenceNumber: Int = 2,
+): CreateStepDto =
+  CreateStepDto(
+    title = title,
+    targetDateRange = targetDateRange,
+    status = status,
+    sequenceNumber = sequenceNumber,
+  )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/GoalServiceTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/GoalServiceTest.kt
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.transaction.TestTransaction
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateGoalDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalService
 
 @Deprecated("Remove this test when we have integration tests that hit controller endpoints and therefore exercise the GoalService")
@@ -20,10 +20,10 @@ class GoalServiceTest : IntegrationTestBase() {
   fun `should create new goal given action plan does not exist`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val goal = aValidGoal()
+    val createGoalDto = aValidCreateGoalDto()
 
     // When
-    goalService.createGoal(prisonNumber, goal)
+    goalService.createGoal(prisonNumber, createGoalDto)
 
     // Then
     TestTransaction.flagForCommit()
@@ -40,17 +40,17 @@ class GoalServiceTest : IntegrationTestBase() {
     // Given
     val prisonNumber = aValidPrisonNumber()
 
-    val goal = aValidGoal(
+    val createGoalDto = aValidCreateGoalDto(
       title = "Goal 1",
     )
-    goalService.createGoal(prisonNumber, goal)
+    goalService.createGoal(prisonNumber, createGoalDto)
 
-    val newGoal = aValidGoal(
+    val newCreateGoalDto = aValidCreateGoalDto(
       title = "Goal 2",
     )
 
     // When
-    goalService.createGoal(prisonNumber, newGoal)
+    goalService.createGoal(prisonNumber, newCreateGoalDto)
 
     // Then
     TestTransaction.flagForCommit()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.map
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanSummary
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateActionPlanDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanPersistenceAdapter
 
 @Component
@@ -13,8 +14,8 @@ class JpaActionPlanPersistenceAdapter(
   private val actionPlanMapper: ActionPlanEntityMapper,
 ) : ActionPlanPersistenceAdapter {
 
-  override fun createActionPlan(actionPlan: ActionPlan): ActionPlan {
-    val persistedEntity = actionPlanRepository.save(actionPlanMapper.fromDomainToEntity(actionPlan))
+  override fun createActionPlan(createActionPlanDto: CreateActionPlanDto): ActionPlan {
+    val persistedEntity = actionPlanRepository.save(actionPlanMapper.fromDomainDtoToEntity(createActionPlanDto))
     return actionPlanMapper.fromEntityToDomain(persistedEntity)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
@@ -15,7 +15,7 @@ class JpaActionPlanPersistenceAdapter(
 ) : ActionPlanPersistenceAdapter {
 
   override fun createActionPlan(createActionPlanDto: CreateActionPlanDto): ActionPlan {
-    val persistedEntity = actionPlanRepository.save(actionPlanMapper.fromDomainDtoToEntity(createActionPlanDto))
+    val persistedEntity = actionPlanRepository.save(actionPlanMapper.fromDtoToEntity(createActionPlanDto))
     return actionPlanMapper.fromEntityToDomain(persistedEntity)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
@@ -33,7 +33,7 @@ class JpaGoalPersistenceAdapter(
       )
     }
 
-    val goalEntity = goalMapper.fromDomainDtoToEntity(createGoalDto)
+    val goalEntity = goalMapper.fromDtoToEntity(createGoalDto)
 
     with(actionPlanEntity) {
       addGoal(goalEntity)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.GoalEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateGoalDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalPersistenceAdapter
 import java.util.UUID
 
@@ -20,7 +21,7 @@ class JpaGoalPersistenceAdapter(
 ) : GoalPersistenceAdapter {
 
   @Transactional
-  override fun createGoal(goal: Goal, prisonNumber: String): Goal {
+  override fun createGoal(prisonNumber: String, createGoalDto: CreateGoalDto): Goal {
     var actionPlanEntity = actionPlanRepository.findByPrisonNumber(prisonNumber)
     // TODO RR-227 - throw 404 instead?
     if (actionPlanEntity == null) {
@@ -32,7 +33,7 @@ class JpaGoalPersistenceAdapter(
       )
     }
 
-    val goalEntity = goalMapper.fromDomainToEntity(goal)
+    val goalEntity = goalMapper.fromDomainDtoToEntity(createGoalDto)
 
     with(actionPlanEntity) {
       addGoal(goalEntity)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapper.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.Crea
 interface ActionPlanEntityMapper {
   @ExcludeJpaManagedFields
   @GenerateNewReference
-  fun fromDomainDtoToEntity(createActionPlanDto: CreateActionPlanDto): ActionPlanEntity
+  fun fromDtoToEntity(createActionPlanDto: CreateActionPlanDto): ActionPlanEntity
 
   fun fromEntityToDomain(actionPlanEntity: ActionPlanEntity): ActionPlan
   fun fromEntitySummariesToDomainSummaries(actionPlanSummaryProjections: List<ActionPlanSummaryProjection>): List<ActionPlanSummary>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapper.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ActionPlanSummaryProjection
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanSummary
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateActionPlanDto
 
 @Mapper(
   uses = [
@@ -13,7 +14,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPl
 )
 interface ActionPlanEntityMapper {
   @ExcludeJpaManagedFields
-  fun fromDomainToEntity(actionPlan: ActionPlan): ActionPlanEntity
+  @GenerateNewReference
+  fun fromDomainDtoToEntity(createActionPlanDto: CreateActionPlanDto): ActionPlanEntity
 
   fun fromEntityToDomain(actionPlanEntity: ActionPlanEntity): ActionPlan
   fun fromEntitySummariesToDomainSummaries(actionPlanSummaryProjections: List<ActionPlanSummaryProjection>): List<ActionPlanSummary>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapper.kt
@@ -27,7 +27,7 @@ abstract class GoalEntityMapper {
    */
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields
   @GenerateNewReference
-  abstract fun fromDomainDtoToEntity(createGoalDto: CreateGoalDto): GoalEntity
+  abstract fun fromDtoToEntity(createGoalDto: CreateGoalDto): GoalEntity
 
   /**
    * Maps the supplied [GoalEntity] into the domain [Goal].

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapper.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateGoalDto
 
 @Mapper(
   uses = [
@@ -20,12 +21,13 @@ abstract class GoalEntityMapper {
   private lateinit var stepEntityMapper: StepEntityMapper
 
   /**
-   * Maps the supplied [Goal] into a new un-persisted [GoalEntity].
-   * The JPA managed fields are not mapped.
+   * Maps the supplied [CreateGoalDto] into a new un-persisted [GoalEntity].
+   * A new reference number is generated and mapped. The JPA managed fields are not mapped.
    * This method is suitable for creating a new [GoalEntity] to be subsequently persisted to the database.
    */
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields
-  abstract fun fromDomainToEntity(goal: Goal): GoalEntity
+  @GenerateNewReference
+  abstract fun fromDomainDtoToEntity(createGoalDto: CreateGoalDto): GoalEntity
 
   /**
    * Maps the supplied [GoalEntity] into the domain [Goal].

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/MappingExclusions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/MappingExclusions.kt
@@ -16,3 +16,6 @@ annotation class ExcludeJpaManagedFieldsIncludingDisplayNameFields
 
 @Mapping(target = "reference", ignore = true)
 annotation class ExcludeReferenceField
+
+@Mapping(target = "reference", expression = "java(UUID.randomUUID())")
+annotation class GenerateNewReference

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapper.kt
@@ -5,9 +5,20 @@ import org.mapstruct.Mapping
 import org.mapstruct.MappingTarget
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateStepDto
 
 @Mapper
 interface StepEntityMapper {
+
+  /**
+   * Maps the supplied [CreateStepDto] into a new un-persisted [StepEntity].
+   * A new reference number is generated and mapped. The JPA managed fields are not mapped.
+   * This method is suitable for creating a new [StepEntity] to be subsequently persisted to the database.
+   */
+  @ExcludeJpaManagedFields
+  @GenerateNewReference
+  @Mapping(target = "targetDate", ignore = true)
+  fun fromDomainDtoToEntity(createStepDto: CreateStepDto): StepEntity
 
   /**
    * Maps the supplied [Step] into a new un-persisted [StepEntity].

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapper.kt
@@ -18,7 +18,7 @@ interface StepEntityMapper {
   @ExcludeJpaManagedFields
   @GenerateNewReference
   @Mapping(target = "targetDate", ignore = true)
-  fun fromDomainDtoToEntity(createStepDto: CreateStepDto): StepEntity
+  fun fromDtoToEntity(createStepDto: CreateStepDto): StepEntity
 
   /**
    * Maps the supplied [Step] into a new un-persisted [StepEntity].

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
@@ -34,7 +34,7 @@ class ActionPlanController(
     request: CreateActionPlanRequest,
     @PathVariable prisonNumber: String,
   ) {
-    actionPlanService.createActionPlan(actionPlanMapper.fromModelToDomain(prisonNumber, request))
+    actionPlanService.createActionPlan(actionPlanMapper.fromModelToDomainDto(prisonNumber, request))
   }
 
   @GetMapping("/{prisonNumber}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
@@ -34,7 +34,7 @@ class ActionPlanController(
     request: CreateActionPlanRequest,
     @PathVariable prisonNumber: String,
   ) {
-    actionPlanService.createActionPlan(actionPlanMapper.fromModelToDomainDto(prisonNumber, request))
+    actionPlanService.createActionPlan(actionPlanMapper.fromModelToDto(prisonNumber, request))
   }
 
   @GetMapping("/{prisonNumber}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -40,7 +40,7 @@ class GoalController(
   ) {
     goalService.createGoal(
       prisonNumber = prisonNumber,
-      createGoalDto = goalResourceMapper.fromModelToDomainDto(request),
+      createGoalDto = goalResourceMapper.fromModelToDto(request),
     ).apply {
       telemetryService.trackGoalCreateEvent(this)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -40,7 +40,7 @@ class GoalController(
   ) {
     goalService.createGoal(
       prisonNumber = prisonNumber,
-      goal = goalResourceMapper.fromModelToDomain(request),
+      createGoalDto = goalResourceMapper.fromModelToDomainDto(request),
     ).apply {
       telemetryService.trackGoalCreateEvent(this)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 
 import org.mapstruct.Mapper
-import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanSummary
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateActionPlanDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanSummaryResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
@@ -15,8 +15,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 )
 interface ActionPlanResourceMapper {
 
-  @Mapping(target = "reference", expression = "java(UUID.randomUUID())")
-  fun fromModelToDomain(prisonNumber: String, request: CreateActionPlanRequest): ActionPlan
+  fun fromModelToDomainDto(prisonNumber: String, request: CreateActionPlanRequest): CreateActionPlanDto
 
   fun fromDomainToModel(actionPlan: ActionPlan): ActionPlanResponse
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapper.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 )
 interface ActionPlanResourceMapper {
 
-  fun fromModelToDomainDto(prisonNumber: String, request: CreateActionPlanRequest): CreateActionPlanDto
+  fun fromModelToDto(prisonNumber: String, request: CreateActionPlanRequest): CreateActionPlanDto
 
   fun fromDomainToModel(actionPlan: ActionPlan): ActionPlanResponse
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateGoalDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
@@ -20,15 +21,8 @@ import java.util.UUID
   ],
 )
 interface GoalResourceMapper {
-  @Mapping(target = "reference", expression = "java(UUID.randomUUID())")
   @Mapping(target = "status", constant = "ACTIVE")
-  @Mapping(target = "createdBy", ignore = true)
-  @Mapping(target = "createdByDisplayName", ignore = true)
-  @Mapping(target = "createdAt", ignore = true)
-  @Mapping(target = "lastUpdatedBy", ignore = true)
-  @Mapping(target = "lastUpdatedByDisplayName", ignore = true)
-  @Mapping(target = "lastUpdatedAt", ignore = true)
-  fun fromModelToDomain(createGoalRequest: CreateGoalRequest): Goal
+  fun fromModelToDomainDto(createGoalRequest: CreateGoalRequest): CreateGoalDto
 
   @Mapping(target = "reference", source = "goalReference")
   @Mapping(target = "createdBy", ignore = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapper.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 )
 interface GoalResourceMapper {
   @Mapping(target = "status", constant = "ACTIVE")
-  fun fromModelToDomainDto(createGoalRequest: CreateGoalRequest): CreateGoalDto
+  fun fromModelToDto(createGoalRequest: CreateGoalRequest): CreateGoalDto
 
   @Mapping(target = "reference", source = "goalReference")
   @Mapping(target = "createdBy", ignore = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapper.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 )
 abstract class StepResourceMapper {
   @Mapping(target = "status", constant = "NOT_STARTED")
-  abstract fun fromModelToDomainDto(createStepRequest: CreateStepRequest): CreateStepDto
+  abstract fun fromModelToDto(createStepRequest: CreateStepRequest): CreateStepDto
 
   @Mapping(target = "reference", expression = "java( existingReferenceElseNewReference(updateStepRequest) )")
   abstract fun fromModelToDomain(updateStepRequest: UpdateStepRequest): Step

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapper.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateStepDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.StepResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateStepRequest
@@ -14,9 +15,8 @@ import java.util.UUID
   ],
 )
 abstract class StepResourceMapper {
-  @Mapping(target = "reference", expression = "java( generateNewReference() )")
   @Mapping(target = "status", constant = "NOT_STARTED")
-  abstract fun fromModelToDomain(createStepRequest: CreateStepRequest): Step
+  abstract fun fromModelToDomainDto(createStepRequest: CreateStepRequest): CreateStepDto
 
   @Mapping(target = "reference", expression = "java( existingReferenceElseNewReference(updateStepRequest) )")
   abstract fun fromModelToDomain(updateStepRequest: UpdateStepRequest): Step

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.map
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlanSummary
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateActionPlanDto
 
 @ExtendWith(MockitoExtension::class)
 class JpaActionPlanPersistenceAdapterTest {
@@ -36,17 +37,19 @@ class JpaActionPlanPersistenceAdapterTest {
     val prisonNumber = aValidPrisonNumber()
     val actionPlanDomain = aValidActionPlan(prisonNumber = prisonNumber)
     val actionPlanEntity = aValidActionPlanEntity(prisonNumber = prisonNumber)
-    given(actionPlanMapper.fromDomainToEntity(any())).willReturn(actionPlanEntity)
+    given(actionPlanMapper.fromDomainDtoToEntity(any())).willReturn(actionPlanEntity)
     given(actionPlanRepository.save(any<ActionPlanEntity>())).willReturn(actionPlanEntity)
     given(actionPlanMapper.fromEntityToDomain(any())).willReturn(actionPlanDomain)
 
+    val createActionPlanDto = aValidCreateActionPlanDto(prisonNumber = prisonNumber)
+
     // When
-    val actual = persistenceAdapter.createActionPlan(actionPlanDomain)
+    val actual = persistenceAdapter.createActionPlan(createActionPlanDto)
 
     // Then
     assertThat(actual).isEqualTo(actionPlanDomain)
     verify(actionPlanRepository).save(actionPlanEntity)
-    verify(actionPlanMapper).fromDomainToEntity(actionPlanDomain)
+    verify(actionPlanMapper).fromDomainDtoToEntity(createActionPlanDto)
     verify(actionPlanMapper).fromEntityToDomain(actionPlanEntity)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
@@ -37,7 +37,7 @@ class JpaActionPlanPersistenceAdapterTest {
     val prisonNumber = aValidPrisonNumber()
     val actionPlanDomain = aValidActionPlan(prisonNumber = prisonNumber)
     val actionPlanEntity = aValidActionPlanEntity(prisonNumber = prisonNumber)
-    given(actionPlanMapper.fromDomainDtoToEntity(any())).willReturn(actionPlanEntity)
+    given(actionPlanMapper.fromDtoToEntity(any())).willReturn(actionPlanEntity)
     given(actionPlanRepository.save(any<ActionPlanEntity>())).willReturn(actionPlanEntity)
     given(actionPlanMapper.fromEntityToDomain(any())).willReturn(actionPlanDomain)
 
@@ -49,7 +49,7 @@ class JpaActionPlanPersistenceAdapterTest {
     // Then
     assertThat(actual).isEqualTo(actionPlanDomain)
     verify(actionPlanRepository).save(actionPlanEntity)
-    verify(actionPlanMapper).fromDomainDtoToEntity(createActionPlanDto)
+    verify(actionPlanMapper).fromDtoToEntity(createActionPlanDto)
     verify(actionPlanMapper).fromEntityToDomain(actionPlanEntity)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.GoalEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateGoalDto
 import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
@@ -42,13 +43,14 @@ class JpaGoalPersistenceAdapterTest {
       val domainGoal = aValidGoal(
         reference = reference,
       )
+      val createGoalDto = aValidCreateGoalDto()
 
       given(actionPlanRepository.findByPrisonNumber(any())).willReturn(null)
 
       val entityGoal = aValidGoalEntity(
         reference = reference,
       )
-      given(goalMapper.fromDomainToEntity(any())).willReturn(entityGoal)
+      given(goalMapper.fromDomainDtoToEntity(any())).willReturn(entityGoal)
 
       val actionPlanEntity = aValidActionPlanEntity(
         prisonNumber = prisonNumber,
@@ -59,12 +61,12 @@ class JpaGoalPersistenceAdapterTest {
       given(goalMapper.fromEntityToDomain(any())).willReturn(domainGoal)
 
       // When
-      val actual = persistenceAdapter.createGoal(domainGoal, prisonNumber)
+      val actual = persistenceAdapter.createGoal(prisonNumber, createGoalDto)
 
       // Then
       assertThat(actual).isEqualTo(domainGoal)
       verify(actionPlanRepository).findByPrisonNumber(prisonNumber)
-      verify(goalMapper).fromDomainToEntity(domainGoal)
+      verify(goalMapper).fromDomainDtoToEntity(createGoalDto)
       verify(goalMapper).fromEntityToDomain(entityGoal)
     }
 
@@ -76,6 +78,7 @@ class JpaGoalPersistenceAdapterTest {
       val domainGoal = aValidGoal(
         reference = reference,
       )
+      val createGoalDto = aValidCreateGoalDto()
 
       val initialActionPlan = aValidActionPlanEntity(
         prisonNumber = prisonNumber,
@@ -86,7 +89,7 @@ class JpaGoalPersistenceAdapterTest {
       val entityGoal = aValidGoalEntity(
         reference = reference,
       )
-      given(goalMapper.fromDomainToEntity(any())).willReturn(entityGoal)
+      given(goalMapper.fromDomainDtoToEntity(any())).willReturn(entityGoal)
 
       val actionPlanEntity = aValidActionPlanEntity(
         prisonNumber = prisonNumber,
@@ -97,12 +100,12 @@ class JpaGoalPersistenceAdapterTest {
       given(goalMapper.fromEntityToDomain(any())).willReturn(domainGoal)
 
       // When
-      val actual = persistenceAdapter.createGoal(domainGoal, prisonNumber)
+      val actual = persistenceAdapter.createGoal(prisonNumber, createGoalDto)
 
       // Then
       assertThat(actual).isEqualTo(domainGoal)
       verify(actionPlanRepository).findByPrisonNumber(prisonNumber)
-      verify(goalMapper).fromDomainToEntity(domainGoal)
+      verify(goalMapper).fromDomainDtoToEntity(createGoalDto)
       verify(goalMapper).fromEntityToDomain(entityGoal)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
@@ -50,7 +50,7 @@ class JpaGoalPersistenceAdapterTest {
       val entityGoal = aValidGoalEntity(
         reference = reference,
       )
-      given(goalMapper.fromDomainDtoToEntity(any())).willReturn(entityGoal)
+      given(goalMapper.fromDtoToEntity(any())).willReturn(entityGoal)
 
       val actionPlanEntity = aValidActionPlanEntity(
         prisonNumber = prisonNumber,
@@ -66,7 +66,7 @@ class JpaGoalPersistenceAdapterTest {
       // Then
       assertThat(actual).isEqualTo(domainGoal)
       verify(actionPlanRepository).findByPrisonNumber(prisonNumber)
-      verify(goalMapper).fromDomainDtoToEntity(createGoalDto)
+      verify(goalMapper).fromDtoToEntity(createGoalDto)
       verify(goalMapper).fromEntityToDomain(entityGoal)
     }
 
@@ -89,7 +89,7 @@ class JpaGoalPersistenceAdapterTest {
       val entityGoal = aValidGoalEntity(
         reference = reference,
       )
-      given(goalMapper.fromDomainDtoToEntity(any())).willReturn(entityGoal)
+      given(goalMapper.fromDtoToEntity(any())).willReturn(entityGoal)
 
       val actionPlanEntity = aValidActionPlanEntity(
         prisonNumber = prisonNumber,
@@ -105,7 +105,7 @@ class JpaGoalPersistenceAdapterTest {
       // Then
       assertThat(actual).isEqualTo(domainGoal)
       verify(actionPlanRepository).findByPrisonNumber(prisonNumber)
-      verify(goalMapper).fromDomainDtoToEntity(createGoalDto)
+      verify(goalMapper).fromDtoToEntity(createGoalDto)
       verify(goalMapper).fromEntityToDomain(entityGoal)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
@@ -30,7 +30,7 @@ class ActionPlanEntityMapperTest {
   private lateinit var goalMapper: GoalEntityMapper
 
   @Test
-  fun `should map from domain dto to entity`() {
+  fun `should map from DTO to entity`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     val actionPlan = aValidActionPlan(
@@ -45,12 +45,12 @@ class ActionPlanEntityMapperTest {
       // JPA managed fields - expect these all to be null, implying a new db entity
       id = null,
     )
-    given(goalMapper.fromDomainDtoToEntity(any())).willReturn(expectedGoalEntity)
+    given(goalMapper.fromDtoToEntity(any())).willReturn(expectedGoalEntity)
 
     val createActionPlanDto = aValidCreateActionPlanDto()
 
     // When
-    val actual = mapper.fromDomainDtoToEntity(createActionPlanDto)
+    val actual = mapper.fromDtoToEntity(createActionPlanDto)
 
     // Then
     assertThat(actual)
@@ -59,7 +59,7 @@ class ActionPlanEntityMapperTest {
       .usingRecursiveComparison()
       .ignoringFields("reference")
       .isEqualTo(expected)
-    verify(goalMapper).fromDomainDtoToEntity(createActionPlanDto.goals[0])
+    verify(goalMapper).fromDtoToEntity(createActionPlanDto.goals[0])
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/ActionPlanEntityMapperTest.kt
@@ -14,9 +14,11 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.anotherValidPrisonNu
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanSummaryProjection
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidGoalEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlanSummary
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateActionPlanDto
 
 @ExtendWith(MockitoExtension::class)
 class ActionPlanEntityMapperTest {
@@ -28,7 +30,7 @@ class ActionPlanEntityMapperTest {
   private lateinit var goalMapper: GoalEntityMapper
 
   @Test
-  fun `should map from domain to entity`() {
+  fun `should map from domain dto to entity`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     val actionPlan = aValidActionPlan(
@@ -40,15 +42,24 @@ class ActionPlanEntityMapperTest {
       prisonNumber = prisonNumber,
       reviewDate = actionPlan.reviewDate,
       goals = mutableListOf(expectedGoalEntity),
+      // JPA managed fields - expect these all to be null, implying a new db entity
+      id = null,
     )
-    given(goalMapper.fromDomainToEntity(any())).willReturn(expectedGoalEntity)
+    given(goalMapper.fromDomainDtoToEntity(any())).willReturn(expectedGoalEntity)
+
+    val createActionPlanDto = aValidCreateActionPlanDto()
 
     // When
-    val actual = mapper.fromDomainToEntity(actionPlan)
+    val actual = mapper.fromDomainDtoToEntity(createActionPlanDto)
 
     // Then
-    assertThat(actual).usingRecursiveComparison().ignoringFields("id").isEqualTo(expected)
-    verify(goalMapper).fromDomainToEntity(actionPlan.goals[0])
+    assertThat(actual)
+      .doesNotHaveJpaManagedFieldsPopulated()
+      .hasAReference()
+      .usingRecursiveComparison()
+      .ignoringFields("reference")
+      .isEqualTo(expected)
+    verify(goalMapper).fromDomainDtoToEntity(createActionPlanDto.goals[0])
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperTest.kt
@@ -46,7 +46,7 @@ class GoalEntityMapperTest {
     )
 
     val expectedEntityStep = aValidStepEntity()
-    given(stepMapper.fromDomainDtoToEntity(any())).willReturn(expectedEntityStep)
+    given(stepMapper.fromDtoToEntity(any())).willReturn(expectedEntityStep)
 
     val expected = aValidGoalEntity(
       title = "Improve communication skills",
@@ -65,7 +65,7 @@ class GoalEntityMapperTest {
     )
 
     // When
-    val actual = mapper.fromDomainDtoToEntity(createGoalDto)
+    val actual = mapper.fromDtoToEntity(createGoalDto)
 
     // Then
     assertThat(actual)
@@ -74,7 +74,7 @@ class GoalEntityMapperTest {
       .usingRecursiveComparison()
       .ignoringFields("reference")
       .isEqualTo(expected)
-    verify(stepMapper).fromDomainDtoToEntity(createStepDto)
+    verify(stepMapper).fromDtoToEntity(createStepDto)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperTest.kt
@@ -14,6 +14,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateGoalDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateStepDto
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -34,27 +36,19 @@ class GoalEntityMapperTest {
     // Given
     val reviewDate = LocalDate.now().plusMonths(6)
 
-    val domainStep = aValidStep()
-    val domainGoal = aValidGoal(
-      reference = UUID.randomUUID(),
+    val createStepDto = aValidCreateStepDto()
+    val createGoalDto = aValidCreateGoalDto(
       title = "Improve communication skills",
       reviewDate = reviewDate,
       status = DomainStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
-      steps = listOf(domainStep),
-      createdBy = "asmith_gen",
-      createdByDisplayName = "Alex Smith",
-      createdAt = Instant.now(),
-      lastUpdatedBy = "bjones_gen",
-      lastUpdatedByDisplayName = "Barry Jones",
-      lastUpdatedAt = Instant.now(),
+      steps = listOf(createStepDto),
     )
 
     val expectedEntityStep = aValidStepEntity()
-    given(stepMapper.fromDomainToEntity(any())).willReturn(expectedEntityStep)
+    given(stepMapper.fromDomainDtoToEntity(any())).willReturn(expectedEntityStep)
 
     val expected = aValidGoalEntity(
-      reference = domainGoal.reference,
       title = "Improve communication skills",
       reviewDate = reviewDate,
       status = EntityStatus.ACTIVE,
@@ -71,11 +65,16 @@ class GoalEntityMapperTest {
     )
 
     // When
-    val actual = mapper.fromDomainToEntity(domainGoal)
+    val actual = mapper.fromDomainDtoToEntity(createGoalDto)
 
     // Then
-    assertThat(actual).isEqualToComparingAllFields(expected)
-    verify(stepMapper).fromDomainToEntity(domainStep)
+    assertThat(actual)
+      .doesNotHaveJpaManagedFieldsPopulated()
+      .hasAReference()
+      .usingRecursiveComparison()
+      .ignoringFields("reference")
+      .isEqualTo(expected)
+    verify(stepMapper).fromDomainDtoToEntity(createStepDto)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapperTest.kt
@@ -17,7 +17,7 @@ class StepEntityMapperTest {
   private val mapper = StepEntityMapperImpl()
 
   @Test
-  fun `should map from domain dto to entity`() {
+  fun `should map from DTO to entity`() {
     // Given
     val createStepDto = aValidCreateStepDto(
       title = "Book communication skills course",
@@ -40,7 +40,7 @@ class StepEntityMapperTest {
     )
 
     // When
-    val actual = mapper.fromDomainDtoToEntity(createStepDto)
+    val actual = mapper.fromDtoToEntity(createStepDto)
 
     // Then
     assertThat(actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/StepEntityMapperTest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDateRange
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateStepDto
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepStatus as EntityStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TargetDateRange as EntityTargetDateRange
@@ -14,6 +15,41 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStat
 class StepEntityMapperTest {
 
   private val mapper = StepEntityMapperImpl()
+
+  @Test
+  fun `should map from domain dto to entity`() {
+    // Given
+    val createStepDto = aValidCreateStepDto(
+      title = "Book communication skills course",
+      targetDateRange = TargetDateRange.ZERO_TO_THREE_MONTHS,
+      status = DomainStatus.ACTIVE,
+      sequenceNumber = 1,
+    )
+
+    val expected = aValidStepEntity(
+      title = "Book communication skills course",
+      targetDateRange = EntityTargetDateRange.ZERO_TO_THREE_MONTHS,
+      status = EntityStatus.ACTIVE,
+      sequenceNumber = 1,
+      // JPA managed fields - expect these all to be null, implying a new db entity
+      id = null,
+      createdAt = null,
+      createdBy = null,
+      updatedAt = null,
+      updatedBy = null,
+    )
+
+    // When
+    val actual = mapper.fromDomainDtoToEntity(createStepDto)
+
+    // Then
+    assertThat(actual)
+      .doesNotHaveJpaManagedFieldsPopulated()
+      .hasAReference()
+      .usingRecursiveComparison()
+      .ignoringFields("reference")
+      .isEqualTo(expected)
+  }
 
   @Test
   fun `should map from domain to entity`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
@@ -29,7 +29,7 @@ internal class ActionPlanResourceMapperTest {
   private lateinit var goalMapper: GoalResourceMapper
 
   @Test
-  fun `should map from model to domain dto`() {
+  fun `should map from model to DTO`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     val request = aValidCreateActionPlanRequest()
@@ -39,14 +39,14 @@ internal class ActionPlanResourceMapperTest {
       reviewDate = request.reviewDate,
       goals = listOf(expectedCreateGoalDto),
     )
-    given(goalMapper.fromModelToDomainDto(any())).willReturn(expectedCreateGoalDto)
+    given(goalMapper.fromModelToDto(any())).willReturn(expectedCreateGoalDto)
 
     // When
-    val actual = mapper.fromModelToDomainDto(prisonNumber, request)
+    val actual = mapper.fromModelToDto(prisonNumber, request)
 
     // Then
     assertThat(actual).isEqualTo(expectedCreateActionPlanDto)
-    verify(goalMapper).fromModelToDomainDto(request.goals[0])
+    verify(goalMapper).fromModelToDto(request.goals[0])
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/ActionPlanResourceMapperTest.kt
@@ -13,8 +13,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.anotherValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlan
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidActionPlanSummary
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateActionPlanDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateGoalDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidActionPlanSummaryResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
@@ -29,24 +29,24 @@ internal class ActionPlanResourceMapperTest {
   private lateinit var goalMapper: GoalResourceMapper
 
   @Test
-  fun `should map from model to domain`() {
+  fun `should map from model to domain dto`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     val request = aValidCreateActionPlanRequest()
-    val expectedGoal = aValidGoal()
-    val expectedActionPlan = aValidActionPlan(
+    val expectedCreateGoalDto = aValidCreateGoalDto()
+    val expectedCreateActionPlanDto = aValidCreateActionPlanDto(
       prisonNumber = prisonNumber,
       reviewDate = request.reviewDate,
-      goals = listOf(expectedGoal),
+      goals = listOf(expectedCreateGoalDto),
     )
-    given(goalMapper.fromModelToDomain(any<CreateGoalRequest>())).willReturn(expectedGoal)
+    given(goalMapper.fromModelToDomainDto(any())).willReturn(expectedCreateGoalDto)
 
     // When
-    val actual = mapper.fromModelToDomain(prisonNumber, request)
+    val actual = mapper.fromModelToDomainDto(prisonNumber, request)
 
     // Then
-    assertThat(actual).usingRecursiveComparison().ignoringFields("reference").isEqualTo(expectedActionPlan)
-    verify(goalMapper).fromModelToDomain(request.goals[0])
+    assertThat(actual).isEqualTo(expectedCreateActionPlanDto)
+    verify(goalMapper).fromModelToDomainDto(request.goals[0])
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
@@ -46,7 +46,7 @@ internal class GoalResourceMapperTest {
     )
 
     val expectedStep = aValidCreateStepDto()
-    given(stepMapper.fromModelToDomainDto(any())).willReturn(expectedStep)
+    given(stepMapper.fromModelToDto(any())).willReturn(expectedStep)
 
     val expectedGoal = aValidCreateGoalDto(
       title = createGoalRequest.title,
@@ -57,11 +57,11 @@ internal class GoalResourceMapperTest {
     )
 
     // When
-    val actual = mapper.fromModelToDomainDto(createGoalRequest)
+    val actual = mapper.fromModelToDto(createGoalRequest)
 
     // Then
     assertThat(actual).usingRecursiveComparison().isEqualTo(expectedGoal)
-    verify(stepMapper).fromModelToDomainDto(createStepRequest)
+    verify(stepMapper).fromModelToDto(createStepRequest)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
@@ -12,8 +12,8 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateStepRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateStepRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateGoalDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateStepDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidGoalResponse
@@ -22,7 +22,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aVali
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateStepRequest
 import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.util.UUID
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus as GoalStatusApi
 
 @ExtendWith(MockitoExtension::class)
@@ -46,32 +45,23 @@ internal class GoalResourceMapperTest {
       steps = mutableListOf(createStepRequest),
     )
 
-    val expectedStep = aValidStep()
-    given(stepMapper.fromModelToDomain(any<CreateStepRequest>())).willReturn(expectedStep)
+    val expectedStep = aValidCreateStepDto()
+    given(stepMapper.fromModelToDomainDto(any())).willReturn(expectedStep)
 
-    val expectedGoal = aValidGoal(
-      reference = UUID.randomUUID(),
+    val expectedGoal = aValidCreateGoalDto(
       title = createGoalRequest.title,
       reviewDate = createGoalRequest.reviewDate,
       status = GoalStatus.ACTIVE,
       notes = createGoalRequest.notes,
       steps = mutableListOf(expectedStep),
-      // JPA managed fields - expect these all to be null
-      createdAt = null,
-      createdBy = null,
-      createdByDisplayName = null,
-      lastUpdatedAt = null,
-      lastUpdatedBy = null,
-      lastUpdatedByDisplayName = null,
     )
 
     // When
-    val actual = mapper.fromModelToDomain(createGoalRequest)
+    val actual = mapper.fromModelToDomainDto(createGoalRequest)
 
     // Then
-    assertThat(actual).usingRecursiveComparison().ignoringFields("reference").isEqualTo(expectedGoal)
-    assertThat(actual.reference).isNotNull()
-    verify(stepMapper).fromModelToDomain(createStepRequest)
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expectedGoal)
+    verify(stepMapper).fromModelToDomainDto(createStepRequest)
   }
 
   @Test
@@ -85,7 +75,7 @@ internal class GoalResourceMapperTest {
     )
 
     val expectedStep = aValidStep()
-    given(stepMapper.fromModelToDomain(any<UpdateStepRequest>())).willReturn(expectedStep)
+    given(stepMapper.fromModelToDomain(any())).willReturn(expectedStep)
 
     val expectedGoal = aValidGoal(
       reference = updateGoalRequest.goalReference,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapperTest.kt
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.TargetDateRange
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateStepDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidStepResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateStepRequest
@@ -22,13 +23,13 @@ internal class StepResourceMapperTest {
   private lateinit var mapper: StepResourceMapperImpl
 
   @Test
-  fun `should map from CreateStepRequest model to domain`() {
+  fun `should map from CreateStepRequest model to domain DTO`() {
     // Given
     val createStepRequest = aValidCreateStepRequest(
       targetDateRange = TargetDateRangeApi.ZERO_TO_THREE_MONTHS,
     )
 
-    val expectedStep = aValidStep(
+    val expectedCreateStepDto = aValidCreateStepDto(
       title = createStepRequest.title,
       targetDateRange = TargetDateRange.ZERO_TO_THREE_MONTHS,
       status = StepStatus.NOT_STARTED,
@@ -36,11 +37,10 @@ internal class StepResourceMapperTest {
     )
 
     // When
-    val actual = mapper.fromModelToDomain(createStepRequest)
+    val actual = mapper.fromModelToDomainDto(createStepRequest)
 
     // Then
-    assertThat(actual).usingRecursiveComparison().ignoringFields("reference").isEqualTo(expectedStep)
-    assertThat(actual.reference).isNotNull()
+    assertThat(actual).isEqualTo(expectedCreateStepDto)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/StepResourceMapperTest.kt
@@ -23,7 +23,7 @@ internal class StepResourceMapperTest {
   private lateinit var mapper: StepResourceMapperImpl
 
   @Test
-  fun `should map from CreateStepRequest model to domain DTO`() {
+  fun `should map from CreateStepRequest model to DTO`() {
     // Given
     val createStepRequest = aValidCreateStepRequest(
       targetDateRange = TargetDateRangeApi.ZERO_TO_THREE_MONTHS,
@@ -37,7 +37,7 @@ internal class StepResourceMapperTest {
     )
 
     // When
-    val actual = mapper.fromModelToDomainDto(createStepRequest)
+    val actual = mapper.fromModelToDto(createStepRequest)
 
     // Then
     assertThat(actual).isEqualTo(expectedCreateStepDto)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityAssert.kt
@@ -163,4 +163,14 @@ class ActionPlanEntityAssert(actual: ActionPlanEntity?) :
     }
     return this
   }
+
+  fun hasAReference(): ActionPlanEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference == null) {
+        failWithMessage("Expected reference to be populated, but was $reference")
+      }
+    }
+    return this
+  }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityAssert.kt
@@ -171,6 +171,16 @@ class GoalEntityAssert(actual: GoalEntity?) :
     return this
   }
 
+  fun hasAReference(): GoalEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference == null) {
+        failWithMessage("Expected reference to be populated, but was $reference")
+      }
+    }
+    return this
+  }
+
   /**
    * Allows for assertion chaining into the specified child [StepEntity]. Takes a lambda as the method argument
    * to call assertion methods provided by [StepEntityAssert].

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/StepEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/StepEntityAssert.kt
@@ -138,6 +138,16 @@ class StepEntityAssert(actual: StepEntity?) :
     return this
   }
 
+  fun hasAReference(): StepEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference == null) {
+        failWithMessage("Expected reference to be populated, but was $reference")
+      }
+    }
+    return this
+  }
+
   fun hasSequenceNumber(expected: Int): StepEntityAssert {
     isNotNull
     with(actual!!) {


### PR DESCRIPTION
This PR refactors the way we create Action Plans and Goals to use a DTO instead of directly creating a Goal domain object which may have fields we cannot set at this point.

The follow up to this PR will be a very similar one that makes the same type of changes to the Update Goal process (so that we use a DTO). I decided not to do them both in the same PR as this PR is big enough already! 😬 

Once both creating and updating have been changed to use DTOs, then we can update the DTO, domain classes and entities and associated mappers, to map the prisonId from the request objects so that we record the prison ID on create and update 