### PR TITLE
RR-305 - Track a Goal's notes character length in App Insights

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalTest.kt
@@ -111,7 +111,7 @@ class CreateGoalTest : IntegrationTestBase() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     val stepRequest = aValidCreateStepRequest(targetDateRange = TargetDateRange.ZERO_TO_THREE_MONTHS)
-    val createGoalRequest = aValidCreateGoalRequest(steps = listOf(stepRequest))
+    val createGoalRequest = aValidCreateGoalRequest(steps = listOf(stepRequest), notes = "Notes about the goal...")
 
     val dpsUsername = "auser_gen"
     val displayName = "Albert User"
@@ -159,6 +159,7 @@ class CreateGoalTest : IntegrationTestBase() {
       "status" to "ACTIVE",
       "stepCount" to "1",
       "reference" to goal.reference.toString(),
+      "notesCharacterCount" to "23",
     )
     await.untilAsserted {
       verify(telemetryClient).trackEvent("goal-create", expectedEventCustomDimensions, null)
@@ -187,7 +188,9 @@ class CreateGoalTest : IntegrationTestBase() {
     TestTransaction.end()
     TestTransaction.start()
     assertThat(actionPlan).hasNumberOfGoals(1)
-    val createRequest = aValidCreateGoalRequest()
+    val createRequest = aValidCreateGoalRequest(
+      notes = "Chris would like to improve his listening skills, not just his verbal communication",
+    )
 
     // When
     webTestClient.post()
@@ -211,6 +214,7 @@ class CreateGoalTest : IntegrationTestBase() {
       "status" to "ACTIVE",
       "stepCount" to "2",
       "reference" to goal.reference.toString(),
+      "notesCharacterCount" to "83",
     )
     await.untilAsserted {
       verify(telemetryClient).trackEvent("goal-create", expectedEventCustomDimensions, null)
@@ -266,6 +270,7 @@ class CreateGoalTest : IntegrationTestBase() {
       "status" to "ACTIVE",
       "stepCount" to "2",
       "reference" to goal.reference.toString(),
+      "notesCharacterCount" to "0",
     )
     await.untilAsserted {
       verify(telemetryClient).trackEvent("goal-create", expectedEventCustomDimensions, null)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -205,6 +205,7 @@ class UpdateGoalTest : IntegrationTestBase() {
           sequenceNumber = 2,
         ),
       ),
+      notes = "Chris would like to improve his listening skills, not just his verbal communication",
       prisonId = "MDI",
     )
 
@@ -241,6 +242,7 @@ class UpdateGoalTest : IntegrationTestBase() {
 
     val expectedEventCustomDimensions = mapOf(
       "reference" to goalReference.toString(),
+      "notesCharacterCount" to "83",
     )
     await.untilAsserted {
       verify(telemetryClient).trackEvent("goal-update", expectedEventCustomDimensions, null)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
@@ -41,6 +41,7 @@ class TelemetryService(
         "status" to status.name,
         "stepCount" to steps.size.toString(),
         "reference" to reference.toString(),
+        "notesCharacterCount" to (notes?.length ?: 0).toString(),
       )
     }
 
@@ -51,6 +52,7 @@ class TelemetryService(
     with(goal) {
       mapOf(
         "reference" to reference.toString(),
+        "notesCharacterCount" to (notes?.length ?: 0).toString(),
       )
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
@@ -23,7 +23,7 @@ class TelemetryServiceTest {
   private lateinit var telemetryService: TelemetryService
 
   @Test
-  fun `should track create goal event`() {
+  fun `should track create goal event given goal with no notes`() {
     // Given
     val reference = UUID.randomUUID()
     val status = GoalStatus.ACTIVE
@@ -33,12 +33,14 @@ class TelemetryServiceTest {
       reference = reference,
       status = status,
       steps = steps,
+      notes = null,
     )
 
     val expectedEventProperties = mapOf(
       "reference" to reference.toString(),
       "status" to "ACTIVE",
       "stepCount" to "3",
+      "notesCharacterCount" to "0",
     )
 
     // When
@@ -49,7 +51,7 @@ class TelemetryServiceTest {
   }
 
   @Test
-  fun `should track update goal event`() {
+  fun `should track create goal event given goal with some notes`() {
     // Given
     val reference = UUID.randomUUID()
     val status = GoalStatus.ACTIVE
@@ -59,10 +61,66 @@ class TelemetryServiceTest {
       reference = reference,
       status = status,
       steps = steps,
+      notes = "Some notes about the goal",
     )
 
     val expectedEventProperties = mapOf(
       "reference" to reference.toString(),
+      "status" to "ACTIVE",
+      "stepCount" to "3",
+      "notesCharacterCount" to "25",
+    )
+
+    // When
+    telemetryService.trackGoalCreateEvent(goal)
+
+    // Then
+    verify(telemetryClient).trackEvent("goal-create", expectedEventProperties)
+  }
+
+  @Test
+  fun `should track update goal event given goal with no notes`() {
+    // Given
+    val reference = UUID.randomUUID()
+    val status = GoalStatus.ACTIVE
+    val steps = listOf(aValidStep(), aValidStep(), aValidStep())
+
+    val goal = aValidGoal(
+      reference = reference,
+      status = status,
+      steps = steps,
+      notes = null,
+    )
+
+    val expectedEventProperties = mapOf(
+      "reference" to reference.toString(),
+      "notesCharacterCount" to "0",
+    )
+
+    // When
+    telemetryService.trackGoalUpdateEvent(goal)
+
+    // Then
+    verify(telemetryClient).trackEvent("goal-update", expectedEventProperties)
+  }
+
+  @Test
+  fun `should track update goal event given goal with notes`() {
+    // Given
+    val reference = UUID.randomUUID()
+    val status = GoalStatus.ACTIVE
+    val steps = listOf(aValidStep(), aValidStep(), aValidStep())
+
+    val goal = aValidGoal(
+      reference = reference,
+      status = status,
+      steps = steps,
+      notes = "Chris wants to become a chef on release so basic food hygiene course will be useful.",
+    )
+
+    val expectedEventProperties = mapOf(
+      "reference" to reference.toString(),
+      "notesCharacterCount" to "84",
     )
 
     // When


### PR DESCRIPTION
This PR tracks the number of characters used in the `notes` field of  `Goal` in App Insights events for both Create and Update.

We already have code that tracks the `Goal` Create and Update events, so this PR is simply a case of adding the field to the event's custom dimensions 👍 