### PR TITLE
RR-431 - Rename mapper methods

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
@@ -16,7 +16,7 @@ class JpaInductionPersistenceAdapter(
 
   @Transactional
   override fun createInduction(createInductionDto: CreateInductionDto): Induction {
-    val persistedEntity = inductionRepository.save(inductionMapper.fromDtoToEntity(createInductionDto))
+    val persistedEntity = inductionRepository.save(inductionMapper.fromCreateDtoToEntity(createInductionDto))
     return inductionMapper.fromEntityToDomain(persistedEntity)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapper.kt
@@ -22,7 +22,7 @@ interface FutureWorkInterestsEntityMapper {
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromDtoToEntity(dto: CreateFutureWorkInterestsDto): FutureWorkInterestsEntity
+  fun fromCreateDtoToEntity(dto: CreateFutureWorkInterestsDto): FutureWorkInterestsEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapper.kt
@@ -24,7 +24,7 @@ interface InPrisonInterestsEntityMapper {
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromDtoToEntity(dto: CreateInPrisonInterestsDto): InPrisonInterestsEntity
+  fun fromCreateDtoToEntity(dto: CreateInPrisonInterestsDto): InPrisonInterestsEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapper.kt
@@ -24,7 +24,7 @@ interface InductionEntityMapper {
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromDtoToEntity(dto: CreateInductionDto): InductionEntity
+  fun fromCreateDtoToEntity(dto: CreateInductionDto): InductionEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PersonalSkillsAndInterestsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PersonalSkillsAndInterestsEntityMapper.kt
@@ -24,7 +24,7 @@ interface PersonalSkillsAndInterestsEntityMapper {
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromDtoToEntity(dto: CreatePersonalSkillsAndInterestsDto): PersonalSkillsAndInterestsEntity
+  fun fromCreateDtoToEntity(dto: CreatePersonalSkillsAndInterestsDto): PersonalSkillsAndInterestsEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapper.kt
@@ -22,7 +22,7 @@ interface PreviousQualificationsEntityMapper {
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromDtoToEntity(dto: CreatePreviousQualificationsDto): PreviousQualificationsEntity
+  fun fromCreateDtoToEntity(dto: CreatePreviousQualificationsDto): PreviousQualificationsEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapper.kt
@@ -21,7 +21,7 @@ interface PreviousTrainingEntityMapper {
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromDtoToEntity(dto: CreatePreviousTrainingDto): PreviousTrainingEntity
+  fun fromCreateDtoToEntity(dto: CreatePreviousTrainingDto): PreviousTrainingEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousWorkExperiencesEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousWorkExperiencesEntityMapper.kt
@@ -22,7 +22,7 @@ interface PreviousWorkExperiencesEntityMapper {
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromDtoToEntity(dto: CreatePreviousWorkExperiencesDto): PreviousWorkExperiencesEntity
+  fun fromCreateDtoToEntity(dto: CreatePreviousWorkExperiencesDto): PreviousWorkExperiencesEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/WorkOnReleaseEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/WorkOnReleaseEntityMapper.kt
@@ -15,7 +15,7 @@ interface WorkOnReleaseEntityMapper {
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromDtoToEntity(dto: CreateWorkOnReleaseDto): WorkOnReleaseEntity
+  fun fromCreateDtoToEntity(dto: CreateWorkOnReleaseDto): WorkOnReleaseEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapperTest.kt
@@ -39,7 +39,7 @@ class FutureWorkInterestsEntityMapperTest {
     given(workInterestEntityMapper.fromDomainToEntity(any())).willReturn(expectedWorkInterestEntity)
 
     // When
-    val actual = mapper.fromDtoToEntity(createWorkInterestsDto)
+    val actual = mapper.fromCreateDtoToEntity(createWorkInterestsDto)
 
     // Then
     assertThat(actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapperTest.kt
@@ -49,7 +49,7 @@ class InPrisonInterestsEntityMapperTest {
     )
 
     // When
-    val actual = mapper.fromDtoToEntity(createInPrisonInterestsDto)
+    val actual = mapper.fromCreateDtoToEntity(createInPrisonInterestsDto)
 
     // Then
     assertThat(actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapperTest.kt
@@ -85,16 +85,16 @@ class InductionEntityMapperTest {
       createdAtPrison = prisonId,
       updatedAtPrison = prisonId,
     )
-    given(futureWorkInterestsEntityMapper.fromDtoToEntity(any())).willReturn(expectedFutureWorkInterestsEntity)
-    given(inPrisonInterestsEntityMapper.fromDtoToEntity(any())).willReturn(expectedInPrisonInterestsEntity)
-    given(personalSkillsAndInterestsEntityMapper.fromDtoToEntity(any())).willReturn(expectedPersonalSkillsAndInterestsEntity)
-    given(previousQualificationsEntityMapper.fromDtoToEntity(any())).willReturn(expectedPreviousQualificationsEntity)
-    given(previousTrainingEntityMapper.fromDtoToEntity(any())).willReturn(expectedPreviousTrainingEntity)
-    given(previousWorkExperiencesEntityMapper.fromDtoToEntity(any())).willReturn(expectedPreviousWorkExperiencesEntity)
-    given(workOnReleaseEntityMapper.fromDtoToEntity(any())).willReturn(expectedWorkOnReleaseEntity)
+    given(futureWorkInterestsEntityMapper.fromCreateDtoToEntity(any())).willReturn(expectedFutureWorkInterestsEntity)
+    given(inPrisonInterestsEntityMapper.fromCreateDtoToEntity(any())).willReturn(expectedInPrisonInterestsEntity)
+    given(personalSkillsAndInterestsEntityMapper.fromCreateDtoToEntity(any())).willReturn(expectedPersonalSkillsAndInterestsEntity)
+    given(previousQualificationsEntityMapper.fromCreateDtoToEntity(any())).willReturn(expectedPreviousQualificationsEntity)
+    given(previousTrainingEntityMapper.fromCreateDtoToEntity(any())).willReturn(expectedPreviousTrainingEntity)
+    given(previousWorkExperiencesEntityMapper.fromCreateDtoToEntity(any())).willReturn(expectedPreviousWorkExperiencesEntity)
+    given(workOnReleaseEntityMapper.fromCreateDtoToEntity(any())).willReturn(expectedWorkOnReleaseEntity)
 
     // When
-    val actual = mapper.fromDtoToEntity(createInductionDto)
+    val actual = mapper.fromCreateDtoToEntity(createInductionDto)
 
     // Then
     assertThat(actual)
@@ -103,13 +103,13 @@ class InductionEntityMapperTest {
       .usingRecursiveComparison()
       .ignoringFieldsMatchingRegexes(".*reference")
       .isEqualTo(expected)
-    verify(futureWorkInterestsEntityMapper).fromDtoToEntity(createInductionDto.futureWorkInterests!!)
-    verify(inPrisonInterestsEntityMapper).fromDtoToEntity(createInductionDto.inPrisonInterests!!)
-    verify(personalSkillsAndInterestsEntityMapper).fromDtoToEntity(createInductionDto.personalSkillsAndInterests!!)
-    verify(previousQualificationsEntityMapper).fromDtoToEntity(createInductionDto.previousQualifications!!)
-    verify(previousTrainingEntityMapper).fromDtoToEntity(createInductionDto.previousTraining!!)
-    verify(previousWorkExperiencesEntityMapper).fromDtoToEntity(createInductionDto.previousWorkExperiences!!)
-    verify(workOnReleaseEntityMapper).fromDtoToEntity(createInductionDto.workOnRelease)
+    verify(futureWorkInterestsEntityMapper).fromCreateDtoToEntity(createInductionDto.futureWorkInterests!!)
+    verify(inPrisonInterestsEntityMapper).fromCreateDtoToEntity(createInductionDto.inPrisonInterests!!)
+    verify(personalSkillsAndInterestsEntityMapper).fromCreateDtoToEntity(createInductionDto.personalSkillsAndInterests!!)
+    verify(previousQualificationsEntityMapper).fromCreateDtoToEntity(createInductionDto.previousQualifications!!)
+    verify(previousTrainingEntityMapper).fromCreateDtoToEntity(createInductionDto.previousTraining!!)
+    verify(previousWorkExperiencesEntityMapper).fromCreateDtoToEntity(createInductionDto.previousWorkExperiences!!)
+    verify(workOnReleaseEntityMapper).fromCreateDtoToEntity(createInductionDto.workOnRelease)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PersonalSkillsAndInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PersonalSkillsAndInterestsEntityMapperTest.kt
@@ -47,7 +47,7 @@ class PersonalSkillsAndInterestsEntityMapperTest {
     given(personalInterestEntityMapper.fromDomainToEntity(any())).willReturn(expectedPersonalInterest)
 
     // When
-    val actual = mapper.fromDtoToEntity(createPersonalSkillsAndInterestsDto)
+    val actual = mapper.fromCreateDtoToEntity(createPersonalSkillsAndInterestsDto)
 
     // Then
     assertThat(actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapperTest.kt
@@ -46,7 +46,7 @@ class PreviousQualificationsEntityMapperTest {
     given(qualificationEntityMapper.fromDomainToEntity(any())).willReturn(expectedQualificationEntity)
 
     // When
-    val actual = mapper.fromDtoToEntity(createQualificationsDto)
+    val actual = mapper.fromCreateDtoToEntity(createQualificationsDto)
 
     // Then
     assertThat(actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapperTest.kt
@@ -39,7 +39,7 @@ class PreviousTrainingEntityMapperTest {
     given(trainingTypeMapper.fromDomainToEntity(any())).willReturn(listOf(expectedTrainingTypeEntity))
 
     // When
-    val actual = mapper.fromDtoToEntity(createTrainingDto)
+    val actual = mapper.fromCreateDtoToEntity(createTrainingDto)
 
     // Then
     assertThat(actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousWorkExperiencesEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousWorkExperiencesEntityMapperTest.kt
@@ -38,7 +38,7 @@ class PreviousWorkExperiencesEntityMapperTest {
     given(workExperienceEntityMapper.fromDomainToEntity(any())).willReturn(expectedWorkExperienceEntity)
 
     // When
-    val actual = mapper.fromDtoToEntity(createPreviousWorkExperiencesDto)
+    val actual = mapper.fromCreateDtoToEntity(createPreviousWorkExperiencesDto)
 
     // Then
     assertThat(actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/WorkOnReleaseEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/WorkOnReleaseEntityMapperTest.kt
@@ -37,7 +37,7 @@ class WorkOnReleaseEntityMapperTest {
     )
 
     // When
-    val actual = mapper.fromDtoToEntity(createWorkOnReleaseDto)
+    val actual = mapper.fromCreateDtoToEntity(createWorkOnReleaseDto)
 
     // Then
     assertThat(actual)


### PR DESCRIPTION
A precursor before adding `fromUpdateDtoToEntity` methods.