### PR TITLE
RR-422 - Induction related tables and entities

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -16,6 +16,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.InductionRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.TimelineRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.InboundEventsService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.LocalStackContainer
@@ -66,6 +67,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var timelineRepository: TimelineRepository
+
+  @Autowired
+  lateinit var inductionRepository: InductionRepository
 
   @SpyBean
   lateinit var telemetryClient: TelemetryClient

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/TempRepositoryTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/TempRepositoryTest.kt
@@ -1,0 +1,265 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.AffectAbilityToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.FutureWorkInterestsEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.HighestEducationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.HopingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonInterestsEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonTrainingInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonTrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonWorkInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonWorkType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InterestType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.NotHopingToWorkReason
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PersonalInterestEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PersonalSkillEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PersonalSkillsAndInterestsEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PreviousQualificationsEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PreviousTrainingEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PreviousWorkExperiencesEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.QualificationEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.QualificationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.SkillType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.TrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.WorkExperienceEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.WorkExperienceType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.WorkInterestEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.WorkInterestType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.WorkOnReleaseEntity
+import java.util.UUID
+
+@Deprecated("A temporary IT until we have the REST endpoint in place")
+internal class TempRepositoryTest : IntegrationTestBase() {
+
+  @Test
+  @Transactional
+  fun `should process CIAG induction created event`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val prisonId = "BXI"
+    // TODO - add test data builder
+    val induction = InductionEntity(
+      reference = UUID.randomUUID(),
+      prisonNumber = prisonNumber,
+      workOnRelease = WorkOnReleaseEntity(
+        reference = UUID.randomUUID(),
+        hopingToWork = HopingToWork.NO,
+        notHopingToWorkReasons = listOf(NotHopingToWorkReason.NOT_SURE),
+        notHopingToWorkOtherReason = "Test notHopingToWorkOtherReason",
+        affectAbilityToWork = listOf(AffectAbilityToWork.CARING_RESPONSIBILITIES),
+        affectAbilityToWorkOther = "Test affectAbilityToWorkOther",
+        createdAtPrison = prisonId,
+        updatedAtPrison = prisonId,
+      ),
+      previousQualifications = PreviousQualificationsEntity(
+        reference = UUID.randomUUID(),
+        educationLevel = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
+        qualifications = listOf(
+          QualificationEntity(
+            reference = UUID.randomUUID(),
+            subject = "English",
+            level = QualificationLevel.LEVEL_3,
+            grade = "A",
+          ),
+          QualificationEntity(
+            reference = UUID.randomUUID(),
+            subject = "Maths",
+            level = QualificationLevel.LEVEL_4,
+            grade = "A",
+          ),
+        ),
+        createdAtPrison = prisonId,
+        updatedAtPrison = prisonId,
+      ),
+      previousTraining = PreviousTrainingEntity(
+        reference = UUID.randomUUID(),
+        trainingTypes = listOf(TrainingType.OTHER),
+        trainingTypeOther = "Test trainingTypeOther",
+        createdAtPrison = prisonId,
+        updatedAtPrison = prisonId,
+      ),
+      previousWorkExperiences = PreviousWorkExperiencesEntity(
+        reference = UUID.randomUUID(),
+        experiences = listOf(
+          WorkExperienceEntity(
+            reference = UUID.randomUUID(),
+            experienceType = WorkExperienceType.DRIVING,
+            experienceTypeOther = "Test experienceTypeOther",
+            role = "Chief Forklift Truck Driver",
+            details = "Forward, pick stuff up, reverse",
+          ),
+        ),
+        createdAtPrison = prisonId,
+        updatedAtPrison = prisonId,
+      ),
+      inPrisonInterests = InPrisonInterestsEntity(
+        reference = UUID.randomUUID(),
+        inPrisonWorkInterests = listOf(
+          InPrisonWorkInterest(
+            reference = UUID.randomUUID(),
+            workType = InPrisonWorkType.CLEANING_AND_HYGIENE,
+            workTypeOther = "Test workTypeOther",
+          ),
+        ),
+        inPrisonTrainingInterests = listOf(
+          InPrisonTrainingInterest(
+            reference = UUID.randomUUID(),
+            trainingType = InPrisonTrainingType.OTHER,
+            trainingTypeOther = "Test trainingTypeOther",
+          ),
+        ),
+        createdAtPrison = prisonId,
+        updatedAtPrison = prisonId,
+      ),
+      personalSkillsAndInterests = PersonalSkillsAndInterestsEntity(
+        reference = UUID.randomUUID(),
+        skills = listOf(
+          PersonalSkillEntity(
+            reference = UUID.randomUUID(),
+            skillType = SkillType.COMMUNICATION,
+            skillTypeOther = "Test skillTypeOther",
+          ),
+        ),
+        interests = listOf(
+          PersonalInterestEntity(
+            reference = UUID.randomUUID(),
+            interestType = InterestType.COMMUNITY,
+            interestTypeOther = "Test interestTypeOther",
+          ),
+        ),
+        createdAtPrison = prisonId,
+        updatedAtPrison = prisonId,
+      ),
+      futureWorkInterestsEntity = FutureWorkInterestsEntity(
+        reference = UUID.randomUUID(),
+        interests = listOf(
+          WorkInterestEntity(
+            reference = UUID.randomUUID(),
+            workType = WorkInterestType.BEAUTY,
+            workTypeOther = "Test workTypeOther",
+            role = "Cutting nails",
+          ),
+        ),
+        createdAtPrison = prisonId,
+        updatedAtPrison = prisonId,
+      ),
+      createdAtPrison = prisonId,
+      updatedAtPrison = prisonId,
+    )
+    inductionRepository.save(induction)
+
+    // When
+    val actual = inductionRepository.findByPrisonNumber(prisonNumber)
+
+    // Then
+    // TODO - add custom assertions
+    assertThat(actual!!.id).isNotNull()
+    assertThat(actual.reference).isNotNull()
+    assertThat(actual.createdAt).isNotNull()
+    assertThat(actual.createdAtPrison).isEqualTo(prisonId)
+    assertThat(actual.createdBy).isNotNull()
+    assertThat(actual.createdByDisplayName).isNotNull()
+    assertThat(actual.updatedAt).isNotNull()
+    assertThat(actual.updatedAtPrison).isEqualTo(prisonId)
+    assertThat(actual.updatedBy).isNotNull()
+    assertThat(actual.updatedByDisplayName).isNotNull()
+
+    assertThat(actual.workOnRelease).isNotNull()
+    assertThat(actual.workOnRelease!!.id).isNotNull()
+    assertThat(actual.workOnRelease!!.reference).isNotNull()
+    assertThat(actual.workOnRelease!!.hopingToWork).isEqualTo(HopingToWork.NO)
+    assertThat(actual.workOnRelease!!.notHopingToWorkReasons).containsExactly(NotHopingToWorkReason.NOT_SURE)
+    assertThat(actual.workOnRelease!!.notHopingToWorkOtherReason).isEqualTo("Test notHopingToWorkOtherReason")
+    assertThat(actual.workOnRelease!!.affectAbilityToWork).containsExactly(AffectAbilityToWork.CARING_RESPONSIBILITIES)
+    assertThat(actual.workOnRelease!!.affectAbilityToWorkOther).isEqualTo("Test affectAbilityToWorkOther")
+    assertThat(actual.workOnRelease!!.createdAtPrison).isEqualTo(prisonId)
+    assertThat(actual.workOnRelease!!.updatedAtPrison).isEqualTo(prisonId)
+
+    assertThat(actual.previousQualifications).isNotNull()
+    assertThat(actual.previousQualifications!!.id).isNotNull()
+    assertThat(actual.previousQualifications!!.reference).isNotNull()
+    assertThat(actual.previousQualifications!!.educationLevel).isEqualTo(HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS)
+    assertThat(actual.previousQualifications!!.qualifications).hasSize(2)
+    assertThat(actual.previousQualifications!!.createdAt).isNotNull()
+    assertThat(actual.previousQualifications!!.createdAtPrison).isEqualTo(prisonId)
+    assertThat(actual.previousQualifications!!.createdBy).isNotNull()
+    assertThat(actual.previousQualifications!!.createdByDisplayName).isNotNull()
+    assertThat(actual.previousQualifications!!.updatedAt).isNotNull()
+    assertThat(actual.previousQualifications!!.updatedAtPrison).isEqualTo(prisonId)
+    assertThat(actual.previousQualifications!!.updatedBy).isNotNull()
+    assertThat(actual.previousQualifications!!.updatedByDisplayName).isNotNull()
+
+    assertThat(actual.previousTraining).isNotNull()
+    assertThat(actual.previousTraining!!.id).isNotNull()
+    assertThat(actual.previousTraining!!.reference).isNotNull()
+    assertThat(actual.previousTraining!!.trainingTypes).containsExactly(TrainingType.OTHER)
+    assertThat(actual.previousTraining!!.trainingTypeOther).isEqualTo("Test trainingTypeOther")
+    assertThat(actual.previousTraining!!.createdAt).isNotNull()
+    assertThat(actual.previousTraining!!.createdAtPrison).isEqualTo(prisonId)
+    assertThat(actual.previousTraining!!.createdBy).isNotNull()
+    assertThat(actual.previousTraining!!.createdByDisplayName).isNotNull()
+    assertThat(actual.previousTraining!!.updatedAt).isNotNull()
+    assertThat(actual.previousTraining!!.updatedAtPrison).isEqualTo(prisonId)
+    assertThat(actual.previousTraining!!.updatedBy).isNotNull()
+    assertThat(actual.previousTraining!!.updatedByDisplayName).isNotNull()
+
+    assertThat(actual.previousWorkExperiences).isNotNull()
+    assertThat(actual.previousWorkExperiences!!.id).isNotNull()
+    assertThat(actual.previousWorkExperiences!!.reference).isNotNull()
+    assertThat(actual.previousWorkExperiences!!.experiences).hasSize(1)
+    assertThat(actual.previousWorkExperiences!!.createdAt).isNotNull()
+    assertThat(actual.previousWorkExperiences!!.createdAtPrison).isEqualTo(prisonId)
+    assertThat(actual.previousWorkExperiences!!.createdBy).isNotNull()
+    assertThat(actual.previousWorkExperiences!!.createdByDisplayName).isNotNull()
+    assertThat(actual.previousWorkExperiences!!.updatedAt).isNotNull()
+    assertThat(actual.previousWorkExperiences!!.updatedAtPrison).isEqualTo(prisonId)
+    assertThat(actual.previousWorkExperiences!!.updatedBy).isNotNull()
+    assertThat(actual.previousWorkExperiences!!.updatedByDisplayName).isNotNull()
+
+    assertThat(actual.inPrisonInterests).isNotNull()
+    assertThat(actual.inPrisonInterests!!.id).isNotNull()
+    assertThat(actual.inPrisonInterests!!.reference).isNotNull()
+    assertThat(actual.inPrisonInterests!!.inPrisonWorkInterests).hasSize(1)
+    assertThat(actual.inPrisonInterests!!.inPrisonTrainingInterests).hasSize(1)
+    assertThat(actual.inPrisonInterests!!.createdAt).isNotNull()
+    assertThat(actual.inPrisonInterests!!.createdAtPrison).isEqualTo(prisonId)
+    assertThat(actual.inPrisonInterests!!.createdBy).isNotNull()
+    assertThat(actual.inPrisonInterests!!.createdByDisplayName).isNotNull()
+    assertThat(actual.inPrisonInterests!!.updatedAt).isNotNull()
+    assertThat(actual.inPrisonInterests!!.updatedAtPrison).isEqualTo(prisonId)
+    assertThat(actual.inPrisonInterests!!.updatedBy).isNotNull()
+    assertThat(actual.inPrisonInterests!!.updatedByDisplayName).isNotNull()
+
+    assertThat(actual.personalSkillsAndInterests).isNotNull()
+    assertThat(actual.personalSkillsAndInterests!!.id).isNotNull()
+    assertThat(actual.personalSkillsAndInterests!!.reference).isNotNull()
+    assertThat(actual.personalSkillsAndInterests!!.skills).hasSize(1)
+    assertThat(actual.personalSkillsAndInterests!!.interests).hasSize(1)
+    assertThat(actual.personalSkillsAndInterests!!.createdAt).isNotNull()
+    assertThat(actual.personalSkillsAndInterests!!.createdAtPrison).isEqualTo(prisonId)
+    assertThat(actual.personalSkillsAndInterests!!.createdBy).isNotNull()
+    assertThat(actual.personalSkillsAndInterests!!.createdByDisplayName).isNotNull()
+    assertThat(actual.personalSkillsAndInterests!!.updatedAt).isNotNull()
+    assertThat(actual.personalSkillsAndInterests!!.updatedAtPrison).isEqualTo(prisonId)
+    assertThat(actual.personalSkillsAndInterests!!.updatedBy).isNotNull()
+    assertThat(actual.personalSkillsAndInterests!!.updatedByDisplayName).isNotNull()
+
+    assertThat(actual.futureWorkInterestsEntity).isNotNull()
+    assertThat(actual.futureWorkInterestsEntity!!.id).isNotNull()
+    assertThat(actual.futureWorkInterestsEntity!!.reference).isNotNull()
+    assertThat(actual.futureWorkInterestsEntity!!.interests).hasSize(1)
+    assertThat(actual.futureWorkInterestsEntity!!.createdAt).isNotNull()
+    assertThat(actual.futureWorkInterestsEntity!!.createdAtPrison).isEqualTo(prisonId)
+    assertThat(actual.futureWorkInterestsEntity!!.createdBy).isNotNull()
+    assertThat(actual.futureWorkInterestsEntity!!.createdByDisplayName).isNotNull()
+    assertThat(actual.futureWorkInterestsEntity!!.updatedAt).isNotNull()
+    assertThat(actual.futureWorkInterestsEntity!!.updatedAtPrison).isEqualTo(prisonId)
+    assertThat(actual.futureWorkInterestsEntity!!.updatedBy).isNotNull()
+    assertThat(actual.futureWorkInterestsEntity!!.updatedByDisplayName).isNotNull()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
@@ -1,0 +1,118 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Represents a Prisoner's future work aspirations, including the type/sector of work and their desired role within it.
+ */
+@Table(name = "future_work_interests")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class FutureWorkInterestsEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "work_interests_id", nullable = false)
+  var interests: List<WorkInterestEntity>? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+@Table(name = "work_interest")
+@Entity
+class WorkInterestEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var workType: WorkInterestType? = null,
+
+  @Column
+  var workTypeOther: String? = null,
+
+  @Column
+  var role: String? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+enum class WorkInterestType {
+  OUTDOOR,
+  CONSTRUCTION,
+  DRIVING,
+  BEAUTY,
+  HOSPITALITY,
+  TECHNICAL,
+  MANUFACTURING,
+  OFFICE,
+  RETAIL,
+  SPORTS,
+  WAREHOUSING,
+  WASTE_MANAGEMENT,
+  EDUCATION_TRAINING,
+  CLEANING_AND_MAINTENANCE,
+  OTHER,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
@@ -76,6 +76,7 @@ class FutureWorkInterestsEntity(
 
 @Table(name = "work_interest")
 @Entity
+@EntityListeners(AuditingEntityListener::class)
 class WorkInterestEntity(
   @Id
   @GeneratedValue

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
@@ -20,6 +20,9 @@ import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
 import java.time.Instant
 import java.util.UUID
 
@@ -28,7 +31,7 @@ import java.util.UUID
  */
 @Table(name = "future_work_interests")
 @Entity
-@EntityListeners(AuditingEntityListener::class)
+@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class])
 class FutureWorkInterestsEntity(
   @Id
   @GeneratedValue
@@ -47,17 +50,33 @@ class FutureWorkInterestsEntity(
   @CreationTimestamp
   var createdAt: Instant? = null,
 
+  @Column
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
   @Column(updatable = false)
   @CreatedBy
   var createdBy: String? = null,
+
+  @Column
+  @CreatedByDisplayName
+  var createdByDisplayName: String? = null,
 
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
 
   @Column
+  @field:NotNull
+  var updatedAtPrison: String? = null,
+
+  @Column
   @LastModifiedBy
   var updatedBy: String? = null,
+
+  @Column
+  @LastModifiedByDisplayName
+  var updatedByDisplayName: String? = null,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
+import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
@@ -57,7 +58,21 @@ class FutureWorkInterestsEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as FutureWorkInterestsEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference)"
+  }
+}
 
 @Table(name = "work_interest")
 @Entity
@@ -97,7 +112,21 @@ class WorkInterestEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as FutureWorkInterestsEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, workType = $workType, workTypeOther = $workTypeOther)"
+  }
+}
 
 enum class WorkInterestType {
   OUTDOOR,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
+import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
@@ -61,7 +62,21 @@ class InPrisonInterestsEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as InPrisonInterestsEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference)"
+  }
+}
 
 @Table(name = "in_prison_work_interest")
 @Entity
@@ -99,7 +114,21 @@ class InPrisonWorkInterest(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as InPrisonWorkInterest
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, workType = $workType, workTypeOther = $workTypeOther)"
+  }
+}
 
 @Table(name = "in_prison_training_interest")
 @Entity
@@ -137,7 +166,21 @@ class InPrisonTrainingInterest(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as InPrisonTrainingInterest
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, trainingType = $trainingType, trainingTypeOther = $trainingTypeOther)"
+  }
+}
 
 enum class InPrisonWorkType {
   CLEANING_AND_HYGIENE,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
@@ -1,0 +1,170 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Represents any in-prison work or training interests a Prisoner might have during their time in prison.
+ */
+@Table(name = "in_prison_interests")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class InPrisonInterestsEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "interests_id", nullable = false)
+  var inPrisonWorkInterests: List<InPrisonWorkInterest>? = null,
+
+  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "interests_id", nullable = false)
+  var inPrisonTrainingInterests: List<InPrisonTrainingInterest>? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+@Table(name = "in_prison_work_interest")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class InPrisonWorkInterest(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var workType: InPrisonWorkType? = null,
+
+  @Column
+  var workTypeOther: String? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+@Table(name = "in_prison_training_interest")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class InPrisonTrainingInterest(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var trainingType: InPrisonTrainingType? = null,
+
+  @Column
+  var trainingTypeOther: String? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+enum class InPrisonWorkType {
+  CLEANING_AND_HYGIENE,
+  COMPUTERS_OR_DESK_BASED,
+  GARDENING_AND_OUTDOORS,
+  KITCHENS_AND_COOKING,
+  MAINTENANCE,
+  PRISON_LAUNDRY,
+  PRISON_LIBRARY,
+  TEXTILES_AND_SEWING,
+  WELDING_AND_METALWORK,
+  WOODWORK_AND_JOINERY,
+  OTHER,
+}
+
+enum class InPrisonTrainingType {
+  BARBERING_AND_HAIRDRESSING,
+  CATERING,
+  COMMUNICATION_SKILLS,
+  ENGLISH_LANGUAGE_SKILLS,
+  FORKLIFT_DRIVING,
+  INTERVIEW_SKILLS,
+  MACHINERY_TICKETS,
+  NUMERACY_SKILLS,
+  RUNNING_A_BUSINESS,
+  SOCIAL_AND_LIFE_SKILLS,
+  WELDING_AND_METALWORK,
+  WOODWORK_AND_JOINERY,
+  OTHER,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
@@ -20,6 +20,9 @@ import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
 import java.time.Instant
 import java.util.UUID
 
@@ -28,7 +31,7 @@ import java.util.UUID
  */
 @Table(name = "in_prison_interests")
 @Entity
-@EntityListeners(AuditingEntityListener::class)
+@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class])
 class InPrisonInterestsEntity(
   @Id
   @GeneratedValue
@@ -51,17 +54,33 @@ class InPrisonInterestsEntity(
   @CreationTimestamp
   var createdAt: Instant? = null,
 
+  @Column
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
   @Column(updatable = false)
   @CreatedBy
   var createdBy: String? = null,
+
+  @Column
+  @CreatedByDisplayName
+  var createdByDisplayName: String? = null,
 
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
 
   @Column
+  @field:NotNull
+  var updatedAtPrison: String? = null,
+
+  @Column
   @LastModifiedBy
   var updatedBy: String? = null,
+
+  @Column
+  @LastModifiedByDisplayName
+  var updatedByDisplayName: String? = null,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntity.kt
@@ -46,32 +46,32 @@ class InductionEntity(
   var prisonNumber: String? = null,
 
   @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "id")
+  @JoinColumn(name = "work_on_release_id")
   @field:NotNull
   var workOnRelease: WorkOnReleaseEntity? = null,
 
   @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "id")
+  @JoinColumn(name = "previous_qualifications_id")
   var previousQualifications: PreviousQualificationsEntity? = null,
 
   @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "id")
+  @JoinColumn(name = "previous_training_id")
   var previousTraining: PreviousTrainingEntity? = null,
 
   @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "id")
+  @JoinColumn(name = "work_experiences_id")
   var previousWorkExperiences: PreviousWorkExperiencesEntity? = null,
 
   @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "id")
+  @JoinColumn(name = "in_prison_interests_id")
   var inPrisonInterests: InPrisonInterestsEntity? = null,
 
   @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "id")
+  @JoinColumn(name = "skills_and_interests_id")
   var personalSkillsAndInterests: PersonalSkillsAndInterestsEntity? = null,
 
   @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "id")
+  @JoinColumn(name = "future_work_interests_id")
   var futureWorkInterestsEntity: FutureWorkInterestsEntity? = null,
 
   @Column(updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntity.kt
@@ -1,0 +1,106 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Represents a Prisoner's Induction, which is typically carried out by a CIAG officer shortly after the Prisoner
+ * has entered a Prison (either when starting a new sentence, or after being transferred from another Prison).
+ */
+@Table(name = "induction")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class InductionEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var prisonNumber: String? = null,
+
+  @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "id")
+  @field:NotNull
+  var workOnRelease: WorkOnReleaseEntity? = null,
+
+  @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "id")
+  var previousQualifications: PreviousQualificationsEntity? = null,
+
+  @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "id")
+  var previousTraining: PreviousTrainingEntity? = null,
+
+  @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "id")
+  var previousWorkExperiences: PreviousWorkExperiencesEntity? = null,
+
+  @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "id")
+  var inPrisonInterests: InPrisonInterestsEntity? = null,
+
+  @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "id")
+  var personalSkillsAndInterests: PersonalSkillsAndInterestsEntity? = null,
+
+  @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "id")
+  var futureWorkInterestsEntity: FutureWorkInterestsEntity? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @CreatedByDisplayName
+  var createdByDisplayName: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @field:NotNull
+  var updatedAtPrison: String? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+
+  @Column
+  @LastModifiedByDisplayName
+  var updatedByDisplayName: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntity.kt
@@ -11,12 +11,14 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
+import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
 import java.time.Instant
@@ -28,7 +30,7 @@ import java.util.UUID
  */
 @Table(name = "induction")
 @Entity
-@EntityListeners(AuditingEntityListener::class)
+@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class])
 class InductionEntity(
   @Id
   @GeneratedValue
@@ -103,4 +105,18 @@ class InductionEntity(
   @Column
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as InductionEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, prisonNumber = $prisonNumber)"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionNotFoundException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionNotFoundException.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+/**
+ * Thrown when a Induction does not exist for a given Prisoner.
+ */
+class InductionNotFoundException(val prisonNumber: String) :
+  RuntimeException("Induction not found for prisoner [$prisonNumber]")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionNotFoundException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionNotFoundException.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
-
-/**
- * Thrown when a Induction does not exist for a given Prisoner.
- */
-class InductionNotFoundException(val prisonNumber: String) :
-  RuntimeException("Induction not found for prisoner [$prisonNumber]")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
+import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
@@ -63,7 +64,21 @@ class PersonalSkillsAndInterestsEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as PersonalSkillsAndInterestsEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference)"
+  }
+}
 
 @Table(name = "personal_skill")
 @Entity
@@ -101,7 +116,21 @@ class PersonalSkillEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as PersonalSkillEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, skillType = $skillType, skillTypeOther = $skillTypeOther)"
+  }
+}
 
 @Table(name = "personal_interest")
 @Entity
@@ -139,7 +168,21 @@ class PersonalInterestEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as PersonalInterestEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, interestType = $interestType, interestTypeOther = $interestTypeOther)"
+  }
+}
 
 enum class SkillType {
   COMMUNICATION,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
@@ -1,0 +1,172 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Lists the personal skills (such as communication) and interests (such as music) that a Prisoner feels they have.
+ *
+ * Note that the lists of skills/interests cannot be empty, since NONE is an option in both cases.
+ */
+@Table(name = "skills_and_interests")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class PersonalSkillsAndInterestsEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "skills_interests_id", nullable = false)
+  var skills: List<PersonalSkillEntity>? = null,
+
+  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "skills_interests_id", nullable = false)
+  var interests: List<PersonalInterestEntity>? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+@Table(name = "personal_skill")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class PersonalSkillEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var skillType: SkillType? = null,
+
+  @Column
+  var skillTypeOther: String? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+@Table(name = "personal_interest")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class PersonalInterestEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var interestType: InterestType? = null,
+
+  @Column
+  var interestTypeOther: String? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+enum class SkillType {
+  COMMUNICATION,
+  POSITIVE_ATTITUDE,
+  RESILIENCE,
+  SELF_MANAGEMENT,
+  TEAMWORK,
+  THINKING_AND_PROBLEM_SOLVING,
+  WILLINGNESS_TO_LEARN,
+  OTHER,
+  NONE,
+}
+
+enum class InterestType {
+  COMMUNITY,
+  CRAFTS,
+  CREATIVE,
+  DIGITAL,
+  KNOWLEDGE_BASED,
+  MUSICAL,
+  OUTDOOR,
+  NATURE_AND_ANIMALS,
+  SOCIAL,
+  SOLO_ACTIVITIES,
+  SOLO_SPORTS,
+  TEAM_SPORTS,
+  WELLNESS,
+  OTHER,
+  NONE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
@@ -20,6 +20,9 @@ import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
 import java.time.Instant
 import java.util.UUID
 
@@ -30,7 +33,7 @@ import java.util.UUID
  */
 @Table(name = "skills_and_interests")
 @Entity
-@EntityListeners(AuditingEntityListener::class)
+@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class])
 class PersonalSkillsAndInterestsEntity(
   @Id
   @GeneratedValue
@@ -53,17 +56,33 @@ class PersonalSkillsAndInterestsEntity(
   @CreationTimestamp
   var createdAt: Instant? = null,
 
+  @Column
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
   @Column(updatable = false)
   @CreatedBy
   var createdBy: String? = null,
+
+  @Column
+  @CreatedByDisplayName
+  var createdByDisplayName: String? = null,
 
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
 
   @Column
+  @field:NotNull
+  var updatedAtPrison: String? = null,
+
+  @Column
   @LastModifiedBy
   var updatedBy: String? = null,
+
+  @Column
+  @LastModifiedByDisplayName
+  var updatedByDisplayName: String? = null,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntity.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
+import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
@@ -66,7 +67,21 @@ class PreviousQualificationsEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as PreviousQualificationsEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, educationLevel = $educationLevel)"
+  }
+}
 
 @Table(name = "qualification")
 @Entity
@@ -105,7 +120,21 @@ class QualificationEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as QualificationEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, subject = $subject, level = $level, grade = $grade)"
+  }
+}
 
 enum class HighestEducationLevel {
   PRIMARY_SCHOOL,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntity.kt
@@ -20,6 +20,9 @@ import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
 import java.time.Instant
 import java.util.UUID
 
@@ -32,7 +35,7 @@ import java.util.UUID
  */
 @Table(name = "previous_qualifications")
 @Entity
-@EntityListeners(AuditingEntityListener::class)
+@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class])
 class PreviousQualificationsEntity(
   @Id
   @GeneratedValue
@@ -56,17 +59,33 @@ class PreviousQualificationsEntity(
   @CreationTimestamp
   var createdAt: Instant? = null,
 
+  @Column
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
   @Column(updatable = false)
   @CreatedBy
   var createdBy: String? = null,
+
+  @Column
+  @CreatedByDisplayName
+  var createdByDisplayName: String? = null,
 
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
 
   @Column
+  @field:NotNull
+  var updatedAtPrison: String? = null,
+
+  @Column
   @LastModifiedBy
   var updatedBy: String? = null,
+
+  @Column
+  @LastModifiedByDisplayName
+  var updatedByDisplayName: String? = null,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntity.kt
@@ -1,0 +1,131 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Holds details about a Prisoner's educational qualifications, including where relevant, the grades achieved in each
+ * subject.
+ *
+ * Note that the list of `qualifications` can be empty, but `educationLevel` is mandatory (but only if the Prisoner has
+ * been asked about their education).
+ */
+@Table(name = "previous_qualifications")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class PreviousQualificationsEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var educationLevel: HighestEducationLevel? = null,
+
+  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "prev_qualifications_id", nullable = false)
+  var qualifications: List<QualificationEntity>? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+@Table(name = "qualification")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class QualificationEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @field:NotNull
+  var subject: String? = null,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  var level: QualificationLevel? = null,
+
+  @Column
+  var grade: String? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+enum class HighestEducationLevel {
+  PRIMARY_SCHOOL,
+  SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS,
+  SECONDARY_SCHOOL_TOOK_EXAMS,
+  FURTHER_EDUCATION_COLLEGE,
+  UNDERGRADUATE_DEGREE_AT_UNIVERSITY,
+  POSTGRADUATE_DEGREE_AT_UNIVERSITY,
+  NOT_SURE,
+}
+
+enum class QualificationLevel {
+  ENTRY_LEVEL_2,
+  ENTRY_LEVEL_3,
+  LEVEL_1,
+  LEVEL_2,
+  LEVEL_3,
+  LEVEL_4,
+  LEVEL_5,
+  LEVEL_6,
+  LEVEL_7,
+  LEVEL_8,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntity.kt
@@ -19,6 +19,9 @@ import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
 import java.time.Instant
 import java.util.UUID
 
@@ -29,7 +32,7 @@ import java.util.UUID
  */
 @Table(name = "previous_training")
 @Entity
-@EntityListeners(AuditingEntityListener::class)
+@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class])
 class PreviousTrainingEntity(
   @Id
   @GeneratedValue
@@ -53,17 +56,33 @@ class PreviousTrainingEntity(
   @CreationTimestamp
   var createdAt: Instant? = null,
 
+  @Column
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
   @Column(updatable = false)
   @CreatedBy
   var createdBy: String? = null,
+
+  @Column
+  @CreatedByDisplayName
+  var createdByDisplayName: String? = null,
 
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
 
   @Column
+  @field:NotNull
+  var updatedAtPrison: String? = null,
+
+  @Column
   @LastModifiedBy
   var updatedBy: String? = null,
+
+  @Column
+  @LastModifiedByDisplayName
+  var updatedByDisplayName: String? = null,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntity.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Holds details of any additional training that a Prisoner may have done.
+ *
+ * Note that the list of training cannot be empty, since NONE is an option.
+ */
+@Table(name = "previous_training")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class PreviousTrainingEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @ElementCollection(targetClass = TrainingType::class)
+  @Enumerated(value = EnumType.STRING)
+  @CollectionTable(name = "training_type")
+  @Column(name = "type")
+  var trainingTypes: List<TrainingType>? = null,
+
+  @Column
+  var trainingTypeOther: String? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+enum class TrainingType {
+  CSCS_CARD,
+  FIRST_AID_CERTIFICATE,
+  FOOD_HYGIENE_CERTIFICATE,
+  FULL_UK_DRIVING_LICENCE,
+  HEALTH_AND_SAFETY,
+  HGV_LICENCE,
+  MACHINERY_TICKETS,
+  MANUAL_HANDLING,
+  TRADE_COURSE,
+  OTHER,
+  NONE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntity.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
+import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
@@ -62,7 +63,21 @@ class PreviousTrainingEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as PreviousTrainingEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, trainingTypes = $trainingTypes, trainingTypeOther = $trainingTypeOther)"
+  }
+}
 
 enum class TrainingType {
   CSCS_CARD,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntity.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
 import org.hibernate.Hibernate
@@ -41,7 +42,7 @@ class PreviousTrainingEntity(
 
   @ElementCollection(targetClass = TrainingType::class)
   @Enumerated(value = EnumType.STRING)
-  @CollectionTable(name = "training_type")
+  @CollectionTable(name = "training_type", joinColumns = [JoinColumn(name = "training_id")])
   @Column(name = "type")
   var trainingTypes: List<TrainingType>? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
+import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
@@ -60,7 +61,21 @@ class PreviousWorkExperiencesEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as PreviousWorkExperiencesEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference)"
+  }
+}
 
 @Table(name = "work_experience")
 @Entity
@@ -104,7 +119,21 @@ class WorkExperienceEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as WorkExperienceEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, experienceType = $experienceType, experienceTypeOther = $experienceTypeOther)"
+  }
+}
 
 enum class WorkExperienceType {
   OUTDOOR,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
@@ -43,7 +43,7 @@ class PreviousWorkExperiencesEntity(
   var reference: UUID? = null,
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "work_experience_id", nullable = false)
+  @JoinColumn(name = "work_experiences_id", nullable = false)
   var experiences: List<WorkExperienceEntity>? = null,
 
   @Column(updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
@@ -20,6 +20,9 @@ import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
 import java.time.Instant
 import java.util.UUID
 
@@ -31,7 +34,7 @@ import java.util.UUID
  */
 @Table(name = "previous_work_experiences")
 @Entity
-@EntityListeners(AuditingEntityListener::class)
+@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class])
 class PreviousWorkExperiencesEntity(
   @Id
   @GeneratedValue
@@ -50,17 +53,33 @@ class PreviousWorkExperiencesEntity(
   @CreationTimestamp
   var createdAt: Instant? = null,
 
+  @Column
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
   @Column(updatable = false)
   @CreatedBy
   var createdBy: String? = null,
+
+  @Column
+  @CreatedByDisplayName
+  var createdByDisplayName: String? = null,
 
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
 
   @Column
+  @field:NotNull
+  var updatedAtPrison: String? = null,
+
+  @Column
   @LastModifiedBy
   var updatedBy: String? = null,
+
+  @Column
+  @LastModifiedByDisplayName
+  var updatedByDisplayName: String? = null,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
@@ -1,0 +1,125 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Contains details of a Prisoner's work experience, if applicable.
+ *
+ * Note that if the list of `experiences` is empty, then the Prisoner has been asked if they have any work history,
+ * but either they do not, or they do not wish to provide details.
+ */
+@Table(name = "previous_work_experiences")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class PreviousWorkExperiencesEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @JoinColumn(name = "work_experience_id", nullable = false)
+  var experiences: List<WorkExperienceEntity>? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+@Table(name = "work_experience")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class WorkExperienceEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var experienceType: WorkExperienceType? = null,
+
+  @Column
+  var experienceTypeOther: String? = null,
+
+  @Column
+  var role: String? = null,
+
+  @Column
+  var details: String? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+enum class WorkExperienceType {
+  OUTDOOR,
+  CONSTRUCTION,
+  DRIVING,
+  BEAUTY,
+  HOSPITALITY,
+  TECHNICAL,
+  MANUFACTURING,
+  OFFICE,
+  RETAIL,
+  SPORTS,
+  WAREHOUSING,
+  WASTE_MANAGEMENT,
+  EDUCATION_TRAINING,
+  CLEANING_AND_MAINTENANCE,
+  OTHER,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntity.kt
@@ -19,6 +19,9 @@ import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
 import java.time.Instant
 import java.util.UUID
 
@@ -27,7 +30,7 @@ import java.util.UUID
  */
 @Table(name = "work_on_release")
 @Entity
-@EntityListeners(AuditingEntityListener::class)
+@EntityListeners(value = [AuditingEntityListener::class, DisplayNameAuditingEntityListener::class])
 class WorkOnReleaseEntity(
   @Id
   @GeneratedValue
@@ -65,17 +68,33 @@ class WorkOnReleaseEntity(
   @CreationTimestamp
   var createdAt: Instant? = null,
 
+  @Column
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
   @Column(updatable = false)
   @CreatedBy
   var createdBy: String? = null,
+
+  @Column
+  @CreatedByDisplayName
+  var createdByDisplayName: String? = null,
 
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
 
   @Column
+  @field:NotNull
+  var updatedAtPrison: String? = null,
+
+  @Column
   @LastModifiedBy
   var updatedBy: String? = null,
+
+  @Column
+  @LastModifiedByDisplayName
+  var updatedByDisplayName: String? = null,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntity.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
+import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
@@ -74,7 +75,21 @@ class WorkOnReleaseEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as WorkOnReleaseEntity
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + "(id = $id, reference = $reference, hopingToWork = $hopingToWork)"
+  }
+}
 
 enum class HopingToWork {
   YES,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntity.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
 import org.hibernate.Hibernate
@@ -44,7 +45,7 @@ class WorkOnReleaseEntity(
 
   @ElementCollection(targetClass = NotHopingToWorkReason::class)
   @Enumerated(value = EnumType.STRING)
-  @CollectionTable(name = "not_working_reasons")
+  @CollectionTable(name = "not_working_reasons", joinColumns = [JoinColumn(name = "work_on_release_id")])
   @Column(name = "reason")
   var notHopingToWorkReasons: List<NotHopingToWorkReason>? = null,
 
@@ -53,7 +54,7 @@ class WorkOnReleaseEntity(
 
   @ElementCollection(targetClass = AffectAbilityToWork::class)
   @Enumerated(value = EnumType.STRING)
-  @CollectionTable(name = "affecting_ability_to_work")
+  @CollectionTable(name = "affecting_ability_to_work", joinColumns = [JoinColumn(name = "work_on_release_id")])
   @Column(name = "affect")
   var affectAbilityToWork: List<AffectAbilityToWork>? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntity.kt
@@ -1,0 +1,104 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Holds details of a Prisoner's work aspirations, including any barriers affecting their work.
+ */
+@Table(name = "work_on_release")
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class WorkOnReleaseEntity(
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  @Column(updatable = false)
+  @field:NotNull
+  var reference: UUID? = null,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  @field:NotNull
+  var hopingToWork: HopingToWork? = null,
+
+  @ElementCollection(targetClass = NotHopingToWorkReason::class)
+  @Enumerated(value = EnumType.STRING)
+  @CollectionTable(name = "not_working_reasons")
+  @Column(name = "reason")
+  var notHopingToWorkReasons: List<NotHopingToWorkReason>? = null,
+
+  @Column
+  var notHopingToWorkOtherReason: String? = null,
+
+  @ElementCollection(targetClass = AffectAbilityToWork::class)
+  @Enumerated(value = EnumType.STRING)
+  @CollectionTable(name = "affecting_ability_to_work")
+  @Column(name = "affect")
+  var affectAbilityToWork: List<AffectAbilityToWork>? = null,
+
+  @Column
+  var affectAbilityToWorkOther: String? = null,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null,
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null,
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null,
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null,
+)
+
+enum class HopingToWork {
+  YES,
+  NO,
+  NOT_SURE,
+}
+
+enum class NotHopingToWorkReason {
+  LIMIT_THEIR_ABILITY,
+  FULL_TIME_CARER,
+  LACKS_CONFIDENCE_OR_MOTIVATION,
+  HEALTH,
+  RETIRED,
+  NO_RIGHT_TO_WORK,
+  NOT_SURE,
+  OTHER,
+  NO_REASON,
+}
+
+enum class AffectAbilityToWork {
+  CARING_RESPONSIBILITIES,
+  LIMITED_BY_OFFENSE,
+  HEALTH_ISSUES,
+  NO_RIGHT_TO_WORK,
+  OTHER,
+  NONE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntity.kt
@@ -48,7 +48,7 @@ class WorkOnReleaseEntity(
   @Column(name = "reason")
   var notHopingToWorkReasons: List<NotHopingToWorkReason>? = null,
 
-  @Column
+  @Column(name = "not_hoping_other")
   var notHopingToWorkOtherReason: String? = null,
 
   @ElementCollection(targetClass = AffectAbilityToWork::class)
@@ -57,7 +57,7 @@ class WorkOnReleaseEntity(
   @Column(name = "affect")
   var affectAbilityToWork: List<AffectAbilityToWork>? = null,
 
-  @Column
+  @Column(name = "affecting_work_other")
   var affectAbilityToWorkOther: String? = null,
 
   @Column(updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/InductionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/InductionRepository.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionEntity
+import java.util.UUID
+
+@Repository
+interface InductionRepository : JpaRepository<InductionEntity, UUID> {
+  fun findByPrisonNumber(prisonNumber: String): InductionEntity?
+}

--- a/src/main/resources/db/migration/V2023.10.17.0001__add_induction_related_tables.sql
+++ b/src/main/resources/db/migration/V2023.10.17.0001__add_induction_related_tables.sql
@@ -1,0 +1,380 @@
+--- Table induction
+CREATE TABLE induction
+(
+    id                      UUID PRIMARY KEY,
+    reference               UUID                        NOT NULL,
+    prison_number           VARCHAR(10)                 NOT NULL,
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    created_by_display_name VARCHAR(100)                NOT NULL,
+    created_at_prison       VARCHAR(20),
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
+    updated_by_display_name VARCHAR(100)                NOT NULL,
+    updated_at_prison       VARCHAR(20)
+);
+
+CREATE UNIQUE INDEX induction_prison_number_idx ON induction
+(
+    prison_number
+);
+
+--- Table previous_qualifications
+CREATE TABLE previous_qualifications
+(
+    id                      UUID PRIMARY KEY,
+    induction_id            UUID                        NOT NULL,
+    reference               UUID                        NOT NULL,
+    education_level         VARCHAR(50)                 NOT NULL,
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_induction_previous_qualifications FOREIGN KEY (induction_id) REFERENCES induction (id)
+);
+
+CREATE UNIQUE INDEX previous_qualifications_reference_idx ON previous_qualifications
+(
+    reference
+);
+CREATE INDEX previous_qualifications_induction_id_idx ON previous_qualifications
+(
+    induction_id
+);
+
+--- Table qualification
+CREATE TABLE qualification
+(
+    id                     UUID PRIMARY KEY,
+    prev_qualifications_id UUID                        NOT NULL,
+    reference              UUID                        NOT NULL,
+    subject                VARCHAR(100)                NOT NULL,
+    level                  VARCHAR(50),
+    grade                  VARCHAR(50),
+    created_at             TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by             VARCHAR(50)                 NOT NULL,
+    updated_at             TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by             VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_prev_qualifications_qualification FOREIGN KEY (prev_qualifications_id) REFERENCES previous_qualifications (id)
+);
+
+CREATE UNIQUE INDEX qualification_reference_idx ON qualification
+(
+     reference
+);
+CREATE INDEX previous_qualifications_qualification_id_idx ON qualification
+(
+     prev_qualifications_id
+);
+
+
+--- Table work_on_release
+CREATE TABLE work_on_release
+(
+    id                      UUID PRIMARY KEY,
+    induction_id            UUID                        NOT NULL,
+    reference               UUID                        NOT NULL,
+    hoping_to_work          VARCHAR(50)                 NOT NULL,
+    not_hoping_other        VARCHAR(512),
+    affecting_work_other    VARCHAR(512),
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_induction_work_on_release FOREIGN KEY (induction_id) REFERENCES induction (id)
+);
+
+CREATE UNIQUE INDEX work_on_release_reference_idx ON work_on_release
+(
+     reference
+);
+CREATE INDEX work_on_release_induction_id_idx ON work_on_release
+(
+     induction_id
+);
+
+-- Collection Table not_working_reasons
+CREATE TABLE not_working_reasons
+(
+    work_on_release_id UUID NOT NULL,
+    reason VARCHAR(50) NOT NULL
+);
+
+-- Collection Table affecting_ability_to_work
+CREATE TABLE affecting_ability_to_work
+(
+    work_on_release_id UUID NOT NULL,
+    affect VARCHAR(50) NOT NULL
+);
+
+--- Table training
+CREATE TABLE previous_training
+(
+    id                      UUID PRIMARY KEY,
+    induction_id            UUID                        NOT NULL,
+    reference               UUID                        NOT NULL,
+    training_type_other     VARCHAR(512),
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_induction_previous_training FOREIGN KEY (induction_id) REFERENCES induction (id)
+);
+
+CREATE UNIQUE INDEX previous_training_reference_idx ON previous_training
+(
+     reference
+);
+CREATE INDEX previous_training_induction_id_idx ON previous_training
+(
+     induction_id
+);
+
+-- Collection Table training_type
+CREATE TABLE training_type
+(
+    training_id UUID NOT NULL,
+    type VARCHAR(50) NOT NULL
+);
+
+
+--- Table work_experiences
+CREATE TABLE previous_work_experiences
+(
+    id                      UUID PRIMARY KEY,
+    induction_id            UUID                        NOT NULL,
+    reference               UUID                        NOT NULL,
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_induction_previous_work_experiences FOREIGN KEY (induction_id) REFERENCES induction (id)
+);
+
+CREATE UNIQUE INDEX previous_work_experiences_reference_idx ON previous_work_experiences
+(
+     reference
+);
+CREATE INDEX previous_work_experiences_induction_id_idx ON previous_work_experiences
+(
+     induction_id
+);
+
+--- Table work_experience
+CREATE TABLE work_experience
+(
+    id                    UUID PRIMARY KEY,
+    experiences_id    UUID                        NOT NULL,
+    reference             UUID                        NOT NULL,
+    experience_type       VARCHAR(50)                 NOT NULL,
+    experience_type_other VARCHAR(256),
+    role                  VARCHAR(256),
+    details               VARCHAR(512),
+    created_at            TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by            VARCHAR(50)                 NOT NULL,
+    updated_at            TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by            VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_previous_work_experiences_work_experience FOREIGN KEY (experiences_id) REFERENCES previous_work_experiences (id)
+);
+
+--- Table in_prison_interests
+CREATE TABLE in_prison_interests
+(
+    id                      UUID PRIMARY KEY,
+    induction_id            UUID                        NOT NULL,
+    reference               UUID                        NOT NULL,
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_induction_in_prison_interests FOREIGN KEY (induction_id) REFERENCES induction (id)
+);
+
+CREATE UNIQUE INDEX in_prison_interests_reference_idx ON in_prison_interests
+(
+     reference
+);
+CREATE INDEX in_prison_interests_induction_id_idx ON in_prison_interests
+(
+     induction_id
+);
+
+--- Table in_prison_work_interest
+CREATE TABLE in_prison_work_interest
+(
+    id                      UUID PRIMARY KEY,
+    interests_id            UUID                        NOT NULL,
+    reference               UUID                        NOT NULL,
+    work_type               VARCHAR(50)                 NOT NULL,
+    work_type_other         VARCHAR(255),
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_in_prison_interests_work_interest FOREIGN KEY (interests_id) REFERENCES in_prison_interests (id)
+);
+
+CREATE UNIQUE INDEX in_prison_work_interest_reference_idx ON in_prison_work_interest
+(
+     reference
+);
+CREATE INDEX work_interest_in_prison_interests_id_idx ON in_prison_work_interest
+(
+     interests_id
+);
+
+--- Table in_prison_training_interest
+CREATE TABLE in_prison_training_interest
+(
+    id                      UUID PRIMARY KEY,
+    interests_id            UUID                        NOT NULL,
+    reference               UUID                        NOT NULL,
+    training_type           VARCHAR(50)                 NOT NULL,
+    training_type_other     VARCHAR(255),
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_in_prison_interests_training_interest FOREIGN KEY (interests_id) REFERENCES in_prison_interests (id)
+);
+
+CREATE UNIQUE INDEX in_prison_training_interest_reference_idx ON in_prison_training_interest
+(
+     reference
+);
+CREATE INDEX training_interest_in_prison_interests_id_idx ON in_prison_training_interest
+(
+     interests_id
+);
+
+--- Table skills_and_interests
+CREATE TABLE skills_and_interests
+(
+    id                      UUID PRIMARY KEY,
+    induction_id            UUID                        NOT NULL,
+    reference               UUID                        NOT NULL,
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_induction_skills_and_interests FOREIGN KEY (induction_id) REFERENCES induction (id)
+);
+
+CREATE UNIQUE INDEX skills_and_interests_reference_idx ON skills_and_interests
+(
+     reference
+);
+CREATE INDEX skills_and_interests_induction_id_idx ON skills_and_interests
+(
+     induction_id
+);
+
+--- Table personal_skill
+CREATE TABLE personal_skill
+(
+    id                  UUID PRIMARY KEY,
+    skills_interests_id UUID                        NOT NULL,
+    reference           UUID                        NOT NULL,
+    skill_type          VARCHAR(50)                 NOT NULL,
+    skill_type_other    VARCHAR(255),
+    created_at          TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by          VARCHAR(50)                 NOT NULL,
+    updated_at          TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by          VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_skills_and_interests_personal_skill FOREIGN KEY (skills_interests_id) REFERENCES in_prison_interests (id)
+);
+
+CREATE UNIQUE INDEX personal_skill_reference_idx ON personal_skill
+(
+     reference
+);
+CREATE INDEX personal_skill_skills_interests_id_idx ON personal_skill
+(
+     skills_interests_id
+);
+
+--- Table personal_interest
+CREATE TABLE personal_interest
+(
+    id                  UUID PRIMARY KEY,
+    skills_interests_id UUID                        NOT NULL,
+    reference           UUID                        NOT NULL,
+    interest_type       VARCHAR(50)                 NOT NULL,
+    interest_type_other VARCHAR(255),
+    created_at          TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by          VARCHAR(50)                 NOT NULL,
+    updated_at          TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by          VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_skills_and_interests_personal_interest FOREIGN KEY (skills_interests_id) REFERENCES in_prison_interests (id)
+);
+
+CREATE UNIQUE INDEX personal_interest_reference_idx ON personal_interest
+(
+     reference
+);
+CREATE INDEX personal_interest_skills_interests_id_idx ON personal_interest
+(
+     skills_interests_id
+);
+
+
+--- Table work_interests
+CREATE TABLE future_work_interests
+(
+    id                      UUID PRIMARY KEY,
+    induction_id            UUID                        NOT NULL,
+    reference               UUID                        NOT NULL,
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_induction_future_work_interests FOREIGN KEY (induction_id) REFERENCES induction (id)
+);
+
+CREATE UNIQUE INDEX future_work_interests_reference_idx ON future_work_interests
+(
+     reference
+);
+CREATE INDEX future_work_interests_induction_id_idx ON future_work_interests
+(
+     induction_id
+);
+
+--- Table work_interest
+CREATE TABLE work_interest
+(
+    id                UUID PRIMARY KEY,
+    work_interests_id UUID                        NOT NULL,
+    reference         UUID                        NOT NULL,
+    work_type         VARCHAR(50)                 NOT NULL,
+    workTypeOther     VARCHAR(255)                NOT NULL,
+    role              VARCHAR(512)                NOT NULL,
+    created_at        TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by        VARCHAR(50)                 NOT NULL,
+    updated_at        TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by        VARCHAR(50)                 NOT NULL,
+
+    CONSTRAINT fk_future_work_interests_work_interest FOREIGN KEY (work_interests_id) REFERENCES future_work_interests (id)
+);
+
+CREATE UNIQUE INDEX work_interest_reference_idx ON work_interest
+(
+     reference
+);
+CREATE INDEX work_interest_work_interests_id_idx ON work_interest
+(
+     work_interests_id
+);

--- a/src/main/resources/db/migration/V2023.10.17.0001__add_induction_related_tables.sql
+++ b/src/main/resources/db/migration/V2023.10.17.0001__add_induction_related_tables.sql
@@ -34,8 +34,12 @@ CREATE TABLE previous_qualifications
     education_level         VARCHAR(50)                 NOT NULL,
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
+    created_by_display_name VARCHAR(100)                NOT NULL,
+    created_at_prison       VARCHAR(20),
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL
+    updated_by              VARCHAR(50)                 NOT NULL,
+    updated_by_display_name VARCHAR(100)                NOT NULL,
+    updated_at_prison       VARCHAR(20)
 );
 
 CREATE UNIQUE INDEX previous_qualifications_reference_idx ON previous_qualifications
@@ -46,16 +50,16 @@ CREATE UNIQUE INDEX previous_qualifications_reference_idx ON previous_qualificat
 --- Table qualification
 CREATE TABLE qualification
 (
-    id                     UUID PRIMARY KEY,
-    prev_qualifications_id UUID                        NOT NULL,
-    reference              UUID                        NOT NULL,
-    subject                VARCHAR(100)                NOT NULL,
-    level                  VARCHAR(50),
-    grade                  VARCHAR(50),
-    created_at             TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    created_by             VARCHAR(50)                 NOT NULL,
-    updated_at             TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by             VARCHAR(50)                 NOT NULL,
+    id                      UUID PRIMARY KEY,
+    prev_qualifications_id  UUID                        NOT NULL,
+    reference               UUID                        NOT NULL,
+    subject                 VARCHAR(100)                NOT NULL,
+    level                   VARCHAR(50),
+    grade                   VARCHAR(50),
+    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by              VARCHAR(50)                 NOT NULL,
+    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL,
 
     CONSTRAINT fk_prev_qualifications_qualification FOREIGN KEY (prev_qualifications_id) REFERENCES previous_qualifications (id)
 );
@@ -80,9 +84,12 @@ CREATE TABLE work_on_release
     affecting_work_other    VARCHAR(512),
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
+    created_by_display_name VARCHAR(100)                NOT NULL,
+    created_at_prison       VARCHAR(20),
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL
-
+    updated_by              VARCHAR(50)                 NOT NULL,
+    updated_by_display_name VARCHAR(100)                NOT NULL,
+    updated_at_prison       VARCHAR(20)
 );
 
 CREATE UNIQUE INDEX work_on_release_reference_idx ON work_on_release
@@ -104,7 +111,7 @@ CREATE TABLE affecting_ability_to_work
     affect VARCHAR(50) NOT NULL
 );
 
---- Table training
+--- Table previous_training
 CREATE TABLE previous_training
 (
     id                      UUID PRIMARY KEY,
@@ -112,8 +119,12 @@ CREATE TABLE previous_training
     training_type_other     VARCHAR(512),
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
+    created_by_display_name VARCHAR(100)                NOT NULL,
+    created_at_prison       VARCHAR(20),
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL
+    updated_by              VARCHAR(50)                 NOT NULL,
+    updated_by_display_name VARCHAR(100)                NOT NULL,
+    updated_at_prison       VARCHAR(20)
 );
 
 CREATE UNIQUE INDEX previous_training_reference_idx ON previous_training
@@ -136,8 +147,12 @@ CREATE TABLE previous_work_experiences
     reference               UUID                        NOT NULL,
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
+    created_by_display_name VARCHAR(100)                NOT NULL,
+    created_at_prison       VARCHAR(20),
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL
+    updated_by              VARCHAR(50)                 NOT NULL,
+    updated_by_display_name VARCHAR(100)                NOT NULL,
+    updated_at_prison       VARCHAR(20)
 );
 
 CREATE UNIQUE INDEX previous_work_experiences_reference_idx ON previous_work_experiences
@@ -170,8 +185,12 @@ CREATE TABLE in_prison_interests
     reference               UUID                        NOT NULL,
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
+    created_by_display_name VARCHAR(100)                NOT NULL,
+    created_at_prison       VARCHAR(20),
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL
+    updated_by              VARCHAR(50)                 NOT NULL,
+    updated_by_display_name VARCHAR(100)                NOT NULL,
+    updated_at_prison       VARCHAR(20)
 );
 
 CREATE UNIQUE INDEX in_prison_interests_reference_idx ON in_prison_interests
@@ -236,8 +255,12 @@ CREATE TABLE skills_and_interests
     reference               UUID                        NOT NULL,
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
+    created_by_display_name VARCHAR(100)                NOT NULL,
+    created_at_prison       VARCHAR(20),
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL
+    updated_by              VARCHAR(50)                 NOT NULL,
+    updated_by_display_name VARCHAR(100)                NOT NULL,
+    updated_at_prison       VARCHAR(20)
 );
 
 CREATE UNIQUE INDEX skills_and_interests_reference_idx ON skills_and_interests
@@ -303,8 +326,12 @@ CREATE TABLE future_work_interests
     reference               UUID                        NOT NULL,
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
+    created_by_display_name VARCHAR(100)                NOT NULL,
+    created_at_prison       VARCHAR(20),
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL
+    updated_by              VARCHAR(50)                 NOT NULL,
+    updated_by_display_name VARCHAR(100)                NOT NULL,
+    updated_at_prison       VARCHAR(20)
 );
 
 CREATE UNIQUE INDEX future_work_interests_reference_idx ON future_work_interests

--- a/src/main/resources/db/migration/V2023.10.17.0001__add_induction_related_tables.sql
+++ b/src/main/resources/db/migration/V2023.10.17.0001__add_induction_related_tables.sql
@@ -1,17 +1,24 @@
 --- Table induction
 CREATE TABLE induction
 (
-    id                      UUID PRIMARY KEY,
-    reference               UUID                        NOT NULL,
-    prison_number           VARCHAR(10)                 NOT NULL,
-    created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    created_by              VARCHAR(50)                 NOT NULL,
-    created_by_display_name VARCHAR(100)                NOT NULL,
-    created_at_prison       VARCHAR(20),
-    updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL,
-    updated_by_display_name VARCHAR(100)                NOT NULL,
-    updated_at_prison       VARCHAR(20)
+    id                         UUID PRIMARY KEY,
+    reference                  UUID                        NOT NULL,
+    prison_number              VARCHAR(10)                 NOT NULL,
+    work_on_release_id         UUID                        NOT NULL,
+    previous_qualifications_id UUID,
+    previous_training_id       UUID,
+    work_experiences_id        UUID,
+    in_prison_interests_id     UUID,
+    skills_and_interests_id    UUID,
+    future_work_interests_id   UUID,
+    created_at                 TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by                 VARCHAR(50)                 NOT NULL,
+    created_by_display_name    VARCHAR(100)                NOT NULL,
+    created_at_prison          VARCHAR(20),
+    updated_at                 TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by                 VARCHAR(50)                 NOT NULL,
+    updated_by_display_name    VARCHAR(100)                NOT NULL,
+    updated_at_prison          VARCHAR(20)
 );
 
 CREATE UNIQUE INDEX induction_prison_number_idx ON induction
@@ -23,24 +30,17 @@ CREATE UNIQUE INDEX induction_prison_number_idx ON induction
 CREATE TABLE previous_qualifications
 (
     id                      UUID PRIMARY KEY,
-    induction_id            UUID                        NOT NULL,
     reference               UUID                        NOT NULL,
     education_level         VARCHAR(50)                 NOT NULL,
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL,
-
-    CONSTRAINT fk_induction_previous_qualifications FOREIGN KEY (induction_id) REFERENCES induction (id)
+    updated_by              VARCHAR(50)                 NOT NULL
 );
 
 CREATE UNIQUE INDEX previous_qualifications_reference_idx ON previous_qualifications
 (
     reference
-);
-CREATE INDEX previous_qualifications_induction_id_idx ON previous_qualifications
-(
-    induction_id
 );
 
 --- Table qualification
@@ -74,7 +74,6 @@ CREATE INDEX previous_qualifications_qualification_id_idx ON qualification
 CREATE TABLE work_on_release
 (
     id                      UUID PRIMARY KEY,
-    induction_id            UUID                        NOT NULL,
     reference               UUID                        NOT NULL,
     hoping_to_work          VARCHAR(50)                 NOT NULL,
     not_hoping_other        VARCHAR(512),
@@ -82,18 +81,13 @@ CREATE TABLE work_on_release
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL,
+    updated_by              VARCHAR(50)                 NOT NULL
 
-    CONSTRAINT fk_induction_work_on_release FOREIGN KEY (induction_id) REFERENCES induction (id)
 );
 
 CREATE UNIQUE INDEX work_on_release_reference_idx ON work_on_release
 (
      reference
-);
-CREATE INDEX work_on_release_induction_id_idx ON work_on_release
-(
-     induction_id
 );
 
 -- Collection Table not_working_reasons
@@ -114,24 +108,17 @@ CREATE TABLE affecting_ability_to_work
 CREATE TABLE previous_training
 (
     id                      UUID PRIMARY KEY,
-    induction_id            UUID                        NOT NULL,
     reference               UUID                        NOT NULL,
     training_type_other     VARCHAR(512),
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL,
-
-    CONSTRAINT fk_induction_previous_training FOREIGN KEY (induction_id) REFERENCES induction (id)
+    updated_by              VARCHAR(50)                 NOT NULL
 );
 
 CREATE UNIQUE INDEX previous_training_reference_idx ON previous_training
 (
      reference
-);
-CREATE INDEX previous_training_induction_id_idx ON previous_training
-(
-     induction_id
 );
 
 -- Collection Table training_type
@@ -146,30 +133,23 @@ CREATE TABLE training_type
 CREATE TABLE previous_work_experiences
 (
     id                      UUID PRIMARY KEY,
-    induction_id            UUID                        NOT NULL,
     reference               UUID                        NOT NULL,
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL,
-
-    CONSTRAINT fk_induction_previous_work_experiences FOREIGN KEY (induction_id) REFERENCES induction (id)
+    updated_by              VARCHAR(50)                 NOT NULL
 );
 
 CREATE UNIQUE INDEX previous_work_experiences_reference_idx ON previous_work_experiences
 (
      reference
 );
-CREATE INDEX previous_work_experiences_induction_id_idx ON previous_work_experiences
-(
-     induction_id
-);
 
 --- Table work_experience
 CREATE TABLE work_experience
 (
     id                    UUID PRIMARY KEY,
-    experiences_id    UUID                        NOT NULL,
+    work_experiences_id   UUID                        NOT NULL,
     reference             UUID                        NOT NULL,
     experience_type       VARCHAR(50)                 NOT NULL,
     experience_type_other VARCHAR(256),
@@ -180,30 +160,23 @@ CREATE TABLE work_experience
     updated_at            TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     updated_by            VARCHAR(50)                 NOT NULL,
 
-    CONSTRAINT fk_previous_work_experiences_work_experience FOREIGN KEY (experiences_id) REFERENCES previous_work_experiences (id)
+    CONSTRAINT fk_previous_work_experiences_work_experience FOREIGN KEY (work_experiences_id) REFERENCES previous_work_experiences (id)
 );
 
 --- Table in_prison_interests
 CREATE TABLE in_prison_interests
 (
     id                      UUID PRIMARY KEY,
-    induction_id            UUID                        NOT NULL,
     reference               UUID                        NOT NULL,
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL,
-
-    CONSTRAINT fk_induction_in_prison_interests FOREIGN KEY (induction_id) REFERENCES induction (id)
+    updated_by              VARCHAR(50)                 NOT NULL
 );
 
 CREATE UNIQUE INDEX in_prison_interests_reference_idx ON in_prison_interests
 (
      reference
-);
-CREATE INDEX in_prison_interests_induction_id_idx ON in_prison_interests
-(
-     induction_id
 );
 
 --- Table in_prison_work_interest
@@ -260,23 +233,16 @@ CREATE INDEX training_interest_in_prison_interests_id_idx ON in_prison_training_
 CREATE TABLE skills_and_interests
 (
     id                      UUID PRIMARY KEY,
-    induction_id            UUID                        NOT NULL,
     reference               UUID                        NOT NULL,
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL,
-
-    CONSTRAINT fk_induction_skills_and_interests FOREIGN KEY (induction_id) REFERENCES induction (id)
+    updated_by              VARCHAR(50)                 NOT NULL
 );
 
 CREATE UNIQUE INDEX skills_and_interests_reference_idx ON skills_and_interests
 (
      reference
-);
-CREATE INDEX skills_and_interests_induction_id_idx ON skills_and_interests
-(
-     induction_id
 );
 
 --- Table personal_skill
@@ -292,7 +258,7 @@ CREATE TABLE personal_skill
     updated_at          TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     updated_by          VARCHAR(50)                 NOT NULL,
 
-    CONSTRAINT fk_skills_and_interests_personal_skill FOREIGN KEY (skills_interests_id) REFERENCES in_prison_interests (id)
+    CONSTRAINT fk_skills_and_interests_personal_skill FOREIGN KEY (skills_interests_id) REFERENCES skills_and_interests (id)
 );
 
 CREATE UNIQUE INDEX personal_skill_reference_idx ON personal_skill
@@ -317,7 +283,7 @@ CREATE TABLE personal_interest
     updated_at          TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     updated_by          VARCHAR(50)                 NOT NULL,
 
-    CONSTRAINT fk_skills_and_interests_personal_interest FOREIGN KEY (skills_interests_id) REFERENCES in_prison_interests (id)
+    CONSTRAINT fk_skills_and_interests_personal_interest FOREIGN KEY (skills_interests_id) REFERENCES skills_and_interests (id)
 );
 
 CREATE UNIQUE INDEX personal_interest_reference_idx ON personal_interest
@@ -334,23 +300,16 @@ CREATE INDEX personal_interest_skills_interests_id_idx ON personal_interest
 CREATE TABLE future_work_interests
 (
     id                      UUID PRIMARY KEY,
-    induction_id            UUID                        NOT NULL,
     reference               UUID                        NOT NULL,
     created_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by              VARCHAR(50)                 NOT NULL,
     updated_at              TIMESTAMP(3) WITH TIME ZONE NOT NULL,
-    updated_by              VARCHAR(50)                 NOT NULL,
-
-    CONSTRAINT fk_induction_future_work_interests FOREIGN KEY (induction_id) REFERENCES induction (id)
+    updated_by              VARCHAR(50)                 NOT NULL
 );
 
 CREATE UNIQUE INDEX future_work_interests_reference_idx ON future_work_interests
 (
      reference
-);
-CREATE INDEX future_work_interests_induction_id_idx ON future_work_interests
-(
-     induction_id
 );
 
 --- Table work_interest
@@ -360,8 +319,8 @@ CREATE TABLE work_interest
     work_interests_id UUID                        NOT NULL,
     reference         UUID                        NOT NULL,
     work_type         VARCHAR(50)                 NOT NULL,
-    workTypeOther     VARCHAR(255)                NOT NULL,
-    role              VARCHAR(512)                NOT NULL,
+    work_type_other   VARCHAR(255),
+    role              VARCHAR(512),
     created_at        TIMESTAMP(3) WITH TIME ZONE NOT NULL,
     created_by        VARCHAR(50)                 NOT NULL,
     updated_at        TIMESTAMP(3) WITH TIME ZONE NOT NULL,
@@ -377,4 +336,41 @@ CREATE UNIQUE INDEX work_interest_reference_idx ON work_interest
 CREATE INDEX work_interest_work_interests_id_idx ON work_interest
 (
      work_interests_id
+);
+
+ALTER TABLE induction ADD CONSTRAINT fk_work_on_release_induction FOREIGN KEY (work_on_release_id) REFERENCES work_on_release (id);
+ALTER TABLE induction ADD CONSTRAINT fk_previous_qualifications_induction FOREIGN KEY (previous_qualifications_id) REFERENCES previous_qualifications (id);
+ALTER TABLE induction ADD CONSTRAINT fk_previous_training_induction FOREIGN KEY (previous_training_id) REFERENCES previous_training (id);
+ALTER TABLE induction ADD CONSTRAINT fk_previous_work_experiences_induction FOREIGN KEY (work_experiences_id) REFERENCES previous_work_experiences (id);
+ALTER TABLE induction ADD CONSTRAINT fk_in_prison_interests_induction FOREIGN KEY (in_prison_interests_id) REFERENCES in_prison_interests (id);
+ALTER TABLE induction ADD CONSTRAINT fk_skills_and_interests_induction FOREIGN KEY (skills_and_interests_id) REFERENCES skills_and_interests (id);
+ALTER TABLE induction ADD CONSTRAINT fk_future_work_interests_induction FOREIGN KEY (future_work_interests_id) REFERENCES future_work_interests (id);
+
+CREATE INDEX induction_work_on_release_id_idx ON induction
+(
+     work_on_release_id
+);
+CREATE INDEX induction_previous_qualifications_induction_id_idx ON induction
+(
+     previous_qualifications_id
+);
+CREATE INDEX induction_previous_training_induction_id_idx ON induction
+(
+     previous_training_id
+);
+CREATE INDEX induction_previous_work_experiences_induction_id_idx ON induction
+(
+     work_experiences_id
+);
+CREATE INDEX induction_in_prison_interests_induction_id_idx ON induction
+(
+     in_prison_interests_id
+);
+CREATE INDEX induction_skills_and_interests_induction_id_idx ON induction
+(
+     skills_and_interests_id
+);
+CREATE INDEX induction_future_work_interests_induction_id_idx ON induction
+(
+     future_work_interests_id
 );


### PR DESCRIPTION
This PR introduces quite a few DB tables and JPA entities to represent a CIAG Induction.

Note that I've created an `InductionRepository` and a corresponding integration test locally to make sure I can save and retrieve an `InductionEntity`. I'll add test data builders in a subsequent PR, but I'll save the integration test until it's hooked up with the REST API.