### PR TITLE
RR-308 - App Insights event for Updating a Goal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ ext["mapstruct.version"] = "1.5.5.Final"
 ext["postgresql.version"] = "42.6.0"
 ext["kotlin.logging.version"] = "3.0.5"
 ext["springdoc.openapi.version"] = "2.1.0"
+ext["awaitility.version"] = "4.2.0"
 
 allOpen {
   annotations(
@@ -69,6 +70,7 @@ dependencies {
   integrationTestImplementation("com.h2database:h2")
   integrationTestImplementation(testFixtures(project("domain:goal")))
   integrationTestImplementation(testFixtures(project("domain:timeline")))
+  testImplementation("org.awaitility:awaitility-kotlin:${property("awaitility.version")}")
 
   // Test fixtures dependencies
   testFixturesImplementation("org.assertj:assertj-core")

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -1,17 +1,28 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app
 
+import com.microsoft.applicationinsights.TelemetryClient
+import org.awaitility.Awaitility
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import java.security.KeyPair
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.TimeUnit.SECONDS
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("integration-test")
 abstract class IntegrationTestBase {
+
+  init {
+    // set awaitility defaults
+    Awaitility.setDefaultPollInterval(500, MILLISECONDS)
+    Awaitility.setDefaultTimeout(3, SECONDS)
+  }
 
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired
@@ -19,6 +30,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var actionPlanRepository: ActionPlanRepository
+
+  @SpyBean
+  lateinit var telemetryClient: TelemetryClient
 
   @Autowired
   lateinit var keyPair: KeyPair

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
+import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.context.transaction.TestTransaction
@@ -234,5 +236,12 @@ class UpdateGoalTest : IntegrationTestBase() {
           .wasCreatedAtPrison("BXI")
           .wasUpdatedAtPrison("MDI")
       }
+
+    val expectedEventCustomDimensions = mapOf(
+      "reference" to goalReference.toString(),
+    )
+    await.untilAsserted {
+      verify(telemetryClient).trackEvent("goal-update", expectedEventCustomDimensions, null)
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -60,6 +60,8 @@ class GoalController(
     goalService.updateGoal(
       prisonNumber = prisonNumber,
       updatedGoalDto = goalResourceMapper.fromModelToDto(updateGoalRequest),
-    )
+    ).apply {
+      telemetryService.trackGoalUpdateEvent(this)
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
@@ -15,12 +15,20 @@ class TelemetryService(
 
   companion object {
     private const val GOAL_CREATE_EVENT = "goal-create"
+    private const val GOAL_UPDATE_EVENT = "goal-update"
   }
 
   fun trackGoalCreateEvent(goal: Goal) {
     telemetryClient.trackEvent(
       GOAL_CREATE_EVENT,
       createEventCustomDimensions(goal),
+    )
+  }
+
+  fun trackGoalUpdateEvent(goal: Goal) {
+    telemetryClient.trackEvent(
+      GOAL_UPDATE_EVENT,
+      updateEventCustomDimensions(goal),
     )
   }
 
@@ -32,6 +40,16 @@ class TelemetryService(
       mapOf(
         "status" to status.name,
         "stepCount" to steps.size.toString(),
+        "reference" to reference.toString(),
+      )
+    }
+
+  /**
+   * Returns a map of data representing the custom dimensions for the `goal-update` event.
+   */
+  private fun updateEventCustomDimensions(goal: Goal): Map<String, String> =
+    with(goal) {
+      mapOf(
         "reference" to reference.toString(),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
@@ -47,4 +47,28 @@ class TelemetryServiceTest {
     // Then
     verify(telemetryClient).trackEvent("goal-create", expectedEventProperties)
   }
+
+  @Test
+  fun `should track update goal event`() {
+    // Given
+    val reference = UUID.randomUUID()
+    val status = GoalStatus.ACTIVE
+    val steps = listOf(aValidStep(), aValidStep(), aValidStep())
+
+    val goal = aValidGoal(
+      reference = reference,
+      status = status,
+      steps = steps,
+    )
+
+    val expectedEventProperties = mapOf(
+      "reference" to reference.toString(),
+    )
+
+    // When
+    telemetryService.trackGoalUpdateEvent(goal)
+
+    // Then
+    verify(telemetryClient).trackEvent("goal-update", expectedEventProperties)
+  }
 }


### PR DESCRIPTION
This PR adds the Update Goal event to the `TelemtryService` and wires it into the controller for the update goal request.

I've added awaitility, and added assertions that the events were sent in the relevant integration tests.
Strictly speaking there is no need for awaitility at this point as it is all synchronous, but my next PR will introduce an AOP aspect and an async `Future` or similar to send the events, rather than coupling it into the controller.