### PR TITLE
RR-307 - TelemetryEventType now responsible for the events custom dimensions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryEventType.kt
@@ -1,18 +1,58 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+
 /**
- * An enumeration of the types of Goal events that can be sent to the Telemetry Service.
+ * An enumeration of the types of Goal events that can be sent to the Telemetry Service, where each item has:
+ *   * a text field `value` that is the name of the customEvent recorded in App Insights.
+ *   * a function `customDimensions` that returns the customDimensions that are recorded with the App Insights event.
  */
-enum class TelemetryEventType(val value: String) {
-  GOAL_CREATED("goal-created"),
-  GOAL_UPDATED("goal-updated"),
-  GOAL_STARTED("goal-started"),
-  GOAL_COMPLETED("goal-completed"),
-  GOAL_ARCHIVED("goal-archived"),
-  STEP_UPDATED("step-updated"),
-  STEP_NOT_STARTED("step-not-started"),
-  STEP_STARTED("step-started"),
-  STEP_COMPLETED("step-completed"),
-  STEP_REMOVED("step-removed"),
-  STEP_ADDED("step-added"),
+enum class TelemetryEventType(val value: String, val customDimensions: (goal: Goal) -> Map<String, String>) {
+  GOAL_CREATED(
+    "goal-created",
+    {
+      mapOf(
+        "status" to it.status.name,
+        "stepCount" to it.steps.size.toString(),
+        "reference" to it.reference.toString(),
+        "notesCharacterCount" to (it.notes?.length ?: 0).toString(),
+      )
+    },
+  ),
+
+  GOAL_UPDATED(
+    "goal-updated",
+    {
+      mapOf(
+        "reference" to it.reference.toString(),
+        "notesCharacterCount" to (it.notes?.length ?: 0).toString(),
+      )
+    },
+  ),
+
+  GOAL_STARTED("goal-started", { emptyMap() }),
+
+  GOAL_COMPLETED("goal-completed", { emptyMap() }),
+
+  GOAL_ARCHIVED("goal-archived", { emptyMap() }),
+
+  STEP_UPDATED("step-updated", { emptyMap() }),
+
+  STEP_NOT_STARTED("step-not-started", { emptyMap() }),
+
+  STEP_STARTED("step-started", { emptyMap() }),
+
+  STEP_COMPLETED("step-completed", { emptyMap() }),
+
+  STEP_REMOVED(
+    "step-removed",
+    {
+      mapOf(
+        "reference" to it.reference.toString(),
+        "stepCount" to it.steps.size.toString(),
+      )
+    },
+  ),
+
+  STEP_ADDED("step-added", { emptyMap() }),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
@@ -18,15 +18,15 @@ class TelemetryService(
 ) {
 
   fun trackGoalCreatedEvent(goal: Goal) {
-    telemetryClient.trackEvent(GOAL_CREATED.value, createEventCustomDimensions(goal))
+    sendTelemetryEventForGoal(goal, GOAL_CREATED)
   }
 
   fun trackGoalUpdatedEvent(goal: Goal) {
-    telemetryClient.trackEvent(GOAL_UPDATED.value, updateEventCustomDimensions(goal))
+    sendTelemetryEventForGoal(goal, GOAL_UPDATED)
   }
 
   fun trackStepRemovedEvent(goal: Goal) {
-    telemetryClient.trackEvent(STEP_REMOVED.value, stepRemoveEventCustomDimensions(goal))
+    sendTelemetryEventForGoal(goal, STEP_REMOVED)
   }
 
   /**
@@ -45,38 +45,6 @@ class TelemetryService(
     }
   }
 
-  /**
-   * Returns a map of data representing the custom dimensions for the `goal-create` event.
-   */
-  private fun createEventCustomDimensions(goal: Goal): Map<String, String> =
-    with(goal) {
-      mapOf(
-        "status" to status.name,
-        "stepCount" to steps.size.toString(),
-        "reference" to reference.toString(),
-        "notesCharacterCount" to (notes?.length ?: 0).toString(),
-      )
-    }
-
-  /**
-   * Returns a map of data representing the custom dimensions for the `goal-update` event.
-   */
-  private fun updateEventCustomDimensions(goal: Goal): Map<String, String> =
-    with(goal) {
-      mapOf(
-        "reference" to reference.toString(),
-        "notesCharacterCount" to (notes?.length ?: 0).toString(),
-      )
-    }
-
-  /**
-   * Returns a map of data representing the custom dimensions for the `step-remove` event.
-   */
-  private fun stepRemoveEventCustomDimensions(goal: Goal): Map<String, String> =
-    with(goal) {
-      mapOf(
-        "reference" to reference.toString(),
-        "stepCount" to steps.size.toString(),
-      )
-    }
+  private fun sendTelemetryEventForGoal(goal: Goal, telemetryEventType: TelemetryEventType) =
+    telemetryClient.trackEvent(telemetryEventType.value, telemetryEventType.customDimensions(goal))
 }


### PR DESCRIPTION
This PR makes a minor refactoring to the enum `TelemetryEventType` so that it is responsible for generating the custom dimensions map, rather than doing it in `TelemetryService`

Previously the enum `TelemetryEventType` knew about and was responsible for the App Insights customEvent name (the `value` field), but the `TelemetryService` knew about how to generate the custom dimensions for each event type. This felt wrong.

This PR adds a field to the enum `TelemetryEventType` which is a function that returns the custom dimensions specific for that event type. It feels right, in that the enum now knows about everything it needs in order to send the App Insights telemetry event. It knows about the customEvent name, and also the map of custom dimensions 👍 