### PR TITLE
RR-308 - Decouple sending App Insights events from the controller, and send them asynchronously

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
   implementation(project("domain:goal"))
   implementation(project("domain:timeline"))
 
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalEventService.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalEventService.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+
+/**
+ * Interface defining a series of Goal lifecycle event methods.
+ */
+interface GoalEventService {
+
+  /**
+   * Implementations providing custom code for when a [Goal] is created.
+   */
+  fun goalCreated(createdGoal: Goal)
+
+  /**
+   * Implementations providing custom code for when a [Goal] is updated.
+   */
+  fun goalUpdated(updatedGoal: Goal)
+}

--- a/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
+++ b/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalNotFoundException
@@ -24,6 +25,9 @@ class GoalServiceTest {
 
   @Mock
   private lateinit var persistenceAdapter: GoalPersistenceAdapter
+
+  @Mock
+  private lateinit var goalEventService: GoalEventService
 
   @Test
   fun `should create new goal for a prison number`() {
@@ -41,6 +45,7 @@ class GoalServiceTest {
     // Then
     assertThat(actual).isEqualTo(goal)
     verify(persistenceAdapter).createGoal(prisonNumber, createGoalDto)
+    verify(goalEventService).goalCreated(actual)
   }
 
   @Test
@@ -98,6 +103,7 @@ class GoalServiceTest {
     // Then
     assertThat(actual).isEqualTo(goal)
     verify(persistenceAdapter).updateGoal(prisonNumber, updatedGoal)
+    verify(goalEventService).goalUpdated(actual)
   }
 
   @Test
@@ -121,5 +127,6 @@ class GoalServiceTest {
     assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
     assertThat(exception.goalReference).isEqualTo(goalReference)
     verify(persistenceAdapter).updateGoal(prisonNumber, updatedGoal)
+    verifyNoInteractions(goalEventService)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanPersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalEventService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalPersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalService
 
@@ -16,8 +17,9 @@ class DomainConfiguration {
   @Bean
   fun goalDomainService(
     goalPersistenceAdapter: GoalPersistenceAdapter,
+    goalEventService: GoalEventService,
   ): GoalService =
-    GoalService(goalPersistenceAdapter)
+    GoalService(goalPersistenceAdapter, goalEventService)
 
   @Bean
   fun actionPlanDomainService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.GoalResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.GoalReferenceMatchesReferenceInUpdateGoalRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
@@ -26,7 +25,6 @@ import java.util.UUID
 class GoalController(
   private val goalService: GoalService,
   private val goalResourceMapper: GoalResourceMapper,
-  private val telemetryService: TelemetryService,
 ) {
 
   @PostMapping
@@ -41,9 +39,7 @@ class GoalController(
     goalService.createGoal(
       prisonNumber = prisonNumber,
       createGoalDto = goalResourceMapper.fromModelToDto(request),
-    ).apply {
-      telemetryService.trackGoalCreateEvent(this)
-    }
+    )
   }
 
   @PutMapping("{goalReference}")
@@ -60,8 +56,6 @@ class GoalController(
     goalService.updateGoal(
       prisonNumber = prisonNumber,
       updatedGoalDto = goalResourceMapper.fromModelToDto(updateGoalRequest),
-    ).apply {
-      telemetryService.trackGoalUpdateEvent(this)
-    }
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncGoalEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncGoalEventService.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalEventService
+
+/**
+ * Implementation of [GoalEventService] that decorates Goal Service methods with additional behaviours that are
+ * invoked asynchronously.
+ */
+@Component
+class AsyncGoalEventService(private val telemetryService: TelemetryService) : GoalEventService {
+
+  override fun goalCreated(createdGoal: Goal) {
+    runBlocking {
+      launch {
+        telemetryService.trackGoalCreateEvent(createdGoal)
+      }
+    }
+  }
+
+  override fun goalUpdated(updatedGoal: Goal) {
+    runBlocking {
+      launch {
+        telemetryService.trackGoalUpdateEvent(updatedGoal)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/UpdateGoalRequestReferenceConstraintValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/UpdateGoalRequestReferenceConstraintValidatorTest.kt
@@ -15,7 +15,7 @@ class UpdateGoalRequestReferenceConstraintValidatorTest {
   private val validatorFactory = Validation.buildDefaultValidatorFactory()
   private val validator = validatorFactory.validator.forExecutables()
 
-  private val goalController = GoalController(mock(), mock(), mock())
+  private val goalController = GoalController(mock(), mock())
   private val updateGoalMethod = GoalController::class.java.getMethod(
     "updateGoal",
     UpdateGoalRequest::class.java,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncGoalEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncGoalEventServiceTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
+
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
+
+@ExtendWith(MockitoExtension::class)
+class AsyncGoalEventServiceTest {
+
+  @InjectMocks
+  private lateinit var goalEventService: AsyncGoalEventService
+
+  @Mock
+  private lateinit var telemetryService: TelemetryService
+
+  @Test
+  fun `should send app insights telemetry event given goal created`() {
+    // Given
+    val createdGoal = aValidGoal()
+
+    // When
+    goalEventService.goalCreated(createdGoal)
+
+    // Then
+    await.untilAsserted {
+      verify(telemetryService).trackGoalCreateEvent(createdGoal)
+    }
+  }
+
+  @Test
+  fun `should send app insights telemetry event given goal updated`() {
+    // Given
+    val updatedGoal = aValidGoal()
+
+    // When
+    goalEventService.goalUpdated(updatedGoal)
+
+    // Then
+    await.untilAsserted {
+      verify(telemetryService).trackGoalUpdateEvent(updatedGoal)
+    }
+  }
+}


### PR DESCRIPTION
This PR decouples sending App Insights events from the controller, and send them asynchronously

It does this by creating an interface `GoalEventService` which defines methods that allow the application to decorate the core service events for creating and updating Goals