### PR TITLE
RR-308 - Decouple sending App Insights events from the controller

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
   implementation(project("domain:goal"))
   implementation(project("domain:timeline"))
 
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceDecorator.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceDecorator.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateGoalDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.UpdateGoalDto
+import java.util.UUID
+
+/**
+ * Interface defining a series of "before" and "after" methods to decorate the [GoalService] method behaviour with.
+ */
+interface GoalServiceDecorator {
+
+  /**
+   * Custom code invoked before a [Goal] is created.
+   */
+  fun beforeCreateGoal(prisonNumber: String, createGoalDto: CreateGoalDto)
+
+  /**
+   * Custom code invoked after a [Goal] is created.
+   */
+  fun afterCreateGoal(prisonNumber: String, createGoalDto: CreateGoalDto, createdGoal: Goal)
+
+  /**
+   * Custom code invoked before a [Goal] is returned.
+   */
+  fun beforeGetGoal(prisonNumber: String, goalReference: UUID)
+
+  /**
+   * Custom code invoked after a [Goal] is returned.
+   */
+  fun afterGetGoal(prisonNumber: String, goalReference: UUID, retrievedGoal: Goal)
+
+  /**
+   * Custom code invoked before a [Goal] is updated.
+   */
+  fun beforeUpdateGoal(prisonNumber: String, updatedGoalDto: UpdateGoalDto)
+
+  /**
+   * Custom code invoked after a [Goal] is updated.
+   */
+  fun afterUpdateGoal(prisonNumber: String, updatedGoalDto: UpdateGoalDto, updatedGoal: Goal)
+}
+
+/**
+ * Default No-op implementation of [GoalServiceDecorator], suitable to be overridden.
+ */
+open class NoopGoalServiceDecorator : GoalServiceDecorator {
+
+  override fun beforeCreateGoal(prisonNumber: String, createGoalDto: CreateGoalDto) {}
+
+  override fun afterCreateGoal(prisonNumber: String, createGoalDto: CreateGoalDto, createdGoal: Goal) {}
+
+  override fun beforeGetGoal(prisonNumber: String, goalReference: UUID) {}
+
+  override fun afterGetGoal(prisonNumber: String, goalReference: UUID, retrievedGoal: Goal) {}
+
+  override fun beforeUpdateGoal(prisonNumber: String, updatedGoalDto: UpdateGoalDto) {}
+
+  override fun afterUpdateGoal(prisonNumber: String, updatedGoalDto: UpdateGoalDto, updatedGoal: Goal) {}
+}

--- a/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
+++ b/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
@@ -2,11 +2,11 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
-import org.mockito.Mock
-import org.mockito.junit.jupiter.MockitoExtension
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
@@ -17,13 +17,18 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGo
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidCreateGoalDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidUpdateGoalDto
 
-@ExtendWith(MockitoExtension::class)
+@TestInstance(Lifecycle.PER_CLASS)
 class GoalServiceTest {
-  @InjectMocks
   private lateinit var service: GoalService
 
-  @Mock
-  private lateinit var persistenceAdapter: GoalPersistenceAdapter
+  private var persistenceAdapter: GoalPersistenceAdapter = mock()
+
+  private var goalServiceDecorator: GoalServiceDecorator = mock()
+
+  @BeforeAll
+  fun setupService() {
+    service = GoalService(persistenceAdapter, goalServiceDecorator)
+  }
 
   @Test
   fun `should create new goal for a prison number`() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalPersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalServiceDecorator
 
 /**
  * Configuration class responsible for providing domain bean implementations
@@ -16,8 +17,9 @@ class DomainConfiguration {
   @Bean
   fun goalDomainService(
     goalPersistenceAdapter: GoalPersistenceAdapter,
+    goalServiceDecorator: GoalServiceDecorator,
   ): GoalService =
-    GoalService(goalPersistenceAdapter)
+    GoalService(goalPersistenceAdapter, goalServiceDecorator)
 
   @Bean
   fun actionPlanDomainService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.GoalResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.GoalReferenceMatchesReferenceInUpdateGoalRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
@@ -26,7 +25,6 @@ import java.util.UUID
 class GoalController(
   private val goalService: GoalService,
   private val goalResourceMapper: GoalResourceMapper,
-  private val telemetryService: TelemetryService,
 ) {
 
   @PostMapping
@@ -41,9 +39,7 @@ class GoalController(
     goalService.createGoal(
       prisonNumber = prisonNumber,
       createGoalDto = goalResourceMapper.fromModelToDto(request),
-    ).apply {
-      telemetryService.trackGoalCreateEvent(this)
-    }
+    )
   }
 
   @PutMapping("{goalReference}")
@@ -60,8 +56,6 @@ class GoalController(
     goalService.updateGoal(
       prisonNumber = prisonNumber,
       updatedGoalDto = goalResourceMapper.fromModelToDto(updateGoalRequest),
-    ).apply {
-      telemetryService.trackGoalUpdateEvent(this)
-    }
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncGoalServiceDecorator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncGoalServiceDecorator.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateGoalDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.UpdateGoalDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalServiceDecorator
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.NoopGoalServiceDecorator
+
+/**
+ * Implementation of [GoalServiceDecorator] that decorates Goal Service methods with additional behaviours that are
+ * invoked asynchronously.
+ */
+@Component
+class AsyncGoalServiceDecorator(private val telemetryService: TelemetryService) : NoopGoalServiceDecorator() {
+
+  override fun afterCreateGoal(prisonNumber: String, createGoalDto: CreateGoalDto, createdGoal: Goal) {
+    runBlocking {
+      launch {
+        telemetryService.trackGoalCreateEvent(createdGoal)
+      }
+    }
+  }
+
+  override fun afterUpdateGoal(prisonNumber: String, updatedGoalDto: UpdateGoalDto, updatedGoal: Goal) {
+    runBlocking {
+      launch {
+        telemetryService.trackGoalUpdateEvent(updatedGoal)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/UpdateGoalRequestReferenceConstraintValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/UpdateGoalRequestReferenceConstraintValidatorTest.kt
@@ -15,7 +15,7 @@ class UpdateGoalRequestReferenceConstraintValidatorTest {
   private val validatorFactory = Validation.buildDefaultValidatorFactory()
   private val validator = validatorFactory.validator.forExecutables()
 
-  private val goalController = GoalController(mock(), mock(), mock())
+  private val goalController = GoalController(mock(), mock())
   private val updateGoalMethod = GoalController::class.java.getMethod(
     "updateGoal",
     UpdateGoalRequest::class.java,


### PR DESCRIPTION
This PR decouples sending App Insights events from the controller, and send them asynchronously

It does this by refactoring the `GoalService` so that it injects a `GoalServiceDecorator` instance, where the default implementation is a no-op impl. The decorator interface defines a "before" and "after" method for each service method.

In this PR a custom `GoalServiceDecorator` is implemented that calls the telemtry service methods to track events. It does this asynchronously using kotlin coroutines.