### PR TITLE
RR-152 - Refactor `create-goal` API to `create-goals`

### DIFF
--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalPersistenceAdapter.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalPersistenceAdapter.kt
@@ -16,9 +16,9 @@ import java.util.UUID
 interface GoalPersistenceAdapter {
 
   /**
-   * Creates a new [Goal] for the prisoner identified by their prison number.
+   * Creates new [Goal]s for the prisoner identified by their prison number.
    */
-  fun createGoal(prisonNumber: String, createGoalDto: CreateGoalDto): Goal
+  fun createGoals(prisonNumber: String, createGoalDtos: List<CreateGoalDto>): List<Goal>
 
   /**
    * Returns a [Goal] identified by its `prisonNumber` and `goalReference` if found, otherwise `null`.

--- a/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
+++ b/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -38,48 +39,108 @@ class GoalServiceTest {
   @Mock
   private lateinit var actionPlanEventService: ActionPlanEventService
 
-  @Test
-  fun `should create new goal for a prisoner`() {
-    // Given
-    val prisonNumber = aValidPrisonNumber()
-    val goal = aValidGoal()
-    given(actionPlanPersistenceAdapter.getActionPlan(any())).willReturn(aValidActionPlan())
-    given(goalPersistenceAdapter.createGoal(any(), any())).willReturn(goal)
-    val createGoalDto = aValidCreateGoalDto()
+  @Nested
+  inner class CreateGoal {
+    @Test
+    fun `should create new goal for a prisoner`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val goal = aValidGoal()
+      given(actionPlanPersistenceAdapter.getActionPlan(any())).willReturn(aValidActionPlan())
+      given(goalPersistenceAdapter.createGoals(any(), any())).willReturn(listOf(goal))
+      val createGoalDto = aValidCreateGoalDto()
 
-    // When
-    val actual = service.createGoal(prisonNumber, createGoalDto)
+      // When
+      val actual = service.createGoal(prisonNumber, createGoalDto)
 
-    // Then
-    assertThat(actual).isEqualTo(goal)
-    verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
-    verify(goalPersistenceAdapter).createGoal(prisonNumber, createGoalDto)
-    verify(goalEventService).goalCreated(prisonNumber, actual)
-    verifyNoInteractions(actionPlanEventService)
+      // Then
+      assertThat(actual).isEqualTo(goal)
+      verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
+      verify(goalPersistenceAdapter).createGoals(prisonNumber, listOf(createGoalDto))
+      verify(goalEventService).goalCreated(prisonNumber, actual)
+      verifyNoInteractions(actionPlanEventService)
+    }
+
+    @Test
+    fun `should add goal to new action plan given prisoner does not have an action plan`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val goal = aValidGoal()
+      val actionPlan = aValidActionPlan(prisonNumber = prisonNumber, goals = listOf(goal))
+      given(actionPlanPersistenceAdapter.getActionPlan(any())).willReturn(null)
+      given(actionPlanPersistenceAdapter.createActionPlan(any())).willReturn(actionPlan)
+      val createGoalDto = aValidCreateGoalDto()
+      val expectedCreateActionPlanDto =
+        aValidCreateActionPlanDto(prisonNumber = prisonNumber, reviewDate = null, goals = listOf(createGoalDto))
+
+      // When
+      val actual = service.createGoal(prisonNumber, createGoalDto)
+
+      // Then
+      assertThat(actual).isEqualTo(goal)
+      verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
+      verify(actionPlanPersistenceAdapter).createActionPlan(expectedCreateActionPlanDto)
+      verify(actionPlanEventService).actionPlanCreated(actionPlan)
+      verifyNoInteractions(goalPersistenceAdapter)
+      verifyNoInteractions(goalEventService)
+    }
   }
 
-  @Test
-  fun `should add goal to new action plan given prisoner does not have an action plan`() {
-    // Given
-    val prisonNumber = aValidPrisonNumber()
-    val goal = aValidGoal()
-    val actionPlan = aValidActionPlan(prisonNumber = prisonNumber, goals = listOf(goal))
-    given(actionPlanPersistenceAdapter.getActionPlan(any())).willReturn(null)
-    given(actionPlanPersistenceAdapter.createActionPlan(any())).willReturn(actionPlan)
-    val createGoalDto = aValidCreateGoalDto()
-    val expectedCreateActionPlanDto =
-      aValidCreateActionPlanDto(prisonNumber = prisonNumber, reviewDate = null, goals = listOf(createGoalDto))
+  @Nested
+  inner class CreateGoals {
+    @Test
+    fun `should create new goals for a prisoner`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val goal1 = aValidGoal(title = "Goal 1")
+      val goal2 = aValidGoal(title = "Goal 2")
+      given(actionPlanPersistenceAdapter.getActionPlan(any())).willReturn(aValidActionPlan())
+      given(goalPersistenceAdapter.createGoals(any(), any())).willReturn(listOf(goal1, goal2))
 
-    // When
-    val actual = service.createGoal(prisonNumber, createGoalDto)
+      val createGoalDto1 = aValidCreateGoalDto(title = "Goal 1")
+      val createGoalDto2 = aValidCreateGoalDto(title = "Goal 2")
+      val createGoalDtos = listOf(createGoalDto1, createGoalDto2)
 
-    // Then
-    assertThat(actual).isEqualTo(goal)
-    verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
-    verify(actionPlanPersistenceAdapter).createActionPlan(expectedCreateActionPlanDto)
-    verify(actionPlanEventService).actionPlanCreated(actionPlan)
-    verifyNoInteractions(goalPersistenceAdapter)
-    verifyNoInteractions(goalEventService)
+      // When
+      val actual = service.createGoals(prisonNumber, createGoalDtos)
+
+      // Then
+      assertThat(actual).containsExactlyInAnyOrder(goal1, goal2)
+      verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
+      verify(goalPersistenceAdapter).createGoals(prisonNumber, createGoalDtos)
+      verify(goalEventService).goalCreated(prisonNumber, goal1)
+      verify(goalEventService).goalCreated(prisonNumber, goal2)
+      verifyNoInteractions(actionPlanEventService)
+    }
+
+    @Test
+    fun `should add goals to new action plan given prisoner does not have an action plan`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val goal1 = aValidGoal(title = "Goal 1")
+      val goal2 = aValidGoal(title = "Goal 2")
+      val actionPlan = aValidActionPlan(prisonNumber = prisonNumber, goals = listOf(goal1, goal2))
+      given(actionPlanPersistenceAdapter.getActionPlan(any())).willReturn(null)
+      given(actionPlanPersistenceAdapter.createActionPlan(any())).willReturn(actionPlan)
+
+      val createGoalDto1 = aValidCreateGoalDto(title = "Goal 1")
+      val createGoalDto2 = aValidCreateGoalDto(title = "Goal 2")
+      val createGoalDtos = listOf(createGoalDto1, createGoalDto2)
+
+      val expectedCreateActionPlanDto =
+        aValidCreateActionPlanDto(prisonNumber = prisonNumber, reviewDate = null, goals = createGoalDtos)
+
+      // When
+      val actual = service.createGoals(prisonNumber, createGoalDtos)
+
+      // Then
+      assertThat(actual).containsExactlyInAnyOrder(goal1, goal2)
+      verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
+      verify(actionPlanPersistenceAdapter).createActionPlan(expectedCreateActionPlanDto)
+      verify(actionPlanEventService).actionPlanCreated(actionPlan)
+      verifyNoInteractions(goalPersistenceAdapter)
+      verifyNoInteractions(goalEventService)
+    }
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -7,10 +7,19 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.test.mock.mockito.SpyBean
+import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.TimelineRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 import java.security.KeyPair
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS
@@ -18,6 +27,13 @@ import java.util.concurrent.TimeUnit.SECONDS
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("integration-test")
 abstract class IntegrationTestBase {
+
+  companion object {
+    const val CREATE_GOALS_URI_TEMPLATE = "/action-plans/{prisonNumber}/goals"
+    const val CREATE_ACTION_PLAN_URI_TEMPLATE = "/action-plans/{prisonNumber}"
+    const val GET_ACTION_PLAN_URI_TEMPLATE = "/action-plans/{prisonNumber}"
+    const val GET_TIMELINE_URI_TEMPLATE = "/timelines/{prisonNumber}"
+  }
 
   init {
     // set awaitility defaults
@@ -46,4 +62,32 @@ abstract class IntegrationTestBase {
     actionPlanRepository.deleteAll() // Will also remove all Goals and Steps due to cascade
     timelineRepository.deleteAll() // Will also remove all TimelineEvents due to cascade
   }
+
+  fun getActionPlan(prisonNumber: String): ActionPlanResponse =
+    webTestClient.get()
+      .uri(GET_ACTION_PLAN_URI_TEMPLATE, prisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .returnResult(ActionPlanResponse::class.java)
+      .responseBody.blockFirst()!!
+
+  fun createActionPlan(
+    prisonNumber: String,
+    createActionPlanRequest: CreateActionPlanRequest = aValidCreateActionPlanRequest(),
+  ) {
+    webTestClient.post()
+      .uri(CREATE_ACTION_PLAN_URI_TEMPLATE, prisonNumber)
+      .withBody(createActionPlanRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+  }
+
+  fun getTimeline(prisonNumber: String): TimelineResponse =
+    webTestClient.get()
+      .uri(GET_TIMELINE_URI_TEMPLATE, prisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .returnResult(TimelineResponse::class.java)
+      .responseBody.blockFirst()!!
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -100,7 +100,7 @@ class CreateActionPlanTest : IntegrationTestBase() {
     assertThat(actual)
       .hasStatus(BAD_REQUEST.value())
       .hasUserMessage("Validation failed for object='createActionPlanRequest'. Error count: 1")
-      .hasDeveloperMessageContaining("Error on field 'goals[0].steps': rejected value [[]], size must be between 1 and 2147483647")
+      .hasDeveloperMessageContaining("Error on field 'goals[0].steps': rejected value [[]], Steps cannot be empty when creating a Goal")
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanSummariesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanSummariesTest.kt
@@ -4,14 +4,12 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.anotherValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanSummaryListResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidActionPlanSummaryResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
@@ -113,16 +111,5 @@ class GetActionPlanSummariesTest : IntegrationTestBase() {
       .ignoringCollectionOrder()
       .ignoringFields("actionPlanSummaries.reference")
       .isEqualTo(expectedResponse)
-  }
-
-  private fun createActionPlan(prisonNumber: String, createActionPlanRequest: CreateActionPlanRequest) {
-    webTestClient.post()
-      .uri("$URI_TEMPLATE/{prisonNumber}", prisonNumber)
-      .withBody(createActionPlanRequest)
-      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
-      .contentType(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus()
-      .isCreated()
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -10,11 +10,11 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewA
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 import java.time.LocalDate
@@ -98,7 +98,7 @@ class GetActionPlanTest : IntegrationTestBase() {
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
       .hasNoReviewDate()
-      .goal(0) {
+      .goal(1) {
         it.wasCreatedAtPrison("BXI")
           .wasCreatedBy("auser_gen")
           .hasCreatedByDisplayName("Albert User")
@@ -135,33 +135,23 @@ class GetActionPlanTest : IntegrationTestBase() {
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
       .hasReviewDate(expectedReviewDate)
-      .goal(0) {
+      .goal(1) {
         it.hasTitle("Learn Spanish")
       }
       // verify order of remaining goals
-      .goal(1) {
+      .goal(2) {
         it.hasTitle("Learn French")
       }
-      .goal(2) {
+      .goal(3) {
         it.hasTitle("Learn German")
       }
   }
 
-  private fun createActionPlan(prisonNumber: String, createActionPlanRequest: CreateActionPlanRequest) {
-    webTestClient.post()
-      .uri("$URI_TEMPLATE", prisonNumber)
-      .withBody(createActionPlanRequest)
-      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
-      .contentType(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus()
-      .isCreated()
-  }
-
   private fun createGoal(prisonNumber: String, createGoalRequest: CreateGoalRequest) {
+    val createGoalsRequest = aValidCreateGoalsRequest(goals = listOf(createGoalRequest))
     webTestClient.post()
       .uri("$URI_TEMPLATE/goals", prisonNumber)
-      .withBody(createGoalRequest)
+      .withBody(createGoalsRequest)
       .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
       .contentType(MediaType.APPLICATION_JSON)
       .exchange()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateGoalsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.aValidUpdateStepRequest
@@ -285,9 +286,10 @@ class UpdateGoalTest : IntegrationTestBase() {
     prisonNumber: String,
     createGoalRequest: CreateGoalRequest,
   ) {
+    val createGoalsRequest = aValidCreateGoalsRequest(goals = listOf(createGoalRequest))
     webTestClient.post()
       .uri("/action-plans/{prisonNumber}/goals", prisonNumber)
-      .withBody(createGoalRequest)
+      .withBody(createGoalsRequest)
       .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
       .contentType(APPLICATION_JSON)
       .exchange()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
 
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ActionPlanEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlan
@@ -14,16 +15,19 @@ class JpaActionPlanPersistenceAdapter(
   private val actionPlanMapper: ActionPlanEntityMapper,
 ) : ActionPlanPersistenceAdapter {
 
+  @Transactional
   override fun createActionPlan(createActionPlanDto: CreateActionPlanDto): ActionPlan {
     val persistedEntity = actionPlanRepository.save(actionPlanMapper.fromDtoToEntity(createActionPlanDto))
     return actionPlanMapper.fromEntityToDomain(persistedEntity)
   }
 
+  @Transactional(readOnly = true)
   override fun getActionPlan(prisonNumber: String): ActionPlan? =
     actionPlanRepository.findByPrisonNumber(prisonNumber)?.let {
       actionPlanMapper.fromEntityToDomain(it)
     }
 
+  @Transactional(readOnly = true)
   override fun getActionPlanSummaries(prisonNumbers: List<String>): List<ActionPlanSummary> =
     actionPlanRepository.findByPrisonNumberIn(prisonNumbers).let {
       actionPlanMapper.fromEntitySummariesToDomainSummaries(it)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.GoalResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.GoalReferenceMatchesReferenceInUpdateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalService
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
 import java.util.UUID
 
@@ -30,15 +30,15 @@ class GoalController(
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
-  fun createGoal(
+  fun createGoals(
     @Valid
     @RequestBody
-    request: CreateGoalRequest,
+    request: CreateGoalsRequest,
     @PathVariable prisonNumber: String,
   ) {
-    goalService.createGoal(
+    goalService.createGoals(
       prisonNumber = prisonNumber,
-      createGoalDto = goalResourceMapper.fromModelToDto(request),
+      createGoalDtos = request.goals.map { goalResourceMapper.fromModelToDto(it) },
     )
   }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,3 +1,5 @@
 Size.createActionPlanRequest.goals=Goals cannot be empty when creating an Action Plan
-Size.createGoalRequest.steps=Steps cannot be empty when creating a Goal
+Size.createActionPlanRequest.goals.steps=Steps cannot be empty when creating a Goal
+Size.createGoalsRequest.goals=Goals cannot be empty when creating Goals
+Size.createGoalsRequest.goals.steps=Steps cannot be empty when creating a Goal
 Size.updateGoalRequest.steps=Steps cannot be empty when updating a Goal

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -86,7 +86,7 @@ paths:
       summary: Creates one or more Goals.
       description: Creates one or more Goals and saves them to the Prisoner's Action Plan (the latter will be created if it doesn't already exist).
       tags:
-        - Action Plan Goals
+        - Goals
       responses:
         '201':
           description: The Goal(s) were created successfully.
@@ -119,7 +119,7 @@ paths:
       summary: Updates a Goal
       description: Updates a single Goal and its list of Steps (including their sequential order if relevant). Note that the whole of a Goal's data should be provided, otherwise the absence of any data (such as a Step) will result in it being removed.
       tags:
-        - Action Plan Goals
+        - Goals
       responses:
         '204':
           description: The Goal was updated successfully.
@@ -490,7 +490,7 @@ components:
     CreateGoalsRequest:
       title: CreateGoalsRequest
       type: object
-      description: A request to create one or more Goals that a Prisoner aims to complete as part of their Action Plan. The goal's status will be set to 'ACTIVE'.
+      description: A request to create one or more Goals that a Prisoner aims to complete as part of their Action Plan. The status of each goal will be set to 'ACTIVE'.
       properties:
         goals:
           type: array

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.2.2'
+  version: '1.3.0'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -83,20 +83,20 @@ paths:
         in: path
         required: true
     post:
-      summary: Creates a Goal.
-      description: Creates a Goal and saves it to the Prisoner's Action Plan (the latter will be created if it doesn't already exist).
+      summary: Creates one or more Goals.
+      description: Creates one or more Goals and saves them to the Prisoner's Action Plan (the latter will be created if it doesn't already exist).
       tags:
-        - Action Plan - Single Goal
+        - Action Plan Goals
       responses:
         '201':
-          description: The Goal was created successfully.
+          description: The Goal(s) were created successfully.
         '400':
           $ref: '#/components/responses/400ErrorResponse'
         '404':
           $ref: '#/components/responses/404ErrorResponse'
-      operationId: create-goal
+      operationId: create-goals
       requestBody:
-        $ref: '#/components/requestBodies/CreateGoal'
+        $ref: '#/components/requestBodies/CreateGoals'
 
   '/action-plans/{prisonNumber}/goals/{goalReference}':
     parameters:
@@ -119,7 +119,7 @@ paths:
       summary: Updates a Goal
       description: Updates a single Goal and its list of Steps (including their sequential order if relevant). Note that the whole of a Goal's data should be provided, otherwise the absence of any data (such as a Step) will result in it being removed.
       tags:
-        - Action Plan - Single Goal
+        - Action Plan Goals
       responses:
         '204':
           description: The Goal was updated successfully.
@@ -443,6 +443,8 @@ components:
       title: CreateActionPlanRequest
       type: object
       description: A request to create an Action Plan with at least one or more Goals that a Prisoner aims to complete.
+      allOf:
+        - $ref: '#/components/schemas/CreateGoalsRequest'
       properties:
         reviewDate:
           type: string
@@ -450,14 +452,6 @@ components:
           x-constraints: 'NotInPast'
           description: An optional ISO-8601 date representing when the Action Plan is up for review.
           example: '2023-12-19'
-        goals:
-          type: array
-          minItems: 1
-          description: A List of at least one Goal.
-          items:
-            $ref: '#/components/schemas/CreateGoalRequest'
-      required:
-        - goals
 
     CreateGoalRequest:
       title: CreateGoalRequest
@@ -492,6 +486,20 @@ components:
         - title
         - steps
         - prisonId
+
+    CreateGoalsRequest:
+      title: CreateGoalsRequest
+      type: object
+      description: A request to create one or more Goals that a Prisoner aims to complete as part of their Action Plan. The goal's status will be set to 'ACTIVE'.
+      properties:
+        goals:
+          type: array
+          minItems: 1
+          description: A List of at least one Goal.
+          items:
+            $ref: '#/components/schemas/CreateGoalRequest'
+      required:
+        - goals
 
     UpdateGoalRequest:
       title: UpdateGoalRequest
@@ -760,12 +768,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CreateActionPlanRequest'
-    CreateGoal:
-      description: Request body to create a single Goal.
+    CreateGoals:
+      description: Request body to create one or more Goals.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CreateGoalRequest'
+            $ref: '#/components/schemas/CreateGoalsRequest'
     UpdateGoal:
       description: Request body to update a single Goal.
       content:

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ActionPlanResponseAssert.kt
@@ -52,15 +52,28 @@ class ActionPlanResponseAssert(actual: ActionPlanResponse?) :
     return this
   }
 
+  fun hasNumberOfGoals(numberOfGoals: Int): ActionPlanResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (goals.size != numberOfGoals) {
+        failWithMessage("Expected ActionPlan to be have $numberOfGoals goals set, but has ${goals.size}")
+      }
+    }
+    return this
+  }
+
   /**
    * Allows for assertion chaining into the specified child [GoalResponse]. Takes a lambda as the method argument
    * to call assertion methods provided by [GoalResponseAssert].
    * Returns this [ActionPlanResponseAssert] to allow further chained assertions on the parent [ActionPlanResponse]
+   *
+   * The `goalNumber` parameter is not zero indexed to make for better readability in tests. IE. the first goal
+   * should be referenced as `.goal(1) { .... }`
    */
   fun goal(goalNumber: Int, consumer: Consumer<GoalResponseAssert>): ActionPlanResponseAssert {
     isNotNull
     with(actual!!) {
-      val goal = goals[goalNumber]
+      val goal = goals[goalNumber - 1]
       consumer.accept(assertThat(goal))
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateGoalsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/CreateGoalsRequestBuilder.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
+
+fun aValidCreateGoalsRequest(
+  goals: List<CreateGoalRequest> = listOf(aValidCreateGoalRequest()),
+): CreateGoalsRequest =
+  CreateGoalsRequest(
+    goals = goals,
+  )
+
+fun anotherValidCreateGoalsRequest(
+  goals: List<CreateGoalRequest> = listOf(anotherValidCreateGoalRequest()),
+): CreateGoalsRequest =
+  CreateGoalsRequest(
+    goals = goals,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/GoalResponseAssert.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.AbstractObjectAssert
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
+import java.util.function.Consumer
 
 fun assertThat(actual: GoalResponse?) = GoalResponseAssert(actual)
 
@@ -123,11 +124,64 @@ class GoalResponseAssert(actual: GoalResponse?) :
     return this
   }
 
+  fun hasNoNotes(): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (notes != null) {
+        failWithMessage("Expected goal to have no notes, but was $notes")
+      }
+    }
+    return this
+  }
+
+  fun hasNotes(expected: String): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (notes != expected) {
+        failWithMessage("Expected goal to have notes '$expected', but was $notes")
+      }
+    }
+    return this
+  }
+
   fun hasReference(expected: UUID): GoalResponseAssert {
     isNotNull
     with(actual!!) {
       if (goalReference != expected) {
         failWithMessage("Expected reference to be $expected, but was $goalReference")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [StepResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [StepResponseAssert].
+   * Returns this [GoalResponseAssert] to allow further chained assertions on the parent [GoalResponse]
+   *
+   * The `stepNumber` parameter is not zero indexed to make for better readability in tests. IE. the first step
+   * should be referenced as `.step(1) { .... }`
+   */
+  fun step(stepNumber: Int, consumer: Consumer<StepResponseAssert>): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val step = steps[stepNumber - 1]
+      consumer.accept(assertThat(step))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into all child [StepResponse]s. Takes a lambda as the method argument
+   * to call assertion methods provided by [SteoResponseAssert].
+   * Returns this [GoalResponseAssert] to allow further chained assertions on the parent [GoalResponse]
+   * The assertions on all [StepResponse]s must pass as true.
+   */
+  fun allSteps(consumer: Consumer<StepResponseAssert>): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      steps.onEach {
+        consumer.accept(assertThat(it))
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/StepResourceAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/StepResourceAssert.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model
+
+import org.assertj.core.api.AbstractObjectAssert
+import java.util.UUID
+
+fun assertThat(actual: StepResponse?) = StepResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [StepResponse]
+ */
+class StepResponseAssert(actual: StepResponse?) :
+  AbstractObjectAssert<StepResponseAssert, StepResponse?>(actual, StepResponseAssert::class.java) {
+
+  fun hasTitle(expected: String): StepResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (title != expected) {
+        failWithMessage("Expected title to be $expected, but was $title")
+      }
+    }
+    return this
+  }
+
+  fun hasTargetDateRange(expected: TargetDateRange): StepResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (targetDateRange != expected) {
+        failWithMessage("Expected targetDateRange to be $expected, but was $targetDateRange")
+      }
+    }
+    return this
+  }
+
+  fun hasStatus(expected: StepStatus): StepResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (status != expected) {
+        failWithMessage("Expected status to be $expected, but was $status")
+      }
+    }
+    return this
+  }
+
+  fun hasReference(expected: UUID): StepResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (stepReference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $stepReference")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/TimelineResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/TimelineResponseAssert.kt
@@ -21,15 +21,28 @@ class TimelineResponseAssert(actual: TimelineResponse?) :
     return this
   }
 
+  fun hasNumberOfEvents(numberOfEvents: Int): TimelineResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (events.size != numberOfEvents) {
+        failWithMessage("Expected Timeline to be have $numberOfEvents events, but has ${events.size}")
+      }
+    }
+    return this
+  }
+
   /**
    * Allows for assertion chaining into the specified child [TimelineEventResponse]. Takes a lambda as the method argument
    * to call assertion methods provided by [TimelineEventResponseAssert].
    * Returns this [TimelineResponseAssert] to allow further chained assertions on the parent [TimelineResponse]
+   *
+   * The `eventNumber` parameter is not zero indexed to make for better readability in tests. IE. the first event
+   * should be referenced as `.event(1) { .... }`
    */
   fun event(eventNumber: Int, consumer: Consumer<TimelineEventResponseAssert>): TimelineResponseAssert {
     isNotNull
     with(actual!!) {
-      val event = events[eventNumber]
+      val event = events[eventNumber - 1]
       consumer.accept(assertThat(event))
     }
     return this


### PR DESCRIPTION
This PR refactors the `create-goal` API to `create-goals` to be able to support creating 1 or more goals in a single request.

It's a pretty big PR, and theres been quite a lot of refactoring along the way. The largest refactoring was the `CreateGoalsIntegrationTest` where the test now exclusively uses REST API calls to setup data and assert state (previously it used database access via repository classes, and we were getting into a confusing mess with transactions !)