### PR TITLE
RR-432 - Update Induction swagger spec

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapper.kt
@@ -6,9 +6,9 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InP
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonTrainingInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonWorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateInPrisonInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PrisonWorkAndEducationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonTrainingType as InPrisonTrainingTypeDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonWorkType as InPrisonWorkTypeDomain
@@ -21,7 +21,7 @@ class InPrisonInterestsResourceMapper(
 ) {
 
   fun toCreateInPrisonInterestsDto(
-    request: PrisonWorkAndEducationRequest?,
+    request: CreatePrisonWorkAndEducationRequest?,
     prisonId: String,
   ): CreateInPrisonInterestsDto? {
     return request?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PersonalSkillsAndInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PersonalSkillsAndInterestsResourceMapper.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Per
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkillsAndInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.SkillType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePersonalSkillsAndInterestsDto
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SkillsAndInterestsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalInterest as PersonalInterestDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkill as PersonalSkillDomain
@@ -20,7 +20,7 @@ class PersonalSkillsAndInterestsResourceMapper(
   private val instantMapper: InstantMapper,
 ) {
   fun toCreatePersonalSkillsAndInterestsDto(
-    request: SkillsAndInterestsRequest?,
+    request: CreateSkillsAndInterestsRequest?,
     prisonId: String,
   ): CreatePersonalSkillsAndInterestsDto? =
     request?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapper.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Wor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePreviousWorkExperiencesDto
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkE
 abstract class PreviousWorkExperiencesResourceMapper {
   @Mapping(target = "experiences", source = "request.workExperience")
   abstract fun toCreatePreviousWorkExperiencesDto(
-    request: PreviousWorkRequest?,
+    request: CreatePreviousWorkRequest?,
     prisonId: String,
   ): CreatePreviousWorkExperiencesDto?
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapper.kt
@@ -9,8 +9,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Tra
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePreviousTrainingDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateEducationAndQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationAndQualificationResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationAndQualificationsRequest
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Train
 @Mapper
 abstract class QualificationsAndTrainingResourceMapper {
   abstract fun toCreatePreviousQualificationsDto(
-    request: EducationAndQualificationsRequest?,
+    request: CreateEducationAndQualificationsRequest?,
     prisonId: String,
   ): CreatePreviousQualificationsDto?
 
@@ -31,7 +31,7 @@ abstract class QualificationsAndTrainingResourceMapper {
   @Mapping(target = "trainingTypes", source = "request.additionalTraining")
   @Mapping(target = "trainingTypeOther", source = "request.additionalTrainingOther")
   abstract fun toCreatePreviousTrainingDto(
-    request: EducationAndQualificationsRequest?,
+    request: CreateEducationAndQualificationsRequest?,
     prisonId: String,
   ): CreatePreviousTrainingDto?
 

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.4.3'
+  version: '1.4.4'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -196,6 +196,30 @@ paths:
         '404':
           $ref: '#/components/responses/404ErrorResponse'
       operationId: get-ciag-prisoner-induction
+    put:
+      summary: Updates an Induction for a Prisoner.
+      description: |
+        Provides the ability to update a Prisoner's Induction. Completely overwrites the existing Prisoner's Induction with the
+        information provided in the update request. If a field is not included in the update request, it will be removed from the 
+        database, effectively making the update request the authoritative source of information. This endpoint has been migrated
+        from the `hmpps-ciag-careers-induction-api` and the data structure has been kept the same in order to prevent breaking
+        the CIAG UI when it is ports to this endpoint.
+      tags:
+        - Induction
+      responses:
+        '200':
+          description: CIAG Induction updated successfully.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CiagInductionResponse"
+        '400':
+          $ref: '#/components/responses/400ErrorResponse'
+        '404':
+          $ref: '#/components/responses/404ErrorResponse'
+      operationId: update-ciag-prisoner-induction
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateCiagInduction'
 
 #
 # --------------------------------------------------------------------------------
@@ -932,18 +956,18 @@ components:
           items:
             $ref: '#/components/schemas/ReasonNotToWork'
         workExperience:
-          $ref: '#/components/schemas/PreviousWorkRequest'
+          $ref: '#/components/schemas/CreatePreviousWorkRequest'
         skillsAndInterests:
-          $ref: '#/components/schemas/SkillsAndInterestsRequest'
+          $ref: '#/components/schemas/CreateSkillsAndInterestsRequest'
         qualificationsAndTraining:
-          $ref: '#/components/schemas/EducationAndQualificationsRequest'
+          $ref: '#/components/schemas/CreateEducationAndQualificationsRequest'
         inPrisonInterests:
-          $ref: '#/components/schemas/PrisonWorkAndEducationRequest'
+          $ref: '#/components/schemas/CreatePrisonWorkAndEducationRequest'
       required:
         - hopingToGetWork
         - prisonId
 
-    PreviousWorkRequest:
+    CreatePreviousWorkRequest:
       description: A request to persist the previous work experience of the Prisoner. Migrated from hmpps-ciag-careers-induction-api.
       type: object
       properties:
@@ -971,7 +995,7 @@ components:
       required:
         - hasWorkedBefore
 
-    SkillsAndInterestsRequest:
+    CreateSkillsAndInterestsRequest:
       description: A request to persist a Prisoner's personal skills and interests. Migrated from hmpps-ciag-careers-induction-api.
       type: object
       properties:
@@ -996,7 +1020,7 @@ components:
           type: string
           description: A specific type of a interest that the Prisoner feels they have. Mandatory when 'personalInterests' includes 'OTHER'.
 
-    EducationAndQualificationsRequest:
+    CreateEducationAndQualificationsRequest:
       description: A request to persist a Prisoner's education and qualifications. Migrated from hmpps-ciag-careers-induction-api.
         the inmate.
       type: object
@@ -1019,7 +1043,7 @@ components:
           type: string
           description: A specific type of training that does not fit the given 'additionalTraining' types. Mandatory when 'additionalTraining' includes 'OTHER'.
 
-    PrisonWorkAndEducationRequest:
+    CreatePrisonWorkAndEducationRequest:
       description: A request to persist a Prisoner's in-prison work and education interests. Migrated from hmpps-ciag-careers-induction-api.
       type: object
       properties:
@@ -1043,6 +1067,179 @@ components:
         inPrisonEducationOther:
           type: string
           description: A specific type of in-prison education/training that does not fit the given 'inPrisonEducation' types. Mandatory when 'inPrisonEducation' includes 'OTHER'.
+
+    UpdateCiagInductionRequest:
+      title: UpdateCiagInductionRequest
+      description: A request to update a CIAG Induction. Migrated from hmpps-ciag-careers-induction-api.
+      type: object
+      properties:
+        reference:
+          type: string
+          format: uuid
+          description: The Induction's unique reference. Currently optional (to avoid breaking the existing CIAG API), but will be mandatory in future (and will most likely become a path variable).
+          example: c88a6c48-97e2-4c04-93b5-98619966447b
+        prisonId:
+          type: string
+          description: The ID of the Prison that that Prisoner is currently at.
+        hopingToGetWork:
+          $ref: '#/components/schemas/HopingToWork'
+        reasonToNotGetWorkOther:
+          type: string
+          description: The reason that is given when the Prisoner does not want to work. This is mandatory when 'reasonToNotGetWork' is set to 'OTHER'.
+        abilityToWork:
+          uniqueItems: true
+          type: array
+          description: One or more factors affecting the Prisoner's ability to work.
+          items:
+            $ref: '#/components/schemas/AbilityToWorkFactor'
+        abilityToWorkOther:
+          type: string
+          description: A specific factor affecting the Prisoner's ability to work. This is mandatory when 'abilityToWork' is set to 'OTHER'.
+        reasonToNotGetWork:
+          uniqueItems: true
+          type: array
+          description: One or more reasons the Prisoner has given not to get work after leaving Prison.
+          items:
+            $ref: '#/components/schemas/ReasonNotToWork'
+        workExperience:
+          $ref: '#/components/schemas/UpdatePreviousWorkRequest'
+        skillsAndInterests:
+          $ref: '#/components/schemas/UpdateSkillsAndInterestsRequest'
+        qualificationsAndTraining:
+          $ref: '#/components/schemas/UpdateEducationAndQualificationsRequest'
+        inPrisonInterests:
+          $ref: '#/components/schemas/UpdatePrisonWorkAndEducationRequest'
+      required:
+        - hopingToGetWork
+        - prisonId
+
+    UpdatePreviousWorkRequest:
+      description: A request to persist the previous work experience of the Prisoner. Migrated from hmpps-ciag-careers-induction-api.
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: A unique reference for this Prisoner's previous work experience.
+          example: c88a6c48-97e2-4c04-93b5-98619966447b
+        hasWorkedBefore:
+          type: boolean
+        typeOfWorkExperience:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          description: A list of the Prisoner's type of previous work experience.
+          items:
+            $ref: '#/components/schemas/WorkType'
+        typeOfWorkExperienceOther:
+          type: string
+          description: A specific work experience type for the Prisoner. Mandatory when 'typeOfWorkExperience' includes 'OTHER'.
+        workExperience:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          description: A list of the Prisoner's previous work experience details.
+          items:
+            $ref: '#/components/schemas/WorkExperience'
+        workInterests:
+          $ref: '#/components/schemas/WorkInterests'
+      required:
+        - id
+        - hasWorkedBefore
+
+    UpdateSkillsAndInterestsRequest:
+      description: A request to persist a Prisoner's personal skills and interests. Migrated from hmpps-ciag-careers-induction-api.
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: A unique reference for this Prisoner's personal skills and interests.
+          example: c88a6c48-97e2-4c04-93b5-98619966447b
+        skills:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          description: One or more skills that the Prisoner feels they have.
+          items:
+            $ref: '#/components/schemas/PersonalSkill'
+        skillsOther:
+          type: string
+          description: A specific type of a skill that the Prisoner feels they have. Mandatory when 'skills' includes 'OTHER'.
+        personalInterests:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          description: One or more interests that the Prisoner feels they have.
+          items:
+            $ref: '#/components/schemas/PersonalInterest'
+        personalInterestsOther:
+          type: string
+          description: A specific type of a interest that the Prisoner feels they have. Mandatory when 'personalInterests' includes 'OTHER'.
+      required:
+        - id
+
+    UpdateEducationAndQualificationsRequest:
+      description: A request to persist a Prisoner's education and qualifications. Migrated from hmpps-ciag-careers-induction-api.
+        the inmate.
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: A unique reference for this Prisoner's education and qualifications.
+          example: c88a6c48-97e2-4c04-93b5-98619966447b
+        educationLevel:
+          $ref: '#/components/schemas/HighestEducationLevel'
+        qualifications:
+          uniqueItems: true
+          type: array
+          description: A list of the Prisoner's previous qualifications
+          items:
+            $ref: '#/components/schemas/AchievedQualification'
+        additionalTraining:
+          uniqueItems: true
+          type: array
+          description: Any additional training that the Prisoner has completed in the past.
+          items:
+            $ref: '#/components/schemas/TrainingType'
+        additionalTrainingOther:
+          type: string
+          description: A specific type of training that does not fit the given 'additionalTraining' types. Mandatory when 'additionalTraining' includes 'OTHER'.
+      required:
+        - id
+
+    UpdatePrisonWorkAndEducationRequest:
+      description: A request to persist a Prisoner's in-prison work and education interests. Migrated from hmpps-ciag-careers-induction-api.
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: A unique reference for this Prisoner's in-prison work and education interests.
+          example: c88a6c48-97e2-4c04-93b5-98619966447b
+        inPrisonWork:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          description: A list of in-prison work that the Prisoner is interested in.
+          items:
+            $ref: '#/components/schemas/InPrisonWorkType'
+        inPrisonWorkOther:
+          type: string
+          description: A specific type of in-prison work that does not fit the given 'inPrisonWork' types. Mandatory when 'inPrisonWork' includes 'OTHER'.
+        inPrisonEducation:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          description: Any potential in-prison education/training that the Prisoner is interested in.
+          items:
+            $ref: '#/components/schemas/InPrisonTrainingType'
+        inPrisonEducationOther:
+          type: string
+          description: A specific type of in-prison education/training that does not fit the given 'inPrisonEducation' types. Mandatory when 'inPrisonEducation' includes 'OTHER'.
+      required:
+        - id
 
     WorkExperience:
       description: A Prisoner's list of work experience details. Migrated from hmpps-ciag-careers-induction-api.
@@ -1461,3 +1658,9 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CreateCiagInductionRequest'
+    UpdateCiagInduction:
+      description: Request body to update a Prisoner's Induction.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateCiagInductionRequest'

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -207,12 +207,8 @@ paths:
       tags:
         - Induction
       responses:
-        '200':
+        '204':
           description: CIAG Induction updated successfully.
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/CiagInductionResponse"
         '400':
           $ref: '#/components/responses/400ErrorResponse'
         '404':
@@ -1115,129 +1111,54 @@ components:
 
     UpdatePreviousWorkRequest:
       description: A request to persist the previous work experience of the Prisoner. Migrated from hmpps-ciag-careers-induction-api.
-      type: object
+      allOf:
+        - $ref: '#/components/schemas/CreatePreviousWorkRequest'
       properties:
         id:
           type: string
           format: uuid
           description: A unique reference for this Prisoner's previous work experience.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
-        hasWorkedBefore:
-          type: boolean
-        typeOfWorkExperience:
-          minItems: 1
-          uniqueItems: true
-          type: array
-          description: A list of the Prisoner's type of previous work experience.
-          items:
-            $ref: '#/components/schemas/WorkType'
-        typeOfWorkExperienceOther:
-          type: string
-          description: A specific work experience type for the Prisoner. Mandatory when 'typeOfWorkExperience' includes 'OTHER'.
-        workExperience:
-          minItems: 1
-          uniqueItems: true
-          type: array
-          description: A list of the Prisoner's previous work experience details.
-          items:
-            $ref: '#/components/schemas/WorkExperience'
-        workInterests:
-          $ref: '#/components/schemas/WorkInterests'
       required:
         - id
-        - hasWorkedBefore
 
     UpdateSkillsAndInterestsRequest:
       description: A request to persist a Prisoner's personal skills and interests. Migrated from hmpps-ciag-careers-induction-api.
-      type: object
+      allOf:
+        - $ref: '#/components/schemas/CreateSkillsAndInterestsRequest'
       properties:
         id:
           type: string
           format: uuid
           description: A unique reference for this Prisoner's personal skills and interests.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
-        skills:
-          minItems: 1
-          uniqueItems: true
-          type: array
-          description: One or more skills that the Prisoner feels they have.
-          items:
-            $ref: '#/components/schemas/PersonalSkill'
-        skillsOther:
-          type: string
-          description: A specific type of a skill that the Prisoner feels they have. Mandatory when 'skills' includes 'OTHER'.
-        personalInterests:
-          minItems: 1
-          uniqueItems: true
-          type: array
-          description: One or more interests that the Prisoner feels they have.
-          items:
-            $ref: '#/components/schemas/PersonalInterest'
-        personalInterestsOther:
-          type: string
-          description: A specific type of a interest that the Prisoner feels they have. Mandatory when 'personalInterests' includes 'OTHER'.
       required:
         - id
 
     UpdateEducationAndQualificationsRequest:
       description: A request to persist a Prisoner's education and qualifications. Migrated from hmpps-ciag-careers-induction-api.
         the inmate.
-      type: object
+      allOf:
+        - $ref: '#/components/schemas/CreateEducationAndQualificationsRequest'
       properties:
         id:
           type: string
           format: uuid
           description: A unique reference for this Prisoner's education and qualifications.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
-        educationLevel:
-          $ref: '#/components/schemas/HighestEducationLevel'
-        qualifications:
-          uniqueItems: true
-          type: array
-          description: A list of the Prisoner's previous qualifications
-          items:
-            $ref: '#/components/schemas/AchievedQualification'
-        additionalTraining:
-          uniqueItems: true
-          type: array
-          description: Any additional training that the Prisoner has completed in the past.
-          items:
-            $ref: '#/components/schemas/TrainingType'
-        additionalTrainingOther:
-          type: string
-          description: A specific type of training that does not fit the given 'additionalTraining' types. Mandatory when 'additionalTraining' includes 'OTHER'.
       required:
         - id
 
     UpdatePrisonWorkAndEducationRequest:
       description: A request to persist a Prisoner's in-prison work and education interests. Migrated from hmpps-ciag-careers-induction-api.
-      type: object
+      allOf:
+        - $ref: '#/components/schemas/CreatePrisonWorkAndEducationRequest'
       properties:
         id:
           type: string
           format: uuid
           description: A unique reference for this Prisoner's in-prison work and education interests.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
-        inPrisonWork:
-          minItems: 1
-          uniqueItems: true
-          type: array
-          description: A list of in-prison work that the Prisoner is interested in.
-          items:
-            $ref: '#/components/schemas/InPrisonWorkType'
-        inPrisonWorkOther:
-          type: string
-          description: A specific type of in-prison work that does not fit the given 'inPrisonWork' types. Mandatory when 'inPrisonWork' includes 'OTHER'.
-        inPrisonEducation:
-          minItems: 1
-          uniqueItems: true
-          type: array
-          description: Any potential in-prison education/training that the Prisoner is interested in.
-          items:
-            $ref: '#/components/schemas/InPrisonTrainingType'
-        inPrisonEducationOther:
-          type: string
-          description: A specific type of in-prison education/training that does not fit the given 'inPrisonEducation' types. Mandatory when 'inPrisonEducation' includes 'OTHER'.
       required:
         - id
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/CreateCiagInductionRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/CreateCiagInductionRequestMapperTest.kt
@@ -50,24 +50,12 @@ class CreateCiagInductionRequestMapperTest {
     val request = aValidCreateCiagInductionRequest(prisonId = prisonId)
 
     given(workOnReleaseMapper.toCreateWorkOnReleaseDto(any())).willReturn(aValidCreateWorkOnReleaseDto())
-    given(qualificationsAndTrainingMapper.toCreatePreviousQualificationsDto(any(), any())).willReturn(
-      aValidCreatePreviousQualificationsDto(),
-    )
-    given(qualificationsAndTrainingMapper.toCreatePreviousTrainingDto(any(), any())).willReturn(
-      aValidCreatePreviousTrainingDto(),
-    )
-    given(workExperiencesMapper.toCreatePreviousWorkExperiencesDto(any(), any())).willReturn(
-      aValidCreatePreviousWorkExperiencesDto(),
-    )
-    given(inPrisonInterestsMapper.toCreateInPrisonInterestsDto(any(), any())).willReturn(
-      aValidCreateInPrisonInterestsDto(),
-    )
-    given(skillsAndInterestsMapper.toCreatePersonalSkillsAndInterestsDto(any(), any())).willReturn(
-      aValidCreatePersonalSkillsAndInterestsDto(),
-    )
-    given(workInterestsMapper.toCreateFutureWorkInterestsDto(any(), any())).willReturn(
-      aValidCreateFutureWorkInterestsDto(),
-    )
+    given(qualificationsAndTrainingMapper.toCreatePreviousQualificationsDto(any(), any())).willReturn(aValidCreatePreviousQualificationsDto())
+    given(qualificationsAndTrainingMapper.toCreatePreviousTrainingDto(any(), any())).willReturn(aValidCreatePreviousTrainingDto())
+    given(workExperiencesMapper.toCreatePreviousWorkExperiencesDto(any(), any())).willReturn(aValidCreatePreviousWorkExperiencesDto())
+    given(inPrisonInterestsMapper.toCreateInPrisonInterestsDto(any(), any())).willReturn(aValidCreateInPrisonInterestsDto())
+    given(skillsAndInterestsMapper.toCreatePersonalSkillsAndInterestsDto(any(), any())).willReturn(aValidCreatePersonalSkillsAndInterestsDto())
+    given(workInterestsMapper.toCreateFutureWorkInterestsDto(any(), any())).willReturn(aValidCreateFutureWorkInterestsDto())
 
     // When
     val actual = mapper.toCreateInductionDto(prisonNumber, request)
@@ -76,10 +64,7 @@ class CreateCiagInductionRequestMapperTest {
     assertThat(actual.prisonNumber).isEqualTo(prisonNumber)
     assertThat(actual.prisonId).isEqualTo(prisonId)
     verify(workOnReleaseMapper).toCreateWorkOnReleaseDto(request)
-    verify(qualificationsAndTrainingMapper).toCreatePreviousQualificationsDto(
-      request.qualificationsAndTraining,
-      prisonId,
-    )
+    verify(qualificationsAndTrainingMapper).toCreatePreviousQualificationsDto(request.qualificationsAndTraining, prisonId)
     verify(qualificationsAndTrainingMapper).toCreatePreviousTrainingDto(request.qualificationsAndTraining, prisonId)
     verify(workExperiencesMapper).toCreatePreviousWorkExperiencesDto(request.workExperience, prisonId)
     verify(inPrisonInterestsMapper).toCreateInPrisonInterestsDto(request.inPrisonInterests, prisonId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapperTest.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
 
-import aValidPrisonWorkAndEducationRequest
+import aValidCreatePrisonWorkAndEducationRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -33,7 +33,7 @@ class InPrisonInterestsResourceMapperTest {
   fun `should map to CreateInPrisonInterestsDto`() {
     // Given
     val prisonId = "BXI"
-    val request = aValidPrisonWorkAndEducationRequest()
+    val request = aValidCreatePrisonWorkAndEducationRequest()
     val expectedInPrisonWorkInterest = listOf(aValidInPrisonWorkInterest())
     val expectedInPrisonTrainingInterest = listOf(aValidInPrisonTrainingInterest())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PersonalSkillsAndInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PersonalSkillsAndInterestsResourceMapperTest.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aVa
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPersonalSkillsAndInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkill
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidSkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidSkillsAndInterestsResponse
 import java.time.OffsetDateTime
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalInterest as PersonalInterestDomain
@@ -35,7 +35,7 @@ class PersonalSkillsAndInterestsResourceMapperTest {
   fun `should map to CreatePersonalSkillsAndInterestsDto`() {
     // Given
     val prisonId = "BXI"
-    val request = aValidSkillsAndInterestsRequest()
+    val request = aValidCreateSkillsAndInterestsRequest()
     val expectedSkills = listOf(PersonalSkillDomain(SkillType.OTHER, "Hidden skills"))
     val expectedInterests = listOf(PersonalInterestDomain(InterestType.OTHER, "Secret interests"))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapperTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aVa
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidWorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkExperienceResource
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterests
@@ -26,7 +26,7 @@ class PreviousWorkExperiencesResourceMapperTest {
   fun `should map to PreviousTrainingDto`() {
     // Given
     val prisonId = "BXI"
-    val request = aValidPreviousWorkRequest()
+    val request = aValidCreatePreviousWorkRequest()
     val expectedExperiences = listOf(
       WorkExperience(
         experienceType = WorkExperienceTypeDomain.OTHER,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapperTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aVa
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateEducationAndQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidEducationAndQualificationsResponse
 import java.time.ZoneOffset
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.HighestEducationLevel as HighestEducationLevelDomain
@@ -26,7 +26,7 @@ class QualificationsAndTrainingResourceMapperTest {
   fun `should map to PreviousQualificationsDto`() {
     // Given
     val prisonId = "BXI"
-    val request = aValidEducationAndQualificationsRequest()
+    val request = aValidCreateEducationAndQualificationsRequest()
     val expectedQualifications = listOf(
       Qualification(
         subject = "English",
@@ -53,7 +53,7 @@ class QualificationsAndTrainingResourceMapperTest {
   fun `should map to PreviousTrainingDto`() {
     // Given
     val prisonId = "BXI"
-    val request = aValidEducationAndQualificationsRequest()
+    val request = aValidCreateEducationAndQualificationsRequest()
     val expectedTrainingTypes = listOf(TrainingTypeDomain.CSCS_CARD, TrainingTypeDomain.OTHER)
 
     // When

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/CreateCiagInductionRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/CreateCiagInductionRequestBuilder.kt
@@ -1,14 +1,14 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
 
-import aValidPrisonWorkAndEducationRequest
+import aValidCreatePrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AbilityToWorkFactor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateCiagInductionRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePrisonWorkAndEducationRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonNotToWork
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SkillsAndInterestsRequest
 
 fun aValidCreateCiagInductionRequest(
   hopingToGetWork: HopingToWork = HopingToWork.NOT_SURE,
@@ -17,10 +17,10 @@ fun aValidCreateCiagInductionRequest(
   abilityToWorkOther: String? = "Lack of interest",
   abilityToWork: Set<AbilityToWorkFactor>? = setOf(AbilityToWorkFactor.OTHER),
   reasonToNotGetWork: Set<ReasonNotToWork>? = setOf(ReasonNotToWork.OTHER),
-  workExperience: PreviousWorkRequest? = aValidPreviousWorkRequest(),
-  skillsAndInterests: SkillsAndInterestsRequest? = aValidSkillsAndInterestsRequest(),
-  qualificationsAndTraining: EducationAndQualificationsRequest? = aValidEducationAndQualificationsRequest(),
-  inPrisonInterests: PrisonWorkAndEducationRequest? = aValidPrisonWorkAndEducationRequest(),
+  workExperience: CreatePreviousWorkRequest? = aValidCreatePreviousWorkRequest(),
+  skillsAndInterests: CreateSkillsAndInterestsRequest? = aValidCreateSkillsAndInterestsRequest(),
+  qualificationsAndTraining: CreateEducationAndQualificationsRequest? = aValidCreateEducationAndQualificationsRequest(),
+  inPrisonInterests: CreatePrisonWorkAndEducationRequest? = aValidCreatePrisonWorkAndEducationRequest(),
 ): CreateCiagInductionRequest = CreateCiagInductionRequest(
   hopingToGetWork = hopingToGetWork,
   prisonId = prisonId,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/EducationAndQualificationsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/EducationAndQualificationsRequestBuilder.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateEducationAndQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HighestEducationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TrainingType
 
-fun aValidEducationAndQualificationsRequest(
+fun aValidCreateEducationAndQualificationsRequest(
   educationLevel: HighestEducationLevel? = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
   qualifications: Set<AchievedQualification>? = setOf(
     aValidAchievedQualification(),
@@ -13,7 +13,7 @@ fun aValidEducationAndQualificationsRequest(
   ),
   additionalTraining: Set<TrainingType>? = setOf(TrainingType.CSCS_CARD, TrainingType.OTHER),
   additionalTrainingOther: String? = "Any training",
-): EducationAndQualificationsRequest = EducationAndQualificationsRequest(
+): CreateEducationAndQualificationsRequest = CreateEducationAndQualificationsRequest(
   educationLevel = educationLevel,
   qualifications = qualifications,
   additionalTraining = additionalTraining,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkRequestBuilder.kt
@@ -1,18 +1,18 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
 
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkExperience
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 
-fun aValidPreviousWorkRequest(
+fun aValidCreatePreviousWorkRequest(
   hasWorkedBefore: Boolean = true,
   typeOfWorkExperience: Set<WorkType>? = setOf(WorkType.OTHER),
   typeOfWorkExperienceOther: String? = "Scientist",
   workExperience: Set<WorkExperience>? = setOf(aValidWorkExperienceResource()),
   workInterests: WorkInterests? = aValidWorkInterests(),
-): PreviousWorkRequest =
-  PreviousWorkRequest(
+): CreatePreviousWorkRequest =
+  CreatePreviousWorkRequest(
     hasWorkedBefore = hasWorkedBefore,
     typeOfWorkExperience = typeOfWorkExperience,
     typeOfWorkExperienceOther = typeOfWorkExperienceOther,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PrisonWorkAndEducationRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PrisonWorkAndEducationRequestBuilder.kt
@@ -1,14 +1,14 @@
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PrisonWorkAndEducationRequest
 
-fun aValidPrisonWorkAndEducationRequest(
+fun aValidCreatePrisonWorkAndEducationRequest(
   inPrisonWork: Set<InPrisonWorkType>? = setOf(InPrisonWorkType.OTHER),
   inPrisonWorkOther: String? = "Any in-prison work",
   inPrisonEducation: Set<InPrisonTrainingType>? = setOf(InPrisonTrainingType.OTHER),
   inPrisonEducationOther: String? = "Any in-prison training",
-): PrisonWorkAndEducationRequest =
-  PrisonWorkAndEducationRequest(
+): CreatePrisonWorkAndEducationRequest =
+  CreatePrisonWorkAndEducationRequest(
     inPrisonWork = inPrisonWork,
     inPrisonWorkOther = inPrisonWorkOther,
     inPrisonEducation = inPrisonEducation,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/SkillsAndInterestsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/SkillsAndInterestsRequestBuilder.kt
@@ -1,16 +1,16 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
 
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkill
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SkillsAndInterestsRequest
 
-fun aValidSkillsAndInterestsRequest(
+fun aValidCreateSkillsAndInterestsRequest(
   skills: Set<PersonalSkill>? = setOf(PersonalSkill.OTHER),
   skillsOther: String? = "Hidden skills",
   personalInterests: Set<PersonalInterest>? = setOf(PersonalInterest.OTHER),
   personalInterestsOther: String? = "Secret interests",
-): SkillsAndInterestsRequest =
-  SkillsAndInterestsRequest(
+): CreateSkillsAndInterestsRequest =
+  CreateSkillsAndInterestsRequest(
     skills = skills,
     skillsOther = skillsOther,
     personalInterests = personalInterests,


### PR DESCRIPTION
PR to add the swagger spec for the update Induction endpoint.

As part of this change, I've prefixed the existing create Induction related request objects with `Request...`, hence the large diff, but really only the swagger spec needs reviewing.