### PR TITLE
RR-282 - Add Prison ID columns and map from create/update requests

### DIFF
--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateGoalDto.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateGoalDto.kt
@@ -8,6 +8,7 @@ import java.time.LocalDate
  */
 class CreateGoalDto(
   val title: String,
+  val prisonId: String,
   val reviewDate: LocalDate?,
   var status: GoalStatus = GoalStatus.ACTIVE,
   val notes: String? = null,

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/UpdateGoalDto.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/UpdateGoalDto.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 class UpdateGoalDto(
   val reference: UUID,
   val title: String,
+  val prisonId: String,
   val reviewDate: LocalDate?,
   var status: GoalStatus = GoalStatus.ACTIVE,
   val notes: String? = null,

--- a/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateGoalDtoBuilder.kt
+++ b/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/CreateGoalDtoBuilder.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 
 fun aValidCreateGoalDto(
   title: String = "Improve communication skills",
+  prisonId: String = "BXI",
   reviewDate: LocalDate? = null,
   steps: List<CreateStepDto> = listOf(aValidCreateStepDto(), anotherValidCreateStepDto()),
   status: GoalStatus = ACTIVE,
@@ -13,6 +14,7 @@ fun aValidCreateGoalDto(
 ): CreateGoalDto =
   CreateGoalDto(
     title = title,
+    prisonId = prisonId,
     reviewDate = reviewDate,
     steps = steps,
     status = status,

--- a/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/UpdateGoalDtoBuilder.kt
+++ b/domain/goal/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/dto/UpdateGoalDtoBuilder.kt
@@ -8,6 +8,7 @@ import java.util.UUID
 fun aValidUpdateGoalDto(
   reference: UUID = UUID.randomUUID(),
   title: String = "Improve communication skills",
+  prisonId: String = "BXI",
   reviewDate: LocalDate? = null,
   steps: List<UpdateStepDto> = listOf(aValidUpdateStepDto(), anotherValidUpdateStepDto()),
   status: GoalStatus = ACTIVE,
@@ -16,6 +17,7 @@ fun aValidUpdateGoalDto(
   UpdateGoalDto(
     reference = reference,
     title = title,
+    prisonId = prisonId,
     reviewDate = reviewDate,
     steps = steps,
     status = status,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -223,10 +223,12 @@ class CreateActionPlanTest : IntegrationTestBase() {
     assertThat(goal)
       .hasTitle(createGoalRequest.title)
       .hasNumberOfSteps(createGoalRequest.steps.size)
+      .wasCreatedAtPrison(createGoalRequest.prisonId)
       .wasCreatedBy(dpsUsername)
       .hasCreatedByDisplayName(displayName)
       .wasUpdatedBy(dpsUsername)
       .hasUpdatedByDisplayName(displayName)
+      .wasUpdatedAtPrison(createGoalRequest.prisonId)
     val step = goal.steps!![0]
     assertThat(step)
       .hasTitle(createStepRequest.title)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
@@ -139,8 +139,10 @@ class CreateGoalTest : IntegrationTestBase() {
     assertThat(goal)
       .hasTitle(createGoalRequest.title)
       .hasNumberOfSteps(createGoalRequest.steps.size)
+      .wasCreatedAtPrison(createGoalRequest.prisonId)
       .wasCreatedBy(dpsUsername)
       .hasCreatedByDisplayName(displayName)
+      .wasUpdatedAtPrison(createGoalRequest.prisonId)
       .wasUpdatedBy(dpsUsername)
       .hasUpdatedByDisplayName(displayName)
     val step = goal.steps!![0]

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -174,6 +174,8 @@ class UpdateGoalTest : IntegrationTestBase() {
               title = "Book course",
             ),
           ),
+          createdAtPrison = "BXI",
+          updatedAtPrison = "BXI",
         ),
       ),
     )
@@ -199,6 +201,7 @@ class UpdateGoalTest : IntegrationTestBase() {
           sequenceNumber = 2,
         ),
       ),
+      prisonId = "MDI",
     )
 
     TestTransaction.start()
@@ -228,6 +231,8 @@ class UpdateGoalTest : IntegrationTestBase() {
           .stepWithSequenceNumber(2) { step ->
             step.hasTitle("Attend course before March 2024")
           }
+          .wasCreatedAtPrison("BXI")
+          .wasUpdatedAtPrison("MDI")
       }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntity.kt
@@ -64,6 +64,10 @@ class GoalEntity(
   @CreationTimestamp
   var createdAt: Instant? = null,
 
+  @Column
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
   @Column(updatable = false)
   @CreatedBy
   var createdBy: String? = null,
@@ -75,6 +79,10 @@ class GoalEntity(
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
+
+  @Column
+  @field:NotNull
+  var updatedAtPrison: String? = null,
 
   @Column
   @LastModifiedBy

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapper.kt
@@ -29,6 +29,8 @@ abstract class GoalEntityMapper {
    */
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields
   @GenerateNewReference
+  @Mapping(target = "createdAtPrison", source = "prisonId")
+  @Mapping(target = "updatedAtPrison", source = "prisonId")
   abstract fun fromDtoToEntity(createGoalDto: CreateGoalDto): GoalEntity
 
   /**
@@ -45,6 +47,7 @@ abstract class GoalEntityMapper {
    */
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields
   @ExcludeReferenceField
+  @Mapping(target = "updatedAtPrison", source = "prisonId")
   @Mapping(target = "steps", expression = "java( updateSteps(goalEntity, updatedGoalDto) )")
   abstract fun updateEntityFromDto(@MappingTarget goalEntity: GoalEntity, updatedGoalDto: UpdateGoalDto)
 

--- a/src/main/resources/db/migration/V2023.09.06.0001__add_prison_id_fields_to_goal.sql
+++ b/src/main/resources/db/migration/V2023.09.06.0001__add_prison_id_fields_to_goal.sql
@@ -1,0 +1,8 @@
+ALTER TABLE goal ADD COLUMN created_at_prison VARCHAR(20);
+ALTER TABLE goal ADD COLUMN updated_at_prison VARCHAR(20);
+
+UPDATE goal SET created_at_prison = 'MDI';
+UPDATE goal SET updated_at_prison = 'MDI';
+
+ALTER TABLE goal ALTER COLUMN created_at_prison SET NOT NULL;
+ALTER TABLE goal ALTER COLUMN updated_at_prison SET NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperTest.kt
@@ -40,6 +40,7 @@ class GoalEntityMapperTest {
     val createStepDto = aValidCreateStepDto()
     val createGoalDto = aValidCreateGoalDto(
       title = "Improve communication skills",
+      prisonId = "BXI",
       reviewDate = reviewDate,
       status = DomainStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
@@ -55,6 +56,8 @@ class GoalEntityMapperTest {
       status = EntityStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = mutableListOf(expectedEntityStep),
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
       // JPA managed fields - expect these all to be null, implying a new db entity
       id = null,
       createdAt = null,
@@ -94,6 +97,8 @@ class GoalEntityMapperTest {
       status = EntityStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = mutableListOf(entityStep),
+      createdAtPrison = "BXI",
+      updatedAtPrison = "MDI",
       createdAt = createdAt,
       createdBy = "asmith_gen",
       createdByDisplayName = "Alex Smith",
@@ -113,9 +118,11 @@ class GoalEntityMapperTest {
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(domainStep),
       createdAt = createdAt,
+      // createdAtPrison = "BXI", TODO - RR-282
       createdBy = "asmith_gen",
       createdByDisplayName = "Alex Smith",
       lastUpdatedAt = updatedAt,
+      // updatedAtPrison = "MDI", TODO - RR-282
       lastUpdatedBy = "bjones_gen",
       lastUpdatedByDisplayName = "Barry Jones",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperUpdateEntityFromDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/GoalEntityMapperUpdateEntityFromDtoTest.kt
@@ -51,11 +51,14 @@ class GoalEntityMapperUpdateEntityFromDtoTest {
           sequenceNumber = 1,
         ),
       ),
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
     )
 
     val updateGoalDto = aValidUpdateGoalDto(
       reference = goalReference,
       title = "Improve communication skills within first 3 months",
+      prisonId = "MDI",
       reviewDate = LocalDate.now().plusMonths(3),
       status = uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.COMPLETED,
       notes = "Chris would like to improve his listening skills, not just his verbal communication; so that he can integrate with prison life",
@@ -75,6 +78,8 @@ class GoalEntityMapperUpdateEntityFromDtoTest {
       reviewDate = LocalDate.now().plusMonths(3)
       status = GoalStatus.COMPLETED
       notes = "Chris would like to improve his listening skills, not just his verbal communication; so that he can integrate with prison life"
+      createdAtPrison = "BXI"
+      updatedAtPrison = "MDI"
     }
 
     // When
@@ -104,11 +109,14 @@ class GoalEntityMapperUpdateEntityFromDtoTest {
       status = GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(stepEntity),
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
     )
 
     val updateGoalDto = aValidUpdateGoalDto(
       reference = goalReference,
       title = "Improve communication skills",
+      prisonId = "BXI",
       reviewDate = LocalDate.now().plusMonths(6),
       status = uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
@@ -163,12 +171,15 @@ class GoalEntityMapperUpdateEntityFromDtoTest {
       status = GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(step1Entity),
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
     )
 
     val updateGoalDto = aValidUpdateGoalDto(
       reference = goalReference,
       title = "Improve communication skills",
       reviewDate = LocalDate.now().plusMonths(6),
+      prisonId = "BXI",
       status = uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(
@@ -239,6 +250,8 @@ class GoalEntityMapperUpdateEntityFromDtoTest {
       status = GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(step1Entity, step2Entity),
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
     )
 
     val newStepReference = aValidReference()
@@ -246,6 +259,7 @@ class GoalEntityMapperUpdateEntityFromDtoTest {
     val updateGoalDto = aValidUpdateGoalDto(
       reference = goalReference,
       title = "Improve communication skills",
+      prisonId = "BXI",
       reviewDate = LocalDate.now().plusMonths(6),
       status = uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
@@ -328,11 +342,14 @@ class GoalEntityMapperUpdateEntityFromDtoTest {
       status = GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(step1Entity, step2Entity),
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
     )
 
     val updateGoalDto = aValidUpdateGoalDto(
       reference = goalReference,
       title = "Improve communication skills",
+      prisonId = "BXI",
       reviewDate = LocalDate.now().plusMonths(6),
       status = uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
@@ -407,11 +424,14 @@ class GoalEntityMapperUpdateEntityFromDtoTest {
       status = GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
       steps = listOf(step1Entity, step2Entity),
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
     )
 
     val updateGoalDto = aValidUpdateGoalDto(
       reference = goalReference,
       title = "Improve communication skills",
+      prisonId = "BXI",
       reviewDate = LocalDate.now().plusMonths(6),
       status = uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",
@@ -465,11 +485,14 @@ class GoalEntityMapperUpdateEntityFromDtoTest {
           sequenceNumber = 1,
         ),
       ),
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
     )
 
     val domainGoal = aValidUpdateGoalDto(
       reference = goalReference,
       title = "Improve communication skills",
+      prisonId = "BXI",
       reviewDate = LocalDate.now().plusMonths(6),
       status = uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus.ACTIVE,
       notes = "Chris would like to improve his listening skills, not just his verbal communication",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/GoalResourceMapperTest.kt
@@ -54,6 +54,7 @@ internal class GoalResourceMapperTest {
 
     val expectedGoal = aValidCreateGoalDto(
       title = createGoalRequest.title,
+      prisonId = createGoalRequest.prisonId,
       reviewDate = createGoalRequest.reviewDate,
       status = GoalStatus.ACTIVE,
       notes = createGoalRequest.notes,
@@ -84,6 +85,7 @@ internal class GoalResourceMapperTest {
     val expectedGoal = aValidUpdateGoalDto(
       reference = updateGoalRequest.goalReference,
       title = updateGoalRequest.title,
+      prisonId = updateGoalRequest.prisonId,
       reviewDate = updateGoalRequest.reviewDate,
       status = GoalStatus.ACTIVE,
       notes = updateGoalRequest.notes,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityAssert.kt
@@ -101,6 +101,16 @@ class GoalEntityAssert(actual: GoalEntity?) :
     return this
   }
 
+  fun wasCreatedAtPrison(expected: String): GoalEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
   fun wasUpdatedBy(expected: String): GoalEntityAssert {
     isNotNull
     with(actual!!) {
@@ -126,6 +136,16 @@ class GoalEntityAssert(actual: GoalEntity?) :
     with(actual!!) {
       if (updatedAt != expected) {
         failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): GoalEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/GoalEntityBuilder.kt
@@ -14,9 +14,11 @@ fun aValidGoalEntity(
   notes: String? = "Chris would like to improve his listening skills, not just his verbal communication",
   steps: List<StepEntity> = listOf(aValidStepEntity()),
   createdAt: Instant? = Instant.now(),
+  createdAtPrison: String = "BXI",
   createdBy: String? = "asmith_gen",
   createdByDisplayName: String? = "Alex Smith",
   updatedAt: Instant? = Instant.now(),
+  updatedAtPrison: String = "BXI",
   updatedBy: String? = "bjones_gen",
   updatedByDisplayName: String? = "Barry Jones",
 ): GoalEntity =
@@ -29,9 +31,11 @@ fun aValidGoalEntity(
     notes = notes,
     steps = steps.toMutableList(),
     createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
     createdBy = createdBy,
     createdByDisplayName = createdByDisplayName,
     updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
     updatedBy = updatedBy,
     updatedByDisplayName = updatedByDisplayName,
   )


### PR DESCRIPTION
This PR adds the columns `createdAtPrison` and `updatedAtPrison` to the `GoalEntity` and database table.

It also maps the values that are passed into relevant the create/update REST API endpoints through to the entity.

A subsequent PR will return these values in the `GoalResponse` object.