### PR TITLE
RR-431 - Corrections to swagger spec and update request builders

### DIFF
--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateFutureWorkInterestsDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateFutureWorkInterestsDto.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterest
+import java.util.UUID
+
+data class UpdateFutureWorkInterestsDto(
+  val reference: UUID,
+  val interests: List<WorkInterest>,
+  val prisonId: String,
+)

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateInPrisonInterestsDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateInPrisonInterestsDto.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonTrainingInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonWorkInterest
+import java.util.UUID
+
+data class UpdateInPrisonInterestsDto(
+  val reference: UUID,
+  val inPrisonWorkInterests: List<InPrisonWorkInterest>,
+  val inPrisonTrainingInterests: List<InPrisonTrainingInterest>,
+  val prisonId: String,
+)

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateInductionDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateInductionDto.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
+
+import java.util.UUID
+
+data class UpdateInductionDto(
+  val reference: UUID,
+  val prisonNumber: String,
+  val workOnRelease: UpdateWorkOnReleaseDto,
+  val previousQualifications: UpdatePreviousQualificationsDto?,
+  val previousTraining: UpdatePreviousTrainingDto?,
+  val previousWorkExperiences: UpdatePreviousWorkExperiencesDto?,
+  val inPrisonInterests: UpdateInPrisonInterestsDto?,
+  val personalSkillsAndInterests: UpdatePersonalSkillsAndInterestsDto?,
+  val futureWorkInterests: UpdateFutureWorkInterestsDto?,
+  val prisonId: String,
+)

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePersonalSkillsAndInterestsDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePersonalSkillsAndInterestsDto.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkill
+import java.util.UUID
+
+data class UpdatePersonalSkillsAndInterestsDto(
+  val reference: UUID,
+  val skills: List<PersonalSkill>,
+  val interests: List<PersonalInterest>,
+  val prisonId: String,
+)

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousQualificationsDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousQualificationsDto.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.HighestEducationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Qualification
+import java.util.UUID
+
+data class UpdatePreviousQualificationsDto(
+  val reference: UUID,
+  val educationLevel: HighestEducationLevel,
+  val qualifications: List<Qualification>,
+  val prisonId: String,
+)

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousTrainingDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousTrainingDto.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.TrainingType
+import java.util.UUID
+
+data class UpdatePreviousTrainingDto(
+  val reference: UUID,
+  val trainingTypes: List<TrainingType>,
+  val trainingTypeOther: String?,
+  val prisonId: String,
+)

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousWorkExperiencesDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousWorkExperiencesDto.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkExperience
+import java.util.UUID
+
+data class UpdatePreviousWorkExperiencesDto(
+  val reference: UUID,
+  val experiences: List<WorkExperience>,
+  val prisonId: String,
+)

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateWorkOnReleaseDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateWorkOnReleaseDto.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.AffectAbilityToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.HopingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.NotHopingToWorkReason
+import java.util.UUID
+
+data class UpdateWorkOnReleaseDto(
+  val reference: UUID,
+  val hopingToWork: HopingToWork,
+  val notHopingToWorkReasons: List<NotHopingToWorkReason>,
+  val notHopingToWorkOtherReason: String?,
+  val affectAbilityToWork: List<AffectAbilityToWork>,
+  val affectAbilityToWorkOther: String?,
+  val prisonId: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapper.kt
@@ -4,20 +4,19 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateFutureWorkInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 
 @Component
 class FutureWorkInterestsResourceMapper {
-  fun toCreateFutureWorkInterestsDto(request: WorkInterests?, prisonId: String): CreateFutureWorkInterestsDto? {
-    return request?.let {
+  fun toCreateFutureWorkInterestsDto(request: CreateWorkInterestsRequest?, prisonId: String): CreateFutureWorkInterestsDto? =
+    request?.let {
       CreateFutureWorkInterestsDto(
         interests = toWorkInterests(it.particularJobInterests, it.workInterestsOther),
         prisonId = prisonId,
       )
     }
-  }
 
   private fun toWorkInterests(
     workInterests: Set<WorkInterestDetail>?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapper.kt
@@ -55,9 +55,10 @@ abstract class PreviousWorkExperiencesResourceMapper {
   @Mapping(target = "otherWork", source = "experienceTypeOther")
   abstract fun toWorkExperienceApi(workExperience: WorkExperienceDomain): WorkExperienceApi
 
-  fun toWorkInterestsResponse(workInterests: FutureWorkInterests?): WorkInterests? {
+  private fun toWorkInterestsResponse(workInterests: FutureWorkInterests?): WorkInterests? {
     return workInterests?.let {
       WorkInterests(
+        id = workInterests.reference,
         workInterests = workInterests.interests.map { toWorkTypeApi(it.workType) }.toSet(),
         workInterestsOther = toWorkInterestsOther(workInterests),
         particularJobInterests = workInterests.interests.map { toWorkInterestDetail(it) }.toSet(),

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.4.4'
+  version: '1.4.5'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -987,9 +987,32 @@ components:
           items:
             $ref: '#/components/schemas/WorkExperience'
         workInterests:
-          $ref: '#/components/schemas/WorkInterests'
+          $ref: '#/components/schemas/CreateWorkInterestsRequest'
       required:
         - hasWorkedBefore
+
+    CreateWorkInterestsRequest:
+      description: The Prisoner's work interests. Migrated from hmpps-ciag-careers-induction-api.
+      type: object
+      properties:
+        workInterests:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          description: A list of Prisoner's future work interests.
+          items:
+            $ref: '#/components/schemas/WorkType'
+        workInterestsOther:
+          type: string
+          description: A work interest, which is not listed in 'workInterests' Enum. Mandatory when 'workInterests' includes 'OTHER'.
+        particularJobInterests:
+          uniqueItems: true
+          type: array
+          description: A detailed list of work interests that a Prisoner has.
+          items:
+            $ref: '#/components/schemas/WorkInterestDetail'
+      required:
+        - workInterests
 
     CreateSkillsAndInterestsRequest:
       description: A request to persist a Prisoner's personal skills and interests. Migrated from hmpps-ciag-careers-induction-api.
@@ -1106,24 +1129,46 @@ components:
         inPrisonInterests:
           $ref: '#/components/schemas/UpdatePrisonWorkAndEducationRequest'
       required:
+        - reference
         - hopingToGetWork
         - prisonId
 
     UpdatePreviousWorkRequest:
-      description: A request to persist the previous work experience of the Prisoner. Migrated from hmpps-ciag-careers-induction-api.
-      allOf:
-        - $ref: '#/components/schemas/CreatePreviousWorkRequest'
+      description: A request to update the previous work experience of the Prisoner. Migrated from hmpps-ciag-careers-induction-api.
+      type: object
       properties:
         id:
           type: string
           format: uuid
           description: A unique reference for this Prisoner's previous work experience.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
+        hasWorkedBefore:
+          type: boolean
+        typeOfWorkExperience:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          description: A list of the Prisoner's type of previous work experience.
+          items:
+            $ref: '#/components/schemas/WorkType'
+        typeOfWorkExperienceOther:
+          type: string
+          description: A specific work experience type for the Prisoner. Mandatory when 'typeOfWorkExperience' includes 'OTHER'.
+        workExperience:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          description: A list of the Prisoner's previous work experience details.
+          items:
+            $ref: '#/components/schemas/WorkExperience'
+        workInterests:
+          $ref: '#/components/schemas/WorkInterests'
       required:
         - id
+        - hasWorkedBefore
 
     UpdateSkillsAndInterestsRequest:
-      description: A request to persist a Prisoner's personal skills and interests. Migrated from hmpps-ciag-careers-induction-api.
+      description: A request to update a Prisoner's personal skills and interests. Migrated from hmpps-ciag-careers-induction-api.
       allOf:
         - $ref: '#/components/schemas/CreateSkillsAndInterestsRequest'
       properties:
@@ -1136,7 +1181,7 @@ components:
         - id
 
     UpdateEducationAndQualificationsRequest:
-      description: A request to persist a Prisoner's education and qualifications. Migrated from hmpps-ciag-careers-induction-api.
+      description: A request to update a Prisoner's education and qualifications. Migrated from hmpps-ciag-careers-induction-api.
         the inmate.
       allOf:
         - $ref: '#/components/schemas/CreateEducationAndQualificationsRequest'
@@ -1150,7 +1195,7 @@ components:
         - id
 
     UpdatePrisonWorkAndEducationRequest:
-      description: A request to persist a Prisoner's in-prison work and education interests. Migrated from hmpps-ciag-careers-induction-api.
+      description: A request to update a Prisoner's in-prison work and education interests. Migrated from hmpps-ciag-careers-induction-api.
       allOf:
         - $ref: '#/components/schemas/CreatePrisonWorkAndEducationRequest'
       properties:
@@ -1182,26 +1227,16 @@ components:
 
     WorkInterests:
       description: The Prisoner's work interests. Migrated from hmpps-ciag-careers-induction-api.
-      type: object
+      allOf:
+        - $ref: '#/components/schemas/CreateWorkInterestsRequest'
       properties:
-        workInterests:
-          minItems: 1
-          uniqueItems: true
-          type: array
-          description: A list of Prisoner's future work interests.
-          items:
-            $ref: '#/components/schemas/WorkType'
-        workInterestsOther:
+        id:
           type: string
-          description: A work interest, which is not listed in 'workInterests' Enum. Mandatory when 'workInterests' includes 'OTHER'.
-        particularJobInterests:
-          uniqueItems: true
-          type: array
-          description: A detailed list of work interests that a Prisoner has.
-          items:
-            $ref: '#/components/schemas/WorkInterestDetail'
+          format: uuid
+          description: A unique reference for this Prisoner's education and qualifications.
+          example: c88a6c48-97e2-4c04-93b5-98619966447b
       required:
-        - workInterests
+        - id
 
     WorkInterestDetail:
       title: WorkInterestDetail

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterests
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkInterestsRequest
 
 class FutureWorkInterestsResourceMapperTest {
   private val mapper = FutureWorkInterestsResourceMapper()
@@ -12,7 +12,7 @@ class FutureWorkInterestsResourceMapperTest {
   fun `should map to CreateFutureWorkInterestsDto`() {
     // Given
     val prisonId = "BXI"
-    val request = aValidWorkInterests()
+    val request = aValidCreateWorkInterestsRequest()
 
     // When
     val actual = mapper.toCreateFutureWorkInterestsDto(request, prisonId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapperTest.kt
@@ -80,6 +80,7 @@ class PreviousWorkExperiencesResourceMapperTest {
         ),
       ),
       workInterests = aValidWorkInterests(
+        id = workInterests.reference,
         workInterests = setOf(WorkType.OTHER),
         workInterestsOther = "Varied interests",
         particularJobInterests = setOf(
@@ -167,6 +168,7 @@ class PreviousWorkExperiencesResourceMapperTest {
       typeOfWorkExperienceOther = null,
       workExperience = emptySet(),
       workInterests = aValidWorkInterests(
+        id = workInterests.reference,
         workInterests = emptySet(),
         workInterestsOther = null,
         particularJobInterests = emptySet(),

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/EducationAndQualificationsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/EducationAndQualificationsRequestBuilder.kt
@@ -4,6 +4,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Achie
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateEducationAndQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HighestEducationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateEducationAndQualificationsRequest
+import java.util.UUID
 
 fun aValidCreateEducationAndQualificationsRequest(
   educationLevel: HighestEducationLevel? = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
@@ -14,6 +16,23 @@ fun aValidCreateEducationAndQualificationsRequest(
   additionalTraining: Set<TrainingType>? = setOf(TrainingType.CSCS_CARD, TrainingType.OTHER),
   additionalTrainingOther: String? = "Any training",
 ): CreateEducationAndQualificationsRequest = CreateEducationAndQualificationsRequest(
+  educationLevel = educationLevel,
+  qualifications = qualifications,
+  additionalTraining = additionalTraining,
+  additionalTrainingOther = additionalTrainingOther,
+)
+
+fun aValidUpdateEducationAndQualificationsRequest(
+  id: UUID = UUID.randomUUID(),
+  educationLevel: HighestEducationLevel? = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
+  qualifications: Set<AchievedQualification>? = setOf(
+    aValidAchievedQualification(),
+    anotherValidAchievedQualification(),
+  ),
+  additionalTraining: Set<TrainingType>? = setOf(TrainingType.CSCS_CARD, TrainingType.OTHER),
+  additionalTrainingOther: String? = "Any training",
+): UpdateEducationAndQualificationsRequest = UpdateEducationAndQualificationsRequest(
+  id = id,
   educationLevel = educationLevel,
   qualifications = qualifications,
   additionalTraining = additionalTraining,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkRequestBuilder.kt
@@ -1,18 +1,38 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkExperience
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
+import java.util.UUID
 
 fun aValidCreatePreviousWorkRequest(
   hasWorkedBefore: Boolean = true,
   typeOfWorkExperience: Set<WorkType>? = setOf(WorkType.OTHER),
   typeOfWorkExperienceOther: String? = "Scientist",
   workExperience: Set<WorkExperience>? = setOf(aValidWorkExperienceResource()),
-  workInterests: WorkInterests? = aValidWorkInterests(),
+  workInterests: CreateWorkInterestsRequest? = aValidCreateWorkInterestsRequest(),
 ): CreatePreviousWorkRequest =
   CreatePreviousWorkRequest(
+    hasWorkedBefore = hasWorkedBefore,
+    typeOfWorkExperience = typeOfWorkExperience,
+    typeOfWorkExperienceOther = typeOfWorkExperienceOther,
+    workExperience = workExperience,
+    workInterests = workInterests,
+  )
+
+fun aValidUpdatePreviousWorkRequest(
+  id: UUID = UUID.randomUUID(),
+  hasWorkedBefore: Boolean = true,
+  typeOfWorkExperience: Set<WorkType>? = setOf(WorkType.OTHER),
+  typeOfWorkExperienceOther: String? = "Scientist",
+  workExperience: Set<WorkExperience>? = setOf(aValidWorkExperienceResource()),
+  workInterests: WorkInterests? = aValidWorkInterests(),
+): UpdatePreviousWorkRequest =
+  UpdatePreviousWorkRequest(
+    id = id,
     hasWorkedBefore = hasWorkedBefore,
     typeOfWorkExperience = typeOfWorkExperience,
     typeOfWorkExperienceOther = typeOfWorkExperienceOther,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PrisonWorkAndEducationRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PrisonWorkAndEducationRequestBuilder.kt
@@ -1,6 +1,8 @@
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePrisonWorkAndEducationRequest
+import java.util.UUID
 
 fun aValidCreatePrisonWorkAndEducationRequest(
   inPrisonWork: Set<InPrisonWorkType>? = setOf(InPrisonWorkType.OTHER),
@@ -9,6 +11,21 @@ fun aValidCreatePrisonWorkAndEducationRequest(
   inPrisonEducationOther: String? = "Any in-prison training",
 ): CreatePrisonWorkAndEducationRequest =
   CreatePrisonWorkAndEducationRequest(
+    inPrisonWork = inPrisonWork,
+    inPrisonWorkOther = inPrisonWorkOther,
+    inPrisonEducation = inPrisonEducation,
+    inPrisonEducationOther = inPrisonEducationOther,
+  )
+
+fun aValidUpdatePrisonWorkAndEducationRequest(
+  id: UUID = UUID.randomUUID(),
+  inPrisonWork: Set<InPrisonWorkType>? = setOf(InPrisonWorkType.OTHER),
+  inPrisonWorkOther: String? = "Any in-prison work",
+  inPrisonEducation: Set<InPrisonTrainingType>? = setOf(InPrisonTrainingType.OTHER),
+  inPrisonEducationOther: String? = "Any in-prison training",
+): UpdatePrisonWorkAndEducationRequest =
+  UpdatePrisonWorkAndEducationRequest(
+    id = id,
     inPrisonWork = inPrisonWork,
     inPrisonWorkOther = inPrisonWorkOther,
     inPrisonEducation = inPrisonEducation,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/SkillsAndInterestsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/SkillsAndInterestsRequestBuilder.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.indu
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkill
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateSkillsAndInterestsRequest
+import java.util.UUID
 
 fun aValidCreateSkillsAndInterestsRequest(
   skills: Set<PersonalSkill>? = setOf(PersonalSkill.OTHER),
@@ -11,6 +13,21 @@ fun aValidCreateSkillsAndInterestsRequest(
   personalInterestsOther: String? = "Secret interests",
 ): CreateSkillsAndInterestsRequest =
   CreateSkillsAndInterestsRequest(
+    skills = skills,
+    skillsOther = skillsOther,
+    personalInterests = personalInterests,
+    personalInterestsOther = personalInterestsOther,
+  )
+
+fun aValidUpdateSkillsAndInterestsRequest(
+  id: UUID = UUID.randomUUID(),
+  skills: Set<PersonalSkill>? = setOf(PersonalSkill.OTHER),
+  skillsOther: String? = "Hidden skills",
+  personalInterests: Set<PersonalInterest>? = setOf(PersonalInterest.OTHER),
+  personalInterestsOther: String? = "Secret interests",
+): UpdateSkillsAndInterestsRequest =
+  UpdateSkillsAndInterestsRequest(
+    id = id,
     skills = skills,
     skillsOther = skillsOther,
     personalInterests = personalInterests,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateCiagInductionRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateCiagInductionRequestBuilder.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import aValidUpdatePrisonWorkAndEducationRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AbilityToWorkFactor
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonNotToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePrisonWorkAndEducationRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateSkillsAndInterestsRequest
+import java.util.UUID
+
+fun aValidUpdateCiagInductionRequest(
+  reference: UUID = UUID.randomUUID(),
+  hopingToGetWork: HopingToWork = HopingToWork.NOT_SURE,
+  prisonId: String = "BXI",
+  reasonToNotGetWorkOther: String? = "Crime pays",
+  abilityToWorkOther: String? = "Lack of interest",
+  abilityToWork: Set<AbilityToWorkFactor>? = setOf(AbilityToWorkFactor.OTHER),
+  reasonToNotGetWork: Set<ReasonNotToWork>? = setOf(ReasonNotToWork.OTHER),
+  workExperience: UpdatePreviousWorkRequest? = aValidUpdatePreviousWorkRequest(),
+  skillsAndInterests: UpdateSkillsAndInterestsRequest? = aValidUpdateSkillsAndInterestsRequest(),
+  qualificationsAndTraining: UpdateEducationAndQualificationsRequest? = aValidUpdateEducationAndQualificationsRequest(),
+  inPrisonInterests: UpdatePrisonWorkAndEducationRequest? = aValidUpdatePrisonWorkAndEducationRequest(),
+): UpdateCiagInductionRequest = UpdateCiagInductionRequest(
+  reference = reference,
+  hopingToGetWork = hopingToGetWork,
+  prisonId = prisonId,
+  reasonToNotGetWorkOther = reasonToNotGetWorkOther,
+  abilityToWorkOther = abilityToWorkOther,
+  abilityToWork = abilityToWork,
+  reasonToNotGetWork = reasonToNotGetWork,
+  workExperience = workExperience,
+  skillsAndInterests = skillsAndInterests,
+  qualificationsAndTraining = qualificationsAndTraining,
+  inPrisonInterests = inPrisonInterests,
+)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/WorkInterestsBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/WorkInterestsBuilder.kt
@@ -1,10 +1,29 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
 
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
+import java.util.UUID
+
+fun aValidCreateWorkInterestsRequest(
+  workInterests: Set<WorkType> = setOf(WorkType.OTHER),
+  workInterestsOther: String? = "Any job I can get",
+  particularJobInterests: Set<WorkInterestDetail>? = setOf(
+    WorkInterestDetail(
+      workInterest = WorkType.OTHER,
+      role = "Any role",
+    ),
+  ),
+): CreateWorkInterestsRequest =
+  CreateWorkInterestsRequest(
+    workInterests = workInterests,
+    workInterestsOther = workInterestsOther,
+    particularJobInterests = particularJobInterests,
+  )
 
 fun aValidWorkInterests(
+  id: UUID = UUID.randomUUID(),
   workInterests: Set<WorkType> = setOf(WorkType.OTHER),
   workInterestsOther: String? = "Any job I can get",
   particularJobInterests: Set<WorkInterestDetail>? = setOf(
@@ -15,6 +34,7 @@ fun aValidWorkInterests(
   ),
 ): WorkInterests =
   WorkInterests(
+    id = id,
     workInterests = workInterests,
     workInterestsOther = workInterestsOther,
     particularJobInterests = particularJobInterests,


### PR DESCRIPTION
As the title suggests, this PR makes some corrections to the swagger spec and also adds the required test data builders for the new Update Induction API model objects. It also adds the required Update DTOs.

This is a precursor before I create a separate PR to add the mappers for converting the update model objects to the new Update DTOs.