### PR TITLE
RR-317 - Database, entity and mappers for persisting Timeline events

### DIFF
--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/Timeline.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/Timeline.kt
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline
 
+import java.util.UUID
+
 /**
  * A Timeline is sequenced list of [TimelineEvent]s for a given prisoner. The list can be empty, representing an empty
  * timeline for the prisoner.
  */
 class Timeline(
+  val reference: UUID,
   val prisonNumber: String,
   events: List<TimelineEvent> = emptyList(),
 ) {

--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimelineNotFoundException.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimelineNotFoundException.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline
+
+/**
+ * Thrown when a Timeline does not exist for a given Prisoner.
+ */
+class TimelineNotFoundException(val prisonNumber: String) :
+  RuntimeException("Timeline not found for prisoner [$prisonNumber]")

--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelinePersistenceAdapter.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelinePersistenceAdapter.kt
@@ -4,11 +4,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Time
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
 
 /**
- * Persistence Adapter for [Timeline] instances
+ * Persistence Adapter for [Timeline] instances.
  *
- * Implementations should use the underlying persistence of the application in question, eg: JPA, Mongo, Dynamo, Redis etc
+ * Implementations should use the underlying persistence of the application in question, eg: JPA, Mongo, Dynamo,
+ * Redis etc.
  *
- * Implementations should not throw exceptions. These are not part of the interface and are not checked or handled by
+ * Implementations should not throw exceptions. These are not part of the interface and are not checked or handled by.
  * [TimelineService].
  */
 interface TimelinePersistenceAdapter {
@@ -16,18 +17,22 @@ interface TimelinePersistenceAdapter {
   /**
    * Records an [TimelineEvent] that has taken place for a prisoner. Creates a new Timeline for the prisoner if it does
    * not already exist.
+   *
+   * @return The [TimelineEvent] with any newly generated values (if applicable).
    */
-  fun recordTimelineEvent(prisonNumber: String, event: TimelineEvent)
+  fun recordTimelineEvent(prisonNumber: String, event: TimelineEvent): TimelineEvent
 
   /**
    * Records multiple [TimelineEvent]s that have taken place for a prisoner. Creates a new Timeline for the prisoner if
    * it does not already exist.
+   *
+   * @return The updated [Timeline] containing all its events.
    */
-  fun recordTimelineEvents(prisonNumber: String, events: List<TimelineEvent>)
+  fun recordTimelineEvents(prisonNumber: String, events: List<TimelineEvent>): Timeline
 
   /**
-   * Find and return the [TimelineEvent]s for the prisoner identified by their prison number.
-   * Returns an empty collection if there are no TimelineEvents for the specified prisoner.
+   * Finds and returns the [Timeline] for the prisoner identified by their prison number.
+   * Returns null if the prisoner does not have a [Timeline] (i.e. no [TimelineEvent]s recorded).
    */
-  fun getTimelineEventsForPrisoner(prisonNumber: String): List<TimelineEvent>
+  fun getTimelineForPrisoner(prisonNumber: String): Timeline?
 }

--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineService.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.ser
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Timeline
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineNotFoundException
 
 /**
  * Service class exposing methods that implement the business rules for the Timeline domain, and is how applications
@@ -30,8 +31,9 @@ class TimelineService(
     persistenceAdapter.recordTimelineEvents(prisonNumber, events)
 
   /**
-   * Returns the [Timeline] for the prisoner identified by their prison number.
+   * Returns the [Timeline] for the prisoner identified by their prison number. Otherwise, throws
+   * [TimelineNotFoundException] if it cannot be found.
    */
-  fun getTimelineForPrisoner(prisonNumber: String): Timeline? =
-    persistenceAdapter.getTimelineForPrisoner(prisonNumber)
+  fun getTimelineForPrisoner(prisonNumber: String): Timeline =
+    persistenceAdapter.getTimelineForPrisoner(prisonNumber) ?: throw TimelineNotFoundException(prisonNumber)
 }

--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineService.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineService.kt
@@ -20,22 +20,18 @@ class TimelineService(
   /**
    * Records an [TimelineEvent] that has taken place for a prisoner.
    */
-  fun recordTimelineEvent(prisonNumber: String, event: TimelineEvent) {
+  fun recordTimelineEvent(prisonNumber: String, event: TimelineEvent) =
     persistenceAdapter.recordTimelineEvent(prisonNumber, event)
-  }
 
   /**
    * Records a collection of [TimelineEvent]s that have taken place for a prisoner.
    */
-  fun recordTimelineEvents(prisonNumber: String, events: List<TimelineEvent>) {
+  fun recordTimelineEvents(prisonNumber: String, events: List<TimelineEvent>) =
     persistenceAdapter.recordTimelineEvents(prisonNumber, events)
-  }
 
   /**
    * Returns the [Timeline] for the prisoner identified by their prison number.
    */
-  fun getTimelineForPrisoner(prisonNumber: String): Timeline {
-    val timelineEvents = persistenceAdapter.getTimelineEventsForPrisoner(prisonNumber)
-    return Timeline(prisonNumber, timelineEvents)
-  }
+  fun getTimelineForPrisoner(prisonNumber: String): Timeline? =
+    persistenceAdapter.getTimelineForPrisoner(prisonNumber)
 }

--- a/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimelineTest.kt
+++ b/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimelineTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.util.UUID
 
 class TimelineTest {
 
@@ -26,10 +27,11 @@ class TimelineTest {
   @Test
   fun `should create timeline given events out of sequence`() {
     // Given
+    val reference = UUID.randomUUID()
     val events = listOf(middleEvent, earliestEvent, latestEvent)
 
     // When
-    val actual = Timeline(prisonNumber, events)
+    val actual = Timeline(reference = reference, prisonNumber = prisonNumber, events = events)
 
     // Then
     assertThat(actual.events).containsExactly(
@@ -42,8 +44,9 @@ class TimelineTest {
   @Test
   fun `should add event and maintain event order`() {
     // Given
+    val reference = UUID.randomUUID()
     val initialEvents = listOf(earliestEvent, latestEvent)
-    val timeline = Timeline(prisonNumber, initialEvents)
+    val timeline = Timeline(reference = reference, prisonNumber = prisonNumber, events = initialEvents)
 
     // When
     timeline.addEvent(middleEvent)

--- a/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
+++ b/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
@@ -8,12 +8,9 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Timeline
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEventType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimeline
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimelineEvent
-import java.time.Instant
 
 @ExtendWith(MockitoExtension::class)
 class TimelineServiceTest {
@@ -26,19 +23,6 @@ class TimelineServiceTest {
 
   companion object {
     private const val prisonNumber = "A1234AB"
-
-    private val earliestEvent = aValidTimelineEvent(
-      eventType = TimelineEventType.ACTION_PLAN_CREATED,
-      timestamp = Instant.MIN,
-    )
-    private val middleEvent = aValidTimelineEvent(
-      eventType = TimelineEventType.GOAL_CREATED,
-      timestamp = Instant.now(),
-    )
-    private val latestEvent = aValidTimelineEvent(
-      eventType = TimelineEventType.STEP_STARTED,
-      timestamp = Instant.MAX,
-    )
   }
 
   @Test
@@ -56,7 +40,7 @@ class TimelineServiceTest {
   @Test
   fun `should record timeline events`() {
     // Given
-    val timelineEvents = listOf(earliestEvent, middleEvent, latestEvent)
+    val timelineEvents = listOf(aValidTimelineEvent(), aValidTimelineEvent())
 
     // When
     service.recordTimelineEvents(prisonNumber, timelineEvents)
@@ -68,27 +52,14 @@ class TimelineServiceTest {
   @Test
   fun `should get timeline for prisoner`() {
     // Given
-    given(persistenceAdapter.getTimelineEventsForPrisoner(any())).willReturn(
-      listOf(
-        earliestEvent,
-        middleEvent,
-        latestEvent,
-      ),
-    )
+    val expected = aValidTimeline()
+    given(persistenceAdapter.getTimelineForPrisoner(any())).willReturn(expected)
 
-    val expected = Timeline(
-      prisonNumber,
-      listOf(
-        earliestEvent,
-        middleEvent,
-        latestEvent,
-      ),
-    )
     // When
     val actual = service.getTimelineForPrisoner(prisonNumber)
 
     // Then
-    assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
-    verify(persistenceAdapter).getTimelineEventsForPrisoner(prisonNumber)
+    assertThat(actual).isEqualTo(expected)
+    verify(persistenceAdapter).getTimelineForPrisoner(prisonNumber)
   }
 }

--- a/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
+++ b/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowableOfType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -9,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineNotFoundException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimeline
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimelineEvent
 
@@ -60,6 +62,24 @@ class TimelineServiceTest {
 
     // Then
     assertThat(actual).isEqualTo(expected)
+    verify(persistenceAdapter).getTimelineForPrisoner(prisonNumber)
+  }
+
+  @Test
+  fun `should fail to get timeline for prisoner given timeline does not exist`() {
+    // Given
+    val prisonNumber = "A1234AB"
+    given(persistenceAdapter.getTimelineForPrisoner(any())).willReturn(null)
+
+    // When
+    val exception = catchThrowableOfType(
+      { service.getTimelineForPrisoner(Companion.prisonNumber) },
+      TimelineNotFoundException::class.java,
+    )
+
+    // Then
+    assertThat(exception).hasMessage("Timeline not found for prisoner [$prisonNumber]")
+    assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
     verify(persistenceAdapter).getTimelineForPrisoner(prisonNumber)
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -10,6 +10,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.TimelineRepository
 import java.security.KeyPair
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS
@@ -31,6 +32,9 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var actionPlanRepository: ActionPlanRepository
 
+  @Autowired
+  lateinit var timelineRepository: TimelineRepository
+
   @SpyBean
   lateinit var telemetryClient: TelemetryClient
 
@@ -40,5 +44,6 @@ abstract class IntegrationTestBase {
   @BeforeEach
   fun clearDatabase() {
     actionPlanRepository.deleteAll() // Will also remove all Goals and Steps due to cascade
+    timelineRepository.deleteAll() // Will also remove all TimelineEvents due to cascade
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -246,6 +246,8 @@ class CreateActionPlanTest : IntegrationTestBase() {
     assertThat(events.size).isEqualTo(1)
     assertThat(events[0].eventType).isEqualTo(TimelineEventType.ACTION_PLAN_CREATED)
     assertThat(events[0].sourceReference).isEqualTo(actionPlan.reference.toString())
+    assertThat(events[0]).hasAReference()
+    assertThat(events[0]).hasJpaManagedFieldsPopulated()
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
@@ -12,6 +13,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditA
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -235,6 +237,15 @@ class CreateActionPlanTest : IntegrationTestBase() {
       .hasTargetDateRange(TargetDateRangeEntity.ZERO_TO_THREE_MONTHS)
       .hasStatus(StepStatus.NOT_STARTED)
       .wasCreatedBy(dpsUsername)
+
+    // TODO RR-319 - Add custom assertions once the GET Timeline endpoint is in place
+    // assert timeline event is created successfully
+    val prisonerTimeline = timelineRepository.findByPrisonNumber(prisonNumber)!!
+    assertThat(prisonerTimeline.prisonNumber).isEqualTo(prisonNumber)
+    val events = prisonerTimeline.events!!
+    assertThat(events.size).isEqualTo(1)
+    assertThat(events[0].eventType).isEqualTo(TimelineEventType.ACTION_PLAN_CREATED)
+    assertThat(events[0].sourceReference).isEqualTo(actionPlan.reference.toString())
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditA
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.StepStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -162,6 +163,15 @@ class CreateGoalTest : IntegrationTestBase() {
     await.untilAsserted {
       verify(telemetryClient).trackEvent("goal-create", expectedEventCustomDimensions, null)
     }
+
+    // TODO RR-319 - Add custom assertions once the GET Timeline endpoint is in place
+    // assert timeline event is created successfully
+    val prisonerTimeline = timelineRepository.findByPrisonNumber(prisonNumber)!!
+    assertThat(prisonerTimeline.prisonNumber).isEqualTo(prisonNumber)
+    val events = prisonerTimeline.events!!
+    assertThat(events.size).isEqualTo(1)
+    assertThat(events[0].eventType).isEqualTo(TimelineEventType.ACTION_PLAN_CREATED)
+    assertThat(events[0].sourceReference).isEqualTo(actionPlan.reference.toString())
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
@@ -172,6 +172,8 @@ class CreateGoalTest : IntegrationTestBase() {
     assertThat(events.size).isEqualTo(1)
     assertThat(events[0].eventType).isEqualTo(TimelineEventType.ACTION_PLAN_CREATED)
     assertThat(events[0].sourceReference).isEqualTo(actionPlan.reference.toString())
+    assertThat(events[0]).hasAReference()
+    assertThat(events[0]).hasJpaManagedFieldsPopulated()
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
+import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.verify
@@ -12,6 +13,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidGoalEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidStepEntity
@@ -243,5 +245,18 @@ class UpdateGoalTest : IntegrationTestBase() {
     await.untilAsserted {
       verify(telemetryClient).trackEvent("goal-update", expectedEventCustomDimensions, null)
     }
+
+    // TODO RR-319 - Add custom assertions once the GET Timeline endpoint is in place
+    // assert timeline events are created successfully
+    val prisonerTimeline = timelineRepository.findByPrisonNumber(prisonNumber)!!
+    assertThat(prisonerTimeline.prisonNumber).isEqualTo(prisonNumber)
+    val events = prisonerTimeline.events!!
+    assertThat(events.size).isEqualTo(3)
+    assertThat(events[0].eventType).isEqualTo(TimelineEventType.GOAL_UPDATED)
+    assertThat(events[0].sourceReference).isEqualTo(goalReference.toString())
+    assertThat(events[1].eventType).isEqualTo(TimelineEventType.STEP_UPDATED)
+    assertThat(events[1].sourceReference).isEqualTo(stepReference.toString())
+    assertThat(events[2].eventType).isEqualTo(TimelineEventType.STEP_STARTED)
+    assertThat(events[2].sourceReference).isEqualTo(stepReference.toString())
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -254,9 +254,15 @@ class UpdateGoalTest : IntegrationTestBase() {
     assertThat(events.size).isEqualTo(3)
     assertThat(events[0].eventType).isEqualTo(TimelineEventType.GOAL_UPDATED)
     assertThat(events[0].sourceReference).isEqualTo(goalReference.toString())
+    assertThat(events[0]).hasAReference()
+    assertThat(events[0]).hasJpaManagedFieldsPopulated()
     assertThat(events[1].eventType).isEqualTo(TimelineEventType.STEP_UPDATED)
     assertThat(events[1].sourceReference).isEqualTo(stepReference.toString())
+    assertThat(events[1]).hasAReference()
+    assertThat(events[1]).hasJpaManagedFieldsPopulated()
     assertThat(events[2].eventType).isEqualTo(TimelineEventType.STEP_STARTED)
     assertThat(events[2].sourceReference).isEqualTo(stepReference.toString())
+    assertThat(events[2]).hasAReference()
+    assertThat(events[2]).hasJpaManagedFieldsPopulated()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -21,8 +21,10 @@ class DomainConfiguration {
   fun goalDomainService(
     goalPersistenceAdapter: GoalPersistenceAdapter,
     goalEventService: GoalEventService,
+    actionPlanPersistenceAdapter: ActionPlanPersistenceAdapter,
+    actionPlanEventService: ActionPlanEventService,
   ): GoalService =
-    GoalService(goalPersistenceAdapter, goalEventService)
+    GoalService(goalPersistenceAdapter, goalEventService, actionPlanPersistenceAdapter, actionPlanEventService)
 
   @Bean
   fun actionPlanDomainService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaTimelinePersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaTimelinePersistenceAdapter.kt
@@ -3,6 +3,12 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TimelineEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TimelineEntity.Companion.newTimelineForPrisoner
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.TimelineEntityMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.TimelineEventEntityMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.TimelineRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Timeline
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelinePersistenceAdapter
 
@@ -10,26 +16,55 @@ private val log = KotlinLogging.logger {}
 
 @Component
 class JpaTimelinePersistenceAdapter(
-  // private val timelineRepository: TimelineRepository,
-  // private val timelineMapper: TimelineEntityMapper,
+  private val timelineRepository: TimelineRepository,
+  private val timelineMapper: TimelineEntityMapper,
+  private val timelineEventMapper: TimelineEventEntityMapper,
 ) : TimelinePersistenceAdapter {
 
   @Transactional
-  override fun recordTimelineEvent(prisonNumber: String, event: TimelineEvent) {
+  override fun recordTimelineEvent(prisonNumber: String, event: TimelineEvent): TimelineEvent {
     log.info { "Recording TimelineEvent [$event] for prisoner [$prisonNumber]" }
-    // TODO RR-317
+
+    val timelineEntity = findOrCreateTimelineEntity(prisonNumber)
+    val timelineEventEntity = timelineEventMapper.fromDomainToEntity(event)
+
+    with(timelineEntity) {
+      addEvent(timelineEventEntity)
+      timelineRepository.saveAndFlush(this)
+    }
+
+    // use the persisted entity with the populated JPA fields, rather than the non persisted entity reference above
+    val persisted = timelineEntity.events!!.first { it.reference == timelineEventEntity.reference }
+    return timelineEventMapper.fromEntityToDomain(persisted)
   }
 
   @Transactional
-  override fun recordTimelineEvents(prisonNumber: String, events: List<TimelineEvent>) {
+  override fun recordTimelineEvents(prisonNumber: String, events: List<TimelineEvent>): Timeline {
     log.info { "Recording [${events.size}] TimelineEvents for prisoner [$prisonNumber]" }
-    // TODO RR-317
+
+    val timelineEntity = findOrCreateTimelineEntity(prisonNumber)
+    events.forEach {
+      timelineEntity.addEvent(timelineEventMapper.fromDomainToEntity(it))
+    }
+
+    timelineRepository.saveAndFlush(timelineEntity)
+    return timelineMapper.fromEntityToDomain(timelineEntity)
   }
 
   @Transactional
-  override fun getTimelineEventsForPrisoner(prisonNumber: String): List<TimelineEvent> {
-    log.info { "Getting TimelineEvents for prisoner [$prisonNumber]" }
-    return emptyList()
-    // TODO RR-317
+  override fun getTimelineForPrisoner(prisonNumber: String): Timeline? {
+    log.info { "Getting Timeline for prisoner [$prisonNumber]" }
+
+    val timelineEntity = timelineRepository.findByPrisonNumber(prisonNumber)
+    return if (timelineEntity != null) timelineMapper.fromEntityToDomain(timelineEntity) else null
+  }
+
+  private fun findOrCreateTimelineEntity(prisonNumber: String): TimelineEntity {
+    var timelineEntity = timelineRepository.findByPrisonNumber(prisonNumber)
+    if (timelineEntity == null) {
+      log.info { "Creating new Timeline for prisoner [$prisonNumber]" }
+      timelineEntity = newTimelineForPrisoner(prisonNumber)
+    }
+    return timelineEntity
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEntity.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.en
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.EntityListeners
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
@@ -16,17 +15,12 @@ import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
-import org.springframework.data.annotation.CreatedBy
-import org.springframework.data.annotation.LastModifiedBy
-import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
-import java.time.LocalDate
 import java.util.UUID
 
-@Table(name = "action_plan")
+@Table(name = "timeline")
 @Entity
-@EntityListeners(AuditingEntityListener::class)
-class ActionPlanEntity(
+class TimelineEntity(
   @Id
   @GeneratedValue
   @UuidGenerator
@@ -38,67 +32,46 @@ class ActionPlanEntity(
 
   @Column(updatable = false)
   @field:NotNull
-  var prisonNumber: String? = null,
-
-  @Column
-  var reviewDate: LocalDate? = null,
+  var prisonNumber: String,
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "action_plan_id", nullable = false)
+  @JoinColumn(name = "timeline_id", nullable = false)
   @OrderBy(value = "createdAt")
   @field:NotNull
-  var goals: MutableList<GoalEntity>? = null,
+  var events: MutableList<TimelineEventEntity>? = null,
 
   @Column(updatable = false)
   @CreationTimestamp
   var createdAt: Instant? = null,
 
-  @Column(updatable = false)
-  @CreatedBy
-  var createdBy: String? = null,
-
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
-
-  @Column
-  @LastModifiedBy
-  var updatedBy: String? = null,
 ) {
 
   companion object {
 
     /**
-     * Returns new un-persisted [ActionPlanEntity] for the specified prisoner with an empty collection of [GoalEntity]s
+     * Returns new un-persisted [TimelineEntity] for the specified prisoner with an empty collection of
+     * [TimelineEventEntity]s.
      */
-    fun newActionPlanForPrisoner(prisonNumber: String, reviewDate: LocalDate?): ActionPlanEntity =
-      ActionPlanEntity(
+    fun newTimelineForPrisoner(prisonNumber: String): TimelineEntity =
+      TimelineEntity(
         reference = UUID.randomUUID(),
         prisonNumber = prisonNumber,
-        reviewDate = reviewDate,
-        goals = mutableListOf(),
+        events = mutableListOf(),
       )
   }
 
-  /**
-   * Returns the [GoalEntity] identified by its reference from this [ActionPlanEntity] instance.
-   * Returns null if the Goal Entity cannot be found.
-   */
-  fun getGoalByReference(goalReference: UUID): GoalEntity? =
-    goals?.find { it.reference == goalReference }
-
-  /**
-   * Adds a [GoalEntity] to this [ActionPlanEntity]
-   */
-  fun addGoal(goalEntity: GoalEntity): ActionPlanEntity {
-    goals!!.add(goalEntity)
+  fun addEvent(timelineEvent: TimelineEventEntity): TimelineEntity {
+    events!!.add(timelineEvent)
     return this
   }
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-    other as ActionPlanEntity
+    other as TimelineEntity
 
     return id != null && id == other.id
   }
@@ -106,6 +79,6 @@ class ActionPlanEntity(
   override fun hashCode(): Int = javaClass.hashCode()
 
   override fun toString(): String {
-    return this::class.simpleName + "(id = $id, prisonNumber = $prisonNumber)"
+    return this::class.simpleName + "(id = $id, reference = $reference, prisonNumber = $prisonNumber)"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEventEntity.kt
@@ -1,0 +1,101 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import org.hibernate.Hibernate
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UuidGenerator
+import java.time.Instant
+import java.util.UUID
+
+@Table(name = "timeline_event")
+@Entity
+class TimelineEventEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var sourceReference: String? = null,
+
+  @Column(updatable = false)
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var eventType: TimelineEventType? = null,
+
+  @Column(updatable = false)
+  var contextualInfo: String? = null,
+
+  /**
+   * The ID of the prison that the event relates to.
+   */
+  @Column(updatable = false)
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
+  /**
+   * Username of the person who created the original event (not to be confused with who/what saved this entity)
+   */
+  @Column(updatable = false)
+  @field:NotNull
+  var createdBy: String? = null,
+
+  /**
+   * Name of the person who created the original event (not to be confused with who/what saved this entity)
+   */
+  @Column(updatable = false)
+  var createdByDisplayName: String? = null,
+
+  /**
+   * The timestamp of the original event (not when this entity was saved to the DB - see createdAt).
+   */
+  @Column(updatable = false)
+  @field:NotNull
+  var timestamp: Instant? = null,
+
+  /**
+   * The timestamp that this entity was created.
+   */
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as TimelineEventEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, sourceReference = $sourceReference, eventType = $eventType)"
+  }
+}
+
+enum class TimelineEventType {
+  ACTION_PLAN_CREATED,
+  GOAL_CREATED,
+  GOAL_UPDATED,
+  GOAL_STARTED,
+  GOAL_COMPLETED,
+  GOAL_ARCHIVED,
+  STEP_UPDATED,
+  STEP_NOT_STARTED,
+  STEP_STARTED,
+  STEP_COMPLETED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/TimelineEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/TimelineEntityMapper.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper
+
+import org.mapstruct.Mapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TimelineEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Timeline
+
+@Mapper(
+  uses = [
+    TimelineEventEntityMapper::class,
+  ],
+)
+interface TimelineEntityMapper {
+  fun fromEntityToDomain(persisted: TimelineEntity): Timeline
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/TimelineEventEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/TimelineEventEntityMapper.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper
+
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TimelineEventEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
+
+@Mapper
+interface TimelineEventEntityMapper {
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "createdAtPrison", source = "prisonId")
+  fun fromDomainToEntity(timelineEvent: TimelineEvent): TimelineEventEntity
+
+  @Mapping(target = "prisonId", source = "createdAtPrison")
+  fun fromEntityToDomain(persisted: TimelineEventEntity): TimelineEvent
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/TimelineRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/TimelineRepository.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TimelineEntity
+import java.util.UUID
+
+@Repository
+interface TimelineRepository : JpaRepository<TimelineEntity, UUID> {
+  fun findByPrisonNumber(prisonNumber: String): TimelineEntity?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GlobalExceptionHandler.kt
@@ -24,6 +24,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanAlreadyExistsException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalNotFoundException
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineNotFoundException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 
 private val log = KotlinLogging.logger {}
@@ -105,6 +106,7 @@ class GlobalExceptionHandler(
     value = [
       ActionPlanNotFoundException::class,
       GoalNotFoundException::class,
+      TimelineNotFoundException::class,
     ],
   )
   fun handleExceptionReturnNotFoundErrorResponse(

--- a/src/main/resources/db/migration/V2023.09.13.0001__add_timeline_related_tables.sql
+++ b/src/main/resources/db/migration/V2023.09.13.0001__add_timeline_related_tables.sql
@@ -1,0 +1,47 @@
+--- Table timeline
+CREATE TABLE timeline
+(
+    id            UUID  PRIMARY KEY,
+    reference     UUID  NOT NULL,
+    prison_number VARCHAR(10) NOT NULL,
+    created_at    TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_at    TIMESTAMP(3) WITH TIME ZONE NOT NULL
+);
+
+CREATE UNIQUE INDEX timeline_prison_number_idx ON timeline
+(
+    prison_number
+);
+
+CREATE UNIQUE INDEX timeline_reference_idx ON timeline
+(
+     reference
+);
+
+
+--- Table timeline_event
+CREATE TABLE timeline_event
+(
+    id                      UUID  PRIMARY KEY,
+    reference               UUID  NOT NULL,
+    timeline_id             UUID  NOT NULL,
+    source_reference        VARCHAR(50)  NOT NULL,
+    event_type              VARCHAR(50)  NOT NULL,
+    contextual_info         VARCHAR(512) NOT NULL,
+    created_by              VARCHAR(50)  NOT NULL,
+    created_by_display_name VARCHAR(100) NOT NULL,
+    timestamp               TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_at_prison       VARCHAR(3)  NOT NULL,
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+
+    CONSTRAINT fk_timeline_timeline_event FOREIGN KEY (timeline_id) REFERENCES timeline(id)
+);
+
+CREATE UNIQUE INDEX timeline_event_reference_idx ON timeline_event
+(
+    reference
+);
+CREATE INDEX timeline_event_timeline_id_idx ON timeline_event
+(
+    timeline_id
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaTimelinePersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaTimelinePersistenceAdapterTest.kt
@@ -1,0 +1,180 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TimelineEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidTimelineEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidTimelineEventEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.TimelineEntityMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.TimelineEventEntityMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.TimelineRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimeline
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimelineEvent
+
+@ExtendWith(MockitoExtension::class)
+class JpaTimelinePersistenceAdapterTest {
+
+  @InjectMocks
+  private lateinit var persistenceAdapter: JpaTimelinePersistenceAdapter
+
+  @Mock
+  private lateinit var timelineRepository: TimelineRepository
+
+  @Mock
+  private lateinit var timelineMapper: TimelineEntityMapper
+
+  @Mock
+  private lateinit var timelineEventMapper: TimelineEventEntityMapper
+
+  @Captor
+  private lateinit var timelineEntityCaptor: ArgumentCaptor<TimelineEntity>
+
+  @Nested
+  inner class AddTimelineEvent {
+
+    @Test
+    fun `should add timeline event to new timeline given timeline does not exist`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val timelineEvent = aValidTimelineEvent()
+      val timelineEventEntity = aValidTimelineEventEntity()
+      given(timelineRepository.findByPrisonNumber(any())).willReturn(null)
+      given(timelineEventMapper.fromDomainToEntity(any())).willReturn(timelineEventEntity)
+      given(timelineEventMapper.fromEntityToDomain(any())).willReturn(timelineEvent)
+
+      // When
+      persistenceAdapter.recordTimelineEvent(prisonNumber = prisonNumber, event = timelineEvent)
+
+      // Then
+      verify(timelineRepository).findByPrisonNumber(prisonNumber)
+      verify(timelineEventMapper).fromDomainToEntity(timelineEvent)
+      verify(timelineEventMapper).fromEntityToDomain(timelineEventEntity)
+      verify(timelineRepository).saveAndFlush(capture(timelineEntityCaptor))
+    }
+
+    @Test
+    fun `should record timeline event given timeline already exists`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val timelineEvent = aValidTimelineEvent()
+      val timelineEntity = aValidTimelineEntity()
+      val timelineEventEntity = aValidTimelineEventEntity()
+      given(timelineRepository.findByPrisonNumber(any())).willReturn(timelineEntity)
+      given(timelineEventMapper.fromDomainToEntity(any())).willReturn(timelineEventEntity)
+      given(timelineEventMapper.fromEntityToDomain(any())).willReturn(timelineEvent)
+
+      // When
+      persistenceAdapter.recordTimelineEvent(prisonNumber = prisonNumber, event = timelineEvent)
+
+      // Then
+      verify(timelineRepository).findByPrisonNumber(prisonNumber)
+      verify(timelineEventMapper).fromDomainToEntity(timelineEvent)
+      verify(timelineEventMapper).fromEntityToDomain(timelineEventEntity)
+      verify(timelineRepository).saveAndFlush(timelineEntity)
+    }
+  }
+
+  @Nested
+  inner class AddTimelineEvents {
+    @Test
+    fun `should add timeline events to new timeline given timeline does not exist`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val timelineEvent1 = aValidTimelineEvent()
+      val timelineEvent2 = aValidTimelineEvent()
+      val timelineEvents = listOf(timelineEvent1, timelineEvent2)
+      val timeline = aValidTimeline(prisonNumber = prisonNumber, events = timelineEvents)
+      val timelineEventEntity1 = aValidTimelineEventEntity()
+      val timelineEventEntity2 = aValidTimelineEventEntity()
+      given(timelineRepository.findByPrisonNumber(any())).willReturn(null)
+      given(timelineEventMapper.fromDomainToEntity(timelineEvent1)).willReturn(timelineEventEntity1)
+      given(timelineEventMapper.fromDomainToEntity(timelineEvent2)).willReturn(timelineEventEntity2)
+      given(timelineMapper.fromEntityToDomain(any())).willReturn(timeline)
+
+      // When
+      persistenceAdapter.recordTimelineEvents(prisonNumber = prisonNumber, events = timelineEvents)
+
+      // Then
+      verify(timelineRepository).findByPrisonNumber(prisonNumber)
+      verify(timelineEventMapper).fromDomainToEntity(timelineEvent1)
+      verify(timelineEventMapper).fromDomainToEntity(timelineEvent2)
+      verify(timelineMapper).fromEntityToDomain(capture(timelineEntityCaptor))
+      verify(timelineRepository).saveAndFlush(capture(timelineEntityCaptor))
+    }
+
+    @Test
+    fun `should record timeline events given timeline already exists`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val timelineEvent1 = aValidTimelineEvent()
+      val timelineEvent2 = aValidTimelineEvent()
+      val timelineEvents = listOf(timelineEvent1, timelineEvent2)
+      val timeline = aValidTimeline(prisonNumber = prisonNumber, events = timelineEvents)
+      val timelineEventEntity1 = aValidTimelineEventEntity()
+      val timelineEventEntity2 = aValidTimelineEventEntity()
+      val timelineEntity = aValidTimelineEntity(events = mutableListOf(timelineEventEntity1, timelineEventEntity2))
+      given(timelineRepository.findByPrisonNumber(any())).willReturn(timelineEntity)
+      given(timelineEventMapper.fromDomainToEntity(timelineEvent1)).willReturn(timelineEventEntity1)
+      given(timelineEventMapper.fromDomainToEntity(timelineEvent2)).willReturn(timelineEventEntity2)
+      given(timelineMapper.fromEntityToDomain(any())).willReturn(timeline)
+
+      // When
+      persistenceAdapter.recordTimelineEvents(prisonNumber = prisonNumber, events = timelineEvents)
+
+      // Then
+      verify(timelineRepository).findByPrisonNumber(prisonNumber)
+      verify(timelineEventMapper).fromDomainToEntity(timelineEvent1)
+      verify(timelineEventMapper).fromDomainToEntity(timelineEvent2)
+      verify(timelineMapper).fromEntityToDomain(timelineEntity)
+      verify(timelineRepository).saveAndFlush(timelineEntity)
+    }
+  }
+
+  @Nested
+  inner class GetTimeline {
+    @Test
+    fun `should get timeline for prisoner`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val timeline = aValidTimeline()
+      val timelineEntity = aValidTimelineEntity()
+      given(timelineRepository.findByPrisonNumber(any())).willReturn(timelineEntity)
+      given(timelineMapper.fromEntityToDomain(any())).willReturn(timeline)
+
+      // When
+      val actual = persistenceAdapter.getTimelineForPrisoner(prisonNumber)
+
+      // Then
+      assertThat(actual).isEqualTo(timeline)
+      verify(timelineRepository).findByPrisonNumber(prisonNumber)
+      verify(timelineMapper).fromEntityToDomain(timelineEntity)
+    }
+
+    @Test
+    fun `should not get timeline given timeline does not exist for prisoner`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      given(timelineRepository.findByPrisonNumber(any())).willReturn(null)
+
+      // When
+      val actual = persistenceAdapter.getTimelineForPrisoner(prisonNumber)
+
+      // Then
+      assertThat(actual).isNull()
+      verifyNoInteractions(timelineMapper)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ActionPlanEntityTest.kt
@@ -14,7 +14,6 @@ class ActionPlanEntityTest {
 
     // When
     val actual = ActionPlanEntity.newActionPlanForPrisoner(
-      reference = UUID.randomUUID(),
       prisonNumber = prisonNumber,
       reviewDate = null,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/TimelineEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/TimelineEntityMapperTest.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidTimelineEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidTimelineEventEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimeline
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimelineEvent
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class TimelineEntityMapperTest {
+
+  @InjectMocks
+  private lateinit var mapper: TimelineEntityMapperImpl
+
+  @Mock
+  private lateinit var eventMapper: TimelineEventEntityMapper
+
+  @Test
+  fun `should map from entity to domain`() {
+    // Given
+    val reference = UUID.randomUUID()
+    val prisonNumber = aValidPrisonNumber()
+    val timelineEntity = aValidTimelineEntity(
+      reference = reference,
+      prisonNumber = prisonNumber,
+      events = mutableListOf(aValidTimelineEventEntity()),
+    )
+    val timelineEvent = aValidTimelineEvent()
+    val expectedEvents = listOf(timelineEvent)
+    val expected = aValidTimeline(
+      reference = reference,
+      prisonNumber = prisonNumber,
+      events = expectedEvents,
+    )
+    given(eventMapper.fromEntityToDomain(any())).willReturn(timelineEvent)
+
+    // When
+    val actual = mapper.fromEntityToDomain(timelineEntity)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/TimelineEventEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/TimelineEventEntityMapperTest.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.aValidTimelineEventEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimelineEvent
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.TimelineEventType as TimelineEventTypeEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEventType as TimelineEventTypeDomain
+
+class TimelineEventEntityMapperTest {
+
+  private val mapper = TimelineEventEntityMapperImpl()
+
+  @Test
+  fun `should map from domain to entity`() {
+    // Given
+    val reference = UUID.randomUUID()
+    val sourceReference = UUID.randomUUID().toString()
+    val prisonId = "BXI"
+    val timelineEvent = aValidTimelineEvent(
+      reference = reference,
+      sourceReference = sourceReference,
+      eventType = TimelineEventTypeDomain.STEP_UPDATED,
+    )
+    val expected = aValidTimelineEventEntity(
+      reference = reference,
+      sourceReference = sourceReference,
+      eventType = TimelineEventTypeEntity.STEP_UPDATED,
+      contextualInfo = null,
+      createdAtPrison = prisonId,
+      createdBy = timelineEvent.createdBy,
+      createdByDisplayName = timelineEvent.createdByDisplayName,
+      timestamp = timelineEvent.timestamp,
+    )
+
+    // When
+    val actual = mapper.fromDomainToEntity(timelineEvent)
+
+    // Then
+    assertThat(actual)
+      .doesNotHaveJpaManagedFieldsPopulated()
+      .hasAReference()
+      .usingRecursiveComparison()
+      .ignoringFields("id", "createdAt")
+      .isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map from entity to domain`() {
+    // Given
+    val reference = UUID.randomUUID()
+    val sourceReference = UUID.randomUUID().toString()
+    val prisonId = "BXI"
+    val timelineEventEntity = aValidTimelineEventEntity(
+      reference = reference,
+      sourceReference = sourceReference,
+      eventType = TimelineEventTypeEntity.STEP_UPDATED,
+      contextualInfo = null,
+      createdAtPrison = prisonId,
+    )
+    val expected = aValidTimelineEvent(
+      reference = reference,
+      sourceReference = sourceReference,
+      eventType = TimelineEventTypeDomain.STEP_UPDATED,
+      contextualInfo = null,
+      prisonId = prisonId,
+      timestamp = timelineEventEntity.timestamp!!,
+    )
+
+    // When
+    val actual = mapper.fromEntityToDomain(timelineEventEntity)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncActionPlanEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncActionPlanEventServiceTest.kt
@@ -21,6 +21,9 @@ class AsyncActionPlanEventServiceTest {
   private lateinit var actionPlanEventService: AsyncActionPlanEventService
 
   @Mock
+  private lateinit var telemetryService: TelemetryService
+
+  @Mock
   private lateinit var timelineEventFactory: TimelineEventFactory
 
   @Mock
@@ -38,6 +41,7 @@ class AsyncActionPlanEventServiceTest {
     actionPlanEventService.actionPlanCreated(actionPlan)
 
     // Then
+    verify(telemetryService).trackGoalCreateEvent(actionPlan.goals[0])
     verify(timelineEventFactory).actionPlanCreatedEvent(actionPlan)
     verify(timelineService).recordTimelineEvent(prisonNumber, createActionPlanEvent)
   }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEntityBuilder.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import java.time.Instant
+import java.util.UUID
+
+fun aValidTimelineEntity(
+  id: UUID = UUID.randomUUID(),
+  reference: UUID = UUID.randomUUID(),
+  prisonNumber: String = aValidPrisonNumber(),
+  events: MutableList<TimelineEventEntity> = mutableListOf(aValidTimelineEventEntity()),
+  createdAt: Instant = Instant.now(),
+  updatedAt: Instant = Instant.now(),
+) = TimelineEntity(
+  id = id,
+  reference = reference,
+  prisonNumber = prisonNumber,
+  events = events,
+  createdAt = createdAt,
+  updatedAt = updatedAt,
+)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEventEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEventEntityAssert.kt
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
+
+import org.assertj.core.api.AbstractObjectAssert
+import java.time.Instant
+import java.util.UUID
+
+fun assertThat(actual: TimelineEventEntity?) = TimelineEventEntityAssert(actual)
+
+/**
+ * AssertJ custom assertion for [TimelineEventEntity]
+ */
+class TimelineEventEntityAssert(actual: TimelineEventEntity?) :
+  AbstractObjectAssert<TimelineEventEntityAssert, TimelineEventEntity?>(actual, TimelineEventEntityAssert::class.java) {
+
+  fun hasJpaManagedFieldsPopulated(): TimelineEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (id == null || createdAt == null) {
+        failWithMessage("Expected entity to have the JPA managed fields populated, but was [id = $id, createdAt = $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun doesNotHaveJpaManagedFieldsPopulated(): TimelineEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (id != null || createdAt != null) {
+        failWithMessage("Expected entity not to have the JPA managed fields populated, but was [id = $id, createdAt = $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun hasId(expected: UUID): TimelineEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (id != expected) {
+        failWithMessage("Expected id to be $expected, but was $id")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): TimelineEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: Instant): TimelineEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): TimelineEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun hasAReference(): TimelineEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference == null) {
+        failWithMessage("Expected reference to be populated, but was $reference")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEventEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEventEntityBuilder.kt
@@ -1,34 +1,28 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
 
 import java.time.Instant
 import java.util.UUID
 
-fun aValidTimeline(
-  reference: UUID = UUID.randomUUID(),
-  prisonNumber: String = "A1234AB",
-  events: List<TimelineEvent> = listOf(aValidTimelineEvent()),
-) = Timeline(
-  reference = reference,
-  prisonNumber = prisonNumber,
-  events = events,
-)
-
-fun aValidTimelineEvent(
+fun aValidTimelineEventEntity(
+  id: UUID = UUID.randomUUID(),
   reference: UUID = UUID.randomUUID(),
   sourceReference: String = UUID.randomUUID().toString(),
   eventType: TimelineEventType = TimelineEventType.GOAL_CREATED,
   contextualInfo: String? = null,
-  prisonId: String = "BXI",
+  createdAtPrison: String = "BXI",
   createdBy: String = "asmith_gen",
-  createdByDisplayName: String = "Alex Smith",
+  createdByDisplayName: String? = "Alex Smith",
   timestamp: Instant = Instant.now(),
-) = TimelineEvent(
+  createdAt: Instant = Instant.now(),
+) = TimelineEventEntity(
+  id = id,
   reference = reference,
   sourceReference = sourceReference,
   eventType = eventType,
   contextualInfo = contextualInfo,
-  prisonId = prisonId,
+  createdAtPrison = createdAtPrison,
   createdBy = createdBy,
   createdByDisplayName = createdByDisplayName,
   timestamp = timestamp,
+  createdAt = createdAt,
 )


### PR DESCRIPTION
This PR introduces the database tables for a Prisoner's Timeline, along with the required JPA entities and repository.

It's larger than anticipated, because I had to make changes to `GoalService` and `JpaGoalPersistenceAdapter` to ensure that the correct events are created whenever an ActionPlan is created, when adding a `Goal`.

I'm going to add the REST endpoint to retrieve a Prisoner's Timeline, along with the required integration tests, in a separate PR.