### PR TITLE
RR-431 - Update Induction API model to DTO mappers

### DIFF
--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/FutureWorkInterests.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/FutureWorkInterests.kt
@@ -27,7 +27,7 @@ data class FutureWorkInterests(
 data class WorkInterest(
   val workType: WorkInterestType,
   val workTypeOther: String?,
-  val role: String,
+  val role: String?,
 )
 
 enum class WorkInterestType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapper.kt
@@ -4,8 +4,10 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateFutureWorkInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateFutureWorkInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 
 @Component
@@ -13,6 +15,15 @@ class FutureWorkInterestsResourceMapper {
   fun toCreateFutureWorkInterestsDto(request: CreateWorkInterestsRequest?, prisonId: String): CreateFutureWorkInterestsDto? =
     request?.let {
       CreateFutureWorkInterestsDto(
+        interests = toWorkInterests(it.particularJobInterests, it.workInterestsOther),
+        prisonId = prisonId,
+      )
+    }
+
+  fun toUpdateFutureWorkInterestsDto(request: WorkInterests?, prisonId: String): UpdateFutureWorkInterestsDto? =
+    request?.let {
+      UpdateFutureWorkInterestsDto(
+        reference = it.id,
         interests = toWorkInterests(it.particularJobInterests, it.workInterestsOther),
         prisonId = prisonId,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapper.kt
@@ -6,10 +6,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InP
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonTrainingInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonWorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateInPrisonInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateInPrisonInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PrisonWorkAndEducationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonTrainingType as InPrisonTrainingTypeDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonWorkType as InPrisonWorkTypeDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingType as InPrisonTrainingTypeApi
@@ -23,18 +25,17 @@ class InPrisonInterestsResourceMapper(
   fun toCreateInPrisonInterestsDto(
     request: CreatePrisonWorkAndEducationRequest?,
     prisonId: String,
-  ): CreateInPrisonInterestsDto? {
-    return request?.let {
+  ): CreateInPrisonInterestsDto? =
+    request?.let {
       CreateInPrisonInterestsDto(
         inPrisonWorkInterests = toInPrisonWorkInterests(it.inPrisonWork, it.inPrisonWorkOther),
         inPrisonTrainingInterests = toInPrisonTrainingInterests(it.inPrisonEducation, it.inPrisonEducationOther),
         prisonId = prisonId,
       )
     }
-  }
 
-  fun toPrisonWorkAndEducationResponse(inPrisonInterests: InPrisonInterests?): PrisonWorkAndEducationResponse? {
-    return inPrisonInterests?.let {
+  fun toPrisonWorkAndEducationResponse(inPrisonInterests: InPrisonInterests?): PrisonWorkAndEducationResponse? =
+    inPrisonInterests?.let {
       PrisonWorkAndEducationResponse(
         id = inPrisonInterests.reference,
         inPrisonWork = toInPrisonWorkTypes(inPrisonInterests.inPrisonWorkInterests),
@@ -45,29 +46,26 @@ class InPrisonInterestsResourceMapper(
         modifiedDateTime = instantMapper.toOffsetDateTime(inPrisonInterests.lastUpdatedAt)!!,
       )
     }
-  }
 
   private fun toInPrisonWorkInterests(
     inPrisonWorkTypes: Set<InPrisonWorkTypeApi>?,
     inPrisonWorkOther: String?,
-  ): List<InPrisonWorkInterest> {
-    return inPrisonWorkTypes?.map {
+  ): List<InPrisonWorkInterest> =
+    inPrisonWorkTypes?.map {
       val workType = InPrisonWorkTypeDomain.valueOf(it.name)
       val workTypeOther = if (it == InPrisonWorkTypeApi.OTHER) inPrisonWorkOther else null
       InPrisonWorkInterest(workType = workType, workTypeOther = workTypeOther)
     } ?: emptyList()
-  }
 
   private fun toInPrisonTrainingInterests(
     inPrisonEducationTypes: Set<InPrisonTrainingTypeApi>?,
     inPrisonEducationOther: String?,
-  ): List<InPrisonTrainingInterest> {
-    return inPrisonEducationTypes?.map {
+  ): List<InPrisonTrainingInterest> =
+    inPrisonEducationTypes?.map {
       val trainingType = InPrisonTrainingTypeDomain.valueOf(it.name)
       val trainingTypeOther = if (it == InPrisonTrainingTypeApi.OTHER) inPrisonEducationOther else null
       InPrisonTrainingInterest(trainingType = trainingType, trainingTypeOther = trainingTypeOther)
     } ?: emptyList()
-  }
 
   private fun toInPrisonWorkTypes(workInterests: List<InPrisonWorkInterest>): Set<InPrisonWorkType> =
     workInterests.map { InPrisonWorkType.valueOf(it.workType.name) }.toSet()
@@ -80,4 +78,17 @@ class InPrisonInterestsResourceMapper(
 
   private fun toInPrisonTrainingOther(inPrisonInterests: InPrisonInterests) =
     inPrisonInterests.inPrisonTrainingInterests.firstOrNull { it.trainingType == InPrisonTrainingTypeDomain.OTHER }?.trainingTypeOther
+
+  fun toUpdateInPrisonInterestsDto(
+    request: UpdatePrisonWorkAndEducationRequest?,
+    prisonId: String,
+  ): UpdateInPrisonInterestsDto? =
+    request?.let {
+      UpdateInPrisonInterestsDto(
+        reference = it.id,
+        inPrisonWorkInterests = toInPrisonWorkInterests(it.inPrisonWork, it.inPrisonWorkOther),
+        inPrisonTrainingInterests = toInPrisonTrainingInterests(it.inPrisonEducation, it.inPrisonEducationOther),
+        prisonId = prisonId,
+      )
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PersonalSkillsAndInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PersonalSkillsAndInterestsResourceMapper.kt
@@ -6,8 +6,10 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Int
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkillsAndInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.SkillType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePersonalSkillsAndInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdatePersonalSkillsAndInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SkillsAndInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalInterest as PersonalInterestDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkill as PersonalSkillDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterest as PersonalInterestApi
@@ -79,4 +81,17 @@ class PersonalSkillsAndInterestsResourceMapper(
 
   private fun toPersonalInterestsOther(skillsAndInterests: PersonalSkillsAndInterests) =
     skillsAndInterests.interests.firstOrNull { it.interestType == InterestType.OTHER }?.interestTypeOther
+
+  fun toUpdatePersonalSkillsAndInterestsDto(
+    request: UpdateSkillsAndInterestsRequest?,
+    prisonId: String,
+  ): UpdatePersonalSkillsAndInterestsDto? =
+    request?.let {
+      UpdatePersonalSkillsAndInterestsDto(
+        reference = it.id,
+        skills = toPersonalSkillsDomain(request.skills, request.skillsOther),
+        interests = toPersonalInterestsDomain(request.personalInterests, request.personalInterestsOther),
+        prisonId = prisonId,
+      )
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapper.kt
@@ -9,8 +9,10 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Wor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePreviousWorkExperiencesDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdatePreviousWorkExperiencesDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
@@ -85,4 +87,11 @@ abstract class PreviousWorkExperiencesResourceMapper {
     workInterests.interests.firstOrNull { it.workType == WorkInterestType.OTHER }?.workTypeOther
 
   fun toOffsetDateTime(instant: Instant?): OffsetDateTime? = instant?.atOffset(ZoneOffset.UTC)
+
+  @Mapping(target = "reference", source = "request.id")
+  @Mapping(target = "experiences", source = "request.workExperience")
+  abstract fun toUpdatePreviousWorkExperiencesDto(
+    request: UpdatePreviousWorkRequest?,
+    prisonId: String,
+  ): UpdatePreviousWorkExperiencesDto?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapper.kt
@@ -8,9 +8,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Qua
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.TrainingType.OTHER
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePreviousTrainingDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdatePreviousQualificationsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdatePreviousTrainingDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateEducationAndQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationAndQualificationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateEducationAndQualificationsRequest
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -72,4 +75,18 @@ abstract class QualificationsAndTrainingResourceMapper {
   abstract fun toTrainingTypesApi(trainingTypesDomain: List<TrainingTypeDomain>): Set<TrainingTypeApi>
 
   fun toOffsetDateTime(instant: Instant?): OffsetDateTime? = instant?.atOffset(ZoneOffset.UTC)
+
+  @Mapping(target = "reference", source = "request.id")
+  abstract fun toUpdatePreviousQualificationsDto(
+    request: UpdateEducationAndQualificationsRequest?,
+    prisonId: String,
+  ): UpdatePreviousQualificationsDto?
+
+  @Mapping(target = "reference", source = "request.id")
+  @Mapping(target = "trainingTypes", source = "request.additionalTraining")
+  @Mapping(target = "trainingTypeOther", source = "request.additionalTrainingOther")
+  abstract fun toUpdatePreviousTrainingDto(
+    request: UpdateEducationAndQualificationsRequest?,
+    prisonId: String,
+  ): UpdatePreviousTrainingDto?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/UpdateCiagInductionRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/UpdateCiagInductionRequestMapper.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateInductionDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateCiagInductionRequest
+
+@Component
+class UpdateCiagInductionRequestMapper(
+  private val workOnReleaseMapper: WorkOnReleaseResourceMapper,
+  private val qualificationsAndTrainingMapper: QualificationsAndTrainingResourceMapper,
+  private val workExperiencesMapper: PreviousWorkExperiencesResourceMapper,
+  private val inPrisonInterestsMapper: InPrisonInterestsResourceMapper,
+  private val skillsAndInterestsMapper: PersonalSkillsAndInterestsResourceMapper,
+  private val workInterestsMapper: FutureWorkInterestsResourceMapper,
+) {
+
+  fun toUpdateInductionDto(prisonNumber: String, request: UpdateCiagInductionRequest): UpdateInductionDto {
+    val prisonId = request.prisonId
+    return UpdateInductionDto(
+      reference = request.reference,
+      prisonNumber = prisonNumber,
+      workOnRelease = workOnReleaseMapper.toUpdateWorkOnReleaseDto(request),
+      previousQualifications = qualificationsAndTrainingMapper.toUpdatePreviousQualificationsDto(
+        request = request.qualificationsAndTraining,
+        prisonId = prisonId,
+      ),
+      previousTraining = qualificationsAndTrainingMapper.toUpdatePreviousTrainingDto(
+        request = request.qualificationsAndTraining,
+        prisonId = prisonId,
+      ),
+      previousWorkExperiences = workExperiencesMapper.toUpdatePreviousWorkExperiencesDto(
+        request = request.workExperience,
+        prisonId = prisonId,
+      ),
+      inPrisonInterests = inPrisonInterestsMapper.toUpdateInPrisonInterestsDto(
+        request = request.inPrisonInterests,
+        prisonId = prisonId,
+      ),
+      personalSkillsAndInterests = skillsAndInterestsMapper.toUpdatePersonalSkillsAndInterestsDto(
+        request = request.skillsAndInterests,
+        prisonId = prisonId,
+      ),
+      futureWorkInterests = workInterestsMapper.toUpdateFutureWorkInterestsDto(
+        request = request.workExperience?.workInterests,
+        prisonId = prisonId,
+      ),
+      prisonId = prisonId,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkOnReleaseResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkOnReleaseResourceMapper.kt
@@ -5,9 +5,11 @@ import org.mapstruct.Mapping
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.AffectAbilityToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.NotHopingToWorkReason
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateWorkOnReleaseDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateWorkOnReleaseDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AbilityToWorkFactor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateCiagInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonNotToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateCiagInductionRequest
 
 @Mapper
 interface WorkOnReleaseResourceMapper {
@@ -22,4 +24,11 @@ interface WorkOnReleaseResourceMapper {
   fun toReasonsNotToWork(domainReasons: List<NotHopingToWorkReason>): Set<ReasonNotToWork>
 
   fun toAbilityToWorkFactors(domainReasons: List<AffectAbilityToWork>): Set<AbilityToWorkFactor>
+
+  @Mapping(target = "hopingToWork", source = "hopingToGetWork")
+  @Mapping(target = "notHopingToWorkReasons", source = "reasonToNotGetWork")
+  @Mapping(target = "notHopingToWorkOtherReason", source = "reasonToNotGetWorkOther")
+  @Mapping(target = "affectAbilityToWork", source = "abilityToWork")
+  @Mapping(target = "affectAbilityToWorkOther", source = "abilityToWorkOther")
+  fun toUpdateWorkOnReleaseDto(request: UpdateCiagInductionRequest): UpdateWorkOnReleaseDto
 }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.4.5'
+  version: '1.4.6'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -1249,7 +1249,6 @@ components:
           type: string
           description: The role within a Prisoner's area of work interest.
       required:
-        - role
         - workInterest
 
     HopingToWork:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterests
 
 class FutureWorkInterestsResourceMapperTest {
   private val mapper = FutureWorkInterestsResourceMapper()
@@ -19,6 +20,24 @@ class FutureWorkInterestsResourceMapperTest {
 
     // Then
     assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.interests).hasSize(1)
+    assertThat(actual.interests[0].workType).isEqualTo(WorkInterestType.OTHER)
+    assertThat(actual.interests[0].workTypeOther).isEqualTo("Any job I can get")
+    assertThat(actual.interests[0].role).isEqualTo("Any role")
+  }
+
+  @Test
+  fun `should map to UpdateFutureWorkInterestsDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidWorkInterests()
+
+    // When
+    val actual = mapper.toUpdateFutureWorkInterestsDto(request, prisonId)
+
+    // Then
+    assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.reference).isEqualTo(request.id)
     assertThat(actual.interests).hasSize(1)
     assertThat(actual.interests[0].workType).isEqualTo(WorkInterestType.OTHER)
     assertThat(actual.interests[0].workTypeOther).isEqualTo("Any job I can get")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapperTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
 
 import aValidCreatePrisonWorkAndEducationRequest
+import aValidUpdatePrisonWorkAndEducationRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -104,5 +105,23 @@ class InPrisonInterestsResourceMapperTest {
 
     // Then
     assertThat(actual).isEqualTo(expectedResponse)
+  }
+
+  @Test
+  fun `should map to UpdateInPrisonInterestsDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdatePrisonWorkAndEducationRequest()
+    val expectedInPrisonWorkInterest = listOf(aValidInPrisonWorkInterest())
+    val expectedInPrisonTrainingInterest = listOf(aValidInPrisonTrainingInterest())
+
+    // When
+    val actual = mapper.toUpdateInPrisonInterestsDto(request, prisonId)
+
+    // Then
+    assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.reference).isEqualTo(request.id)
+    assertThat(actual.inPrisonWorkInterests).isEqualTo(expectedInPrisonWorkInterest)
+    assertThat(actual.inPrisonTrainingInterests).isEqualTo(expectedInPrisonTrainingInterest)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PersonalSkillsAndInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PersonalSkillsAndInterestsResourceMapperTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Perso
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkill
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidSkillsAndInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateSkillsAndInterestsRequest
 import java.time.OffsetDateTime
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalInterest as PersonalInterestDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkill as PersonalSkillDomain
@@ -108,5 +109,23 @@ class PersonalSkillsAndInterestsResourceMapperTest {
 
     // Then
     assertThat(actual).isEqualTo(expectedResponse)
+  }
+
+  @Test
+  fun `should map to UpdatePersonalSkillsAndInterestsDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdateSkillsAndInterestsRequest()
+    val expectedSkills = listOf(PersonalSkillDomain(SkillType.OTHER, "Hidden skills"))
+    val expectedInterests = listOf(PersonalInterestDomain(InterestType.OTHER, "Secret interests"))
+
+    // When
+    val actual = mapper.toUpdatePersonalSkillsAndInterestsDto(request, prisonId)
+
+    // Then
+    assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.reference).isEqualTo(request.id)
+    assertThat(actual.skills).isEqualTo(expectedSkills)
+    assertThat(actual.interests).isEqualTo(expectedInterests)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapperTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkI
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkExperienceResource
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterests
 import java.time.ZoneOffset
@@ -23,7 +24,7 @@ class PreviousWorkExperiencesResourceMapperTest {
   private val mapper = PreviousWorkExperiencesResourceMapperImpl()
 
   @Test
-  fun `should map to PreviousTrainingDto`() {
+  fun `should map to CreatePreviousWorkExperiencesDto`() {
     // Given
     val prisonId = "BXI"
     val request = aValidCreatePreviousWorkRequest()
@@ -181,5 +182,28 @@ class PreviousWorkExperiencesResourceMapperTest {
 
     // Then
     assertThat(actual).isEqualTo(expectedResponse)
+  }
+
+  @Test
+  fun `should map to UpdatePreviousWorkExperiencesDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdatePreviousWorkRequest()
+    val expectedExperiences = listOf(
+      WorkExperience(
+        experienceType = WorkExperienceTypeDomain.OTHER,
+        experienceTypeOther = "Scientist",
+        role = "Lab Technician",
+        details = "Cleaning test tubes",
+      ),
+    )
+
+    // When
+    val actual = mapper.toUpdatePreviousWorkExperiencesDto(request, prisonId)
+
+    // Then
+    assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.reference).isEqualTo(request.id)
+    assertThat(actual.experiences).isEqualTo(expectedExperiences)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapperTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Achie
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateEducationAndQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidEducationAndQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateEducationAndQualificationsRequest
 import java.time.ZoneOffset
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.HighestEducationLevel as HighestEducationLevelDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.TrainingType as TrainingTypeDomain
@@ -23,7 +24,7 @@ class QualificationsAndTrainingResourceMapperTest {
   private val mapper = QualificationsAndTrainingResourceMapperImpl()
 
   @Test
-  fun `should map to PreviousQualificationsDto`() {
+  fun `should map to CreatePreviousQualificationsDto`() {
     // Given
     val prisonId = "BXI"
     val request = aValidCreateEducationAndQualificationsRequest()
@@ -50,7 +51,7 @@ class QualificationsAndTrainingResourceMapperTest {
   }
 
   @Test
-  fun `should map to PreviousTrainingDto`() {
+  fun `should map to CreatePreviousTrainingDto`() {
     // Given
     val prisonId = "BXI"
     val request = aValidCreateEducationAndQualificationsRequest()
@@ -179,5 +180,50 @@ class QualificationsAndTrainingResourceMapperTest {
 
     // Then
     assertThat(actual).isEqualTo(expectedResponse)
+  }
+
+  @Test
+  fun `should map to UpdatePreviousQualificationsDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdateEducationAndQualificationsRequest()
+    val expectedQualifications = listOf(
+      Qualification(
+        subject = "English",
+        level = QualificationLevel.LEVEL_3,
+        grade = "A",
+      ),
+      Qualification(
+        subject = "Maths",
+        level = QualificationLevel.LEVEL_3,
+        grade = "B",
+      ),
+    )
+
+    // When
+    val actual = mapper.toUpdatePreviousQualificationsDto(request, prisonId)
+
+    // Then
+    assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.reference).isEqualTo(request.id)
+    assertThat(actual.educationLevel).isEqualTo(HighestEducationLevelDomain.SECONDARY_SCHOOL_TOOK_EXAMS)
+    assertThat(actual.qualifications).isEqualTo(expectedQualifications)
+  }
+
+  @Test
+  fun `should map to UpdatePreviousTrainingDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdateEducationAndQualificationsRequest()
+    val expectedTrainingTypes = listOf(TrainingTypeDomain.CSCS_CARD, TrainingTypeDomain.OTHER)
+
+    // When
+    val actual = mapper.toUpdatePreviousTrainingDto(request, prisonId)
+
+    // Then
+    assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.reference).isEqualTo(request.id)
+    assertThat(actual.trainingTypes).isEqualTo(expectedTrainingTypes)
+    assertThat(actual.trainingTypeOther).isEqualTo("Any training")
   }
 }


### PR DESCRIPTION
This PR introduces the mappers to convert from the Update Induction API request objects to the equivalent Update DTO ones. It's essentially a copy & paste of the Create Induction mappers, except with the addition of the `id` field.