### PR TITLE
RR-321 GET timeline endpoint

### DIFF
--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimelineEvent.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimelineEvent.kt
@@ -47,7 +47,7 @@ data class TimelineEvent(
     fun newTimelineEvent(
       sourceReference: String,
       eventType: TimelineEventType,
-      contextualInfo: String? = null, // TODO RR-314 - not sure how we're going to populate this?
+      contextualInfo: String? = null,
       prisonId: String,
       actionedBy: String,
       actionedByDisplayName: String? = null,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -246,6 +246,9 @@ class CreateActionPlanTest : IntegrationTestBase() {
     assertThat(events[0]).hasEventType(TimelineEventType.ACTION_PLAN_CREATED)
     assertThat(events[0]).hasSourceReference(actionPlan.reference.toString())
     assertThat(events[0]).hasNoContextualInfo()
+    assertThat(events[0]).wasActionedBy("auser_gen")
+    assertThat(events[0]).wasActionedByDisplayName("Albert User")
+    assertThat(events[0]).hasPrisonId("BXI")
     assertThat(events[0]).hasAReference()
     assertThat(events[0]).hasJpaManagedFieldsPopulated()
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
@@ -224,6 +224,9 @@ class CreateGoalTest : IntegrationTestBase() {
     assertThat(events[0]).hasEventType(TimelineEventType.GOAL_CREATED)
     assertThat(events[0]).hasSourceReference(goal.reference.toString())
     assertThat(events[0]).hasContextualInfo(goal.title!!)
+    assertThat(events[0]).wasActionedBy("auser_gen")
+    assertThat(events[0]).wasActionedByDisplayName("Albert User")
+    assertThat(events[0]).hasPrisonId("BXI")
     assertThat(events[0]).hasAReference()
     assertThat(events[0]).hasJpaManagedFieldsPopulated()
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt
@@ -1,0 +1,206 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.anotherValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
+import java.time.LocalDate
+
+class GetTimelineTest : IntegrationTestBase() {
+
+  companion object {
+    private const val URI_TEMPLATE = "/timelines/{prisonNumber}"
+    private const val CREATE_ACTION_PLAN_URI_TEMPLATE = "/action-plans/{prisonNumber}"
+    private const val CREATE_GOAL_URI_TEMPLATE = "/action-plans/{prisonNumber}/goals"
+    private const val UPDATE_GOAL_URI_TEMPLATE = "/action-plans/{prisonNumber}/goals/{goalReference}"
+  }
+
+  @Test
+  fun `should return unauthorized given no bearer token`() {
+    webTestClient.get()
+      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `should return forbidden given bearer token without required role`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .bearerToken(aValidTokenWithNoAuthorities(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.FORBIDDEN.value())
+      .hasUserMessage("Access Denied")
+      .hasDeveloperMessage("Access denied on uri=/timelines/$prisonNumber")
+  }
+
+  @Test
+  fun `should not get timeline given prisoner has no timeline`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.NOT_FOUND.value())
+      .hasUserMessage("Timeline not found for prisoner [$prisonNumber]")
+  }
+
+  @Test
+  @Transactional
+  fun `should get timeline for prisoner`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val createActionPlanRequest = aValidCreateActionPlanRequest(
+      reviewDate = LocalDate.now(),
+      goals = listOf(aValidCreateGoalRequest(title = "Learn German")),
+    )
+    createActionPlan(prisonNumber, createActionPlanRequest)
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(TimelineResponse::class.java)
+
+    // Then
+    val actionPlan = actionPlanRepository.findByPrisonNumber(prisonNumber)
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .isForPrisonNumber(prisonNumber)
+      .event(0) {
+        it.hasSourceReference(actionPlan!!.reference.toString())
+          .hasEventType(TimelineEventType.ACTION_PLAN_CREATED)
+          .hasPrisonId("BXI")
+          .wasActionedBy("auser_gen")
+          .hasActionedByDisplayName("Albert User")
+          .hasNoContextualInfo()
+      }
+  }
+
+  @Test
+  @Transactional
+  fun `should get timeline with multiple events in order`() {
+    // Given
+    val prisonNumber = anotherValidPrisonNumber()
+    val createActionPlanRequest = aValidCreateActionPlanRequest(
+      reviewDate = LocalDate.now(),
+      goals = listOf(aValidCreateGoalRequest(title = "Learn German")),
+    )
+    createActionPlan(prisonNumber, createActionPlanRequest)
+    createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn French"))
+
+    val actionPlan = actionPlanRepository.findByPrisonNumber(prisonNumber)
+    val actionPlanReference = actionPlan!!.reference!!
+    val goal1Reference = actionPlan.goals!![0].reference!!
+    val goal2Reference = actionPlan.goals!![1].reference!!
+    updateGoal(prisonNumber, aValidUpdateGoalRequest(goalReference = goal1Reference, title = "Learn Spanish"))
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(TimelineResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .isForPrisonNumber(prisonNumber)
+      .event(0) {
+        it.hasEventType(TimelineEventType.ACTION_PLAN_CREATED)
+          .hasPrisonId("BXI")
+          .hasSourceReference(actionPlanReference.toString())
+          .hasNoContextualInfo() // creating an action plan has no contextual info
+      }
+      .event(1) {
+        it.hasEventType(TimelineEventType.GOAL_CREATED)
+          .hasPrisonId("BXI")
+          .hasSourceReference(goal2Reference.toString())
+          .hasContextualInfo("Learn French")
+      }
+      .event(2) {
+        it.hasEventType(TimelineEventType.GOAL_UPDATED)
+          .hasPrisonId("BXI")
+          .hasSourceReference(goal1Reference.toString())
+          .hasContextualInfo("Learn Spanish") // Learn German changed to Learn Spanish
+      }
+  }
+
+  private fun createActionPlan(prisonNumber: String, createActionPlanRequest: CreateActionPlanRequest) {
+    webTestClient.post()
+      .uri(CREATE_ACTION_PLAN_URI_TEMPLATE, prisonNumber)
+      .withBody(createActionPlanRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
+  }
+
+  private fun createGoal(prisonNumber: String, createGoalRequest: CreateGoalRequest) {
+    webTestClient.post()
+      .uri(CREATE_GOAL_URI_TEMPLATE, prisonNumber)
+      .withBody(createGoalRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
+  }
+
+  private fun updateGoal(prisonNumber: String, updateGoalRequest: UpdateGoalRequest) {
+    webTestClient.put()
+      .uri(UPDATE_GOAL_URI_TEMPLATE, prisonNumber, updateGoalRequest.goalReference)
+      .withBody(updateGoalRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isNoContent()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
@@ -29,7 +29,7 @@ class JpaGoalPersistenceAdapter(
     val goalEntity = goalMapper.fromDtoToEntity(createGoalDto)
     with(actionPlanEntity) {
       addGoal(goalEntity)
-      actionPlanRepository.saveAndFlush(this)
+      actionPlanRepository.save(this)
     }
 
     // use the persisted entity with the populated JPA fields, rather than the non persisted entity reference above

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/TimelineController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/TimelineController.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.TimelineResourceMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelineService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
+
+@RestController
+@RequestMapping(value = ["/timelines"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class TimelineController(
+  private val timelineService: TimelineService,
+  private val timelineMapper: TimelineResourceMapper,
+) {
+
+  @GetMapping("/{prisonNumber}")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize(HAS_VIEW_AUTHORITY)
+  fun getTimeline(@PathVariable prisonNumber: String): TimelineResponse =
+    with(timelineService.getTimelineForPrisoner(prisonNumber)) {
+      timelineMapper.fromDomainToModel(this)
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/TimelineEventResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/TimelineEventResourceMapper.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
+
+import org.mapstruct.Mapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventResponse
+import java.time.Instant
+import java.util.UUID
+
+@Mapper(
+  uses = [
+    InstantMapper::class,
+  ],
+  imports = [
+    Instant::class,
+    UUID::class,
+  ],
+)
+interface TimelineEventResourceMapper {
+  fun fromDomainToModel(timelineEventDomain: TimelineEvent): TimelineEventResponse
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/TimelineResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/TimelineResourceMapper.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
+
+import org.mapstruct.Mapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Timeline
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
+
+@Mapper(
+  uses = [
+    TimelineEventResourceMapper::class,
+  ],
+)
+interface TimelineResourceMapper {
+  fun fromDomainToModel(timeline: Timeline): TimelineResponse
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
@@ -78,7 +78,7 @@ class JpaGoalPersistenceAdapterTest {
       )
       given(actionPlanRepository.findByPrisonNumber(any())).willReturn(initialActionPlan)
       given(goalMapper.fromDtoToEntity(any())).willReturn(entityGoal)
-      given(actionPlanRepository.saveAndFlush(any<ActionPlanEntity>())).willReturn(actionPlanEntity)
+      given(actionPlanRepository.save(any<ActionPlanEntity>())).willReturn(actionPlanEntity)
       given(goalMapper.fromEntityToDomain(any())).willReturn(domainGoal)
 
       // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/TimelineEventResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/TimelineEventResourceMapperTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimelineEvent
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEventType as TimelineEventTypeDomain
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType as TimelineEventTypeModel
+
+@ExtendWith(MockitoExtension::class)
+class TimelineEventResourceMapperTest {
+  @InjectMocks
+  private lateinit var mapper: TimelineEventResourceMapperImpl
+
+  @Mock
+  private lateinit var instantMapper: InstantMapper
+
+  @Test
+  fun `should map from domain to model`() {
+    // Given
+    val reference = UUID.randomUUID()
+    val sourceReference = UUID.randomUUID().toString()
+    val goalTitle = "Learn French"
+    val prisonId = "BXI"
+    val actionedBy = "asmith_gen"
+    val actionedByDisplayName = "Alex Smith"
+    val timestamp = OffsetDateTime.now()
+    val timelineEventDomain = aValidTimelineEvent(
+      reference = reference,
+      sourceReference = sourceReference,
+      eventType = TimelineEventTypeDomain.GOAL_CREATED,
+      contextualInfo = goalTitle,
+      prisonId = prisonId,
+      actionedBy = actionedBy,
+      actionedByDisplayName = actionedByDisplayName,
+    )
+    val expected = TimelineEventResponse(
+      reference = reference,
+      sourceReference = sourceReference,
+      eventType = TimelineEventTypeModel.GOAL_CREATED,
+      contextualInfo = goalTitle,
+      prisonId = prisonId,
+      actionedBy = actionedBy,
+      actionedByDisplayName = actionedByDisplayName,
+      timestamp = timestamp,
+    )
+    given(instantMapper.toOffsetDateTime(any())).willReturn(timestamp)
+
+    // When
+    val actual = mapper.fromDomainToModel(timelineEventDomain)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/TimelineResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/TimelineResourceMapperTest.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimeline
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidTimelineEventResponse
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class TimelineResourceMapperTest {
+  @InjectMocks
+  private lateinit var mapper: TimelineResourceMapperImpl
+
+  @Mock
+  private lateinit var timelineEventMapper: TimelineEventResourceMapperImpl
+
+  @Test
+  fun `should map from domain to model`() {
+    // Given
+    val reference = UUID.randomUUID()
+    val prisonNumber = aValidPrisonNumber()
+    val timelineDomain = aValidTimeline(reference = reference, prisonNumber = prisonNumber)
+    val timelineEventResponse = aValidTimelineEventResponse()
+    val expected = TimelineResponse(
+      reference = reference,
+      prisonNumber = prisonNumber,
+      events = listOf(timelineEventResponse),
+    )
+    given(timelineEventMapper.fromDomainToModel(any())).willReturn(timelineEventResponse)
+
+    // When
+    val actual = mapper.fromDomainToModel(timelineDomain)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEventEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/TimelineEventEntityAssert.kt
@@ -52,6 +52,16 @@ class TimelineEventEntityAssert(actual: TimelineEventEntity?) :
     return this
   }
 
+  fun wasActionedByDisplayName(expected: String): TimelineEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (actionedByDisplayName != expected) {
+        failWithMessage("Expected actionedByDisplayName to be $expected, but was $actionedByDisplayName")
+      }
+    }
+    return this
+  }
+
   fun wasCreatedAt(expected: Instant): TimelineEventEntityAssert {
     isNotNull
     with(actual!!) {

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/TimelineEventResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/TimelineEventResponseAssert.kt
@@ -1,0 +1,96 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
+
+import org.assertj.core.api.AbstractObjectAssert
+import java.util.UUID
+
+fun assertThat(actual: TimelineEventResponse?) = TimelineEventResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [TimelineEventResponse]
+ */
+class TimelineEventResponseAssert(actual: TimelineEventResponse?) :
+  AbstractObjectAssert<TimelineEventResponseAssert, TimelineEventResponse?>(
+    actual,
+    TimelineEventResponseAssert::class.java,
+  ) {
+
+  fun hasReference(expected: UUID): TimelineEventResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun hasSourceReference(expected: String): TimelineEventResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (sourceReference != expected) {
+        failWithMessage("Expected sourceReference to be $expected, but was $sourceReference")
+      }
+    }
+    return this
+  }
+
+  fun hasEventType(expected: TimelineEventType): TimelineEventResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (eventType != expected) {
+        failWithMessage("Expected eventType to be $expected, but was $eventType")
+      }
+    }
+    return this
+  }
+
+  fun hasPrisonId(expected: String): TimelineEventResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (prisonId != expected) {
+        failWithMessage("Expected prisonId to be $expected, but was $prisonId")
+      }
+    }
+    return this
+  }
+
+  fun wasActionedBy(expected: String): TimelineEventResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (actionedBy != expected) {
+        failWithMessage("Expected actionedBy to be $expected, but was $actionedBy")
+      }
+    }
+    return this
+  }
+
+  fun hasActionedByDisplayName(expected: String): TimelineEventResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (actionedByDisplayName != expected) {
+        failWithMessage("Expected actionedByDisplayName to be $expected, but was $actionedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun hasContextualInfo(expected: String): TimelineEventResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (contextualInfo != expected) {
+        failWithMessage("Expected contextualInfo to be $expected, but was $contextualInfo")
+      }
+    }
+    return this
+  }
+
+  fun hasNoContextualInfo(): TimelineEventResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (contextualInfo != null) {
+        failWithMessage("Expected contextualInfo to be null, but was $contextualInfo")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/TimelineEventResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/TimelineEventResponseBuilder.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidTimelineEventResponse(
+  reference: UUID = UUID.randomUUID(),
+  sourceReference: String = UUID.randomUUID().toString(),
+  eventType: TimelineEventType = TimelineEventType.GOAL_CREATED,
+  prisonId: String = "BXI",
+  actionedBy: String = "asmith_gen",
+  actionedByDisplayName: String = "Alex Smith",
+  timestamp: OffsetDateTime = OffsetDateTime.now(),
+  contextualInfo: String? = "Learn French",
+): TimelineEventResponse =
+  TimelineEventResponse(
+    reference = reference,
+    sourceReference = sourceReference,
+    eventType = eventType,
+    prisonId = prisonId,
+    actionedBy = actionedBy,
+    actionedByDisplayName = actionedByDisplayName,
+    timestamp = timestamp,
+    contextualInfo = contextualInfo,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/TimelineResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/TimelineResponseAssert.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
+
+import org.assertj.core.api.AbstractObjectAssert
+import java.util.function.Consumer
+
+fun assertThat(actual: TimelineResponse?) = TimelineResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for [TimelineResponse]
+ */
+class TimelineResponseAssert(actual: TimelineResponse?) :
+  AbstractObjectAssert<TimelineResponseAssert, TimelineResponse?>(actual, TimelineResponseAssert::class.java) {
+
+  fun isForPrisonNumber(expected: String): TimelineResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (prisonNumber != expected) {
+        failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [TimelineEventResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [TimelineEventResponseAssert].
+   * Returns this [TimelineResponseAssert] to allow further chained assertions on the parent [TimelineResponse]
+   */
+  fun event(eventNumber: Int, consumer: Consumer<TimelineEventResponseAssert>): TimelineResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val event = events[eventNumber]
+      consumer.accept(assertThat(event))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into all child [TimelineEventResponse]s. Takes a lambda as the method argument
+   * to call assertion methods provided by [TimelineEventResponseAssert].
+   * Returns this [TimelineResponseAssert] to allow further chained assertions on the parent [TimelineResponse]
+   * The assertions on all [TimelineEventResponse]s must pass as true.
+   */
+  fun allEvents(consumer: Consumer<TimelineEventResponseAssert>): TimelineResponseAssert {
+    isNotNull
+    with(actual!!) {
+      events.onEach {
+        consumer.accept(assertThat(it))
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/TimelineResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/TimelineResponseBuilder.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
+
+import java.util.UUID
+
+fun aValidTimelineResponse(
+  reference: UUID = UUID.randomUUID(),
+  prisonNumber: String = "",
+  events: List<TimelineEventResponse> = listOf(aValidTimelineEventResponse()),
+): TimelineResponse =
+  TimelineResponse(
+    reference = reference,
+    prisonNumber = prisonNumber,
+    events = events,
+  )


### PR DESCRIPTION
This PR adds an endpoint to retrieve a list of Timeline "events" in chronological order, detailed in the swagger spec:

![image](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/assets/135589132/74d3f2ce-8b43-4926-918f-8a0e3343a59f)

A number of additional assertions have been added to existing integration tests (e.g. `CreateGoalTest`) to ensure the expected events are created. Also, a new integration test (`GetTimelineTest`) has been added to test the new endpoint in isolation.