### PR TITLE
RR-431 - Mappers for updating an induction's future work interests

### DIFF
--- a/domain/induction/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/FutureWorkInterestsBuilder.kt
+++ b/domain/induction/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/FutureWorkInterestsBuilder.kt
@@ -31,7 +31,7 @@ fun aValidFutureWorkInterests(
 fun aValidWorkInterest(
   workType: WorkInterestType = WorkInterestType.CONSTRUCTION,
   workTypeOther: String? = null,
-  role: String = "Bricklaying",
+  role: String? = "Bricklaying",
 ) = WorkInterest(
   workType = workType,
   workTypeOther = workTypeOther,

--- a/domain/induction/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/FutureWorkInterestsDtoBuilder.kt
+++ b/domain/induction/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/FutureWorkInterestsDtoBuilder.kt
@@ -2,12 +2,24 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dt
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidWorkInterest
+import java.util.UUID
 
 fun aValidCreateFutureWorkInterestsDto(
   interests: List<WorkInterest> = listOf(aValidWorkInterest()),
   prisonId: String = "BXI",
 ) =
   CreateFutureWorkInterestsDto(
+    interests = interests,
+    prisonId = prisonId,
+  )
+
+fun aValidUpdateFutureWorkInterestsDto(
+  reference: UUID = UUID.randomUUID(),
+  interests: List<WorkInterest> = listOf(aValidWorkInterest()),
+  prisonId: String = "BXI",
+) =
+  UpdateFutureWorkInterestsDto(
+    reference = reference,
     interests = interests,
     prisonId = prisonId,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
@@ -44,7 +44,7 @@ class FutureWorkInterestsEntity(
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "work_interests_id", nullable = false)
-  var interests: List<WorkInterestEntity>? = null,
+  var interests: MutableList<WorkInterestEntity>? = null,
 
   @Column(updatable = false)
   @CreationTimestamp
@@ -136,7 +136,7 @@ class WorkInterestEntity(
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-    other as FutureWorkInterestsEntity
+    other as WorkInterestEntity
 
     return id != null && id == other.id
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapper.kt
@@ -2,33 +2,103 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import org.mapstruct.MappingTarget
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.FutureWorkInterestsEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.WorkInterestEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeJpaManagedFields
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeJpaManagedFieldsIncludingDisplayNameFields
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeReferenceField
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.GenerateNewReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.FutureWorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateFutureWorkInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateFutureWorkInterestsDto
 
 @Mapper(
   uses = [
     WorkInterestEntityMapper::class,
   ],
 )
-interface FutureWorkInterestsEntityMapper {
+abstract class FutureWorkInterestsEntityMapper {
+  @Autowired
+  private lateinit var workInterestEntityMapper: WorkInterestEntityMapper
 
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromCreateDtoToEntity(dto: CreateFutureWorkInterestsDto): FutureWorkInterestsEntity
+  abstract fun fromCreateDtoToEntity(dto: CreateFutureWorkInterestsDto): FutureWorkInterestsEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")
   @Mapping(target = "lastUpdatedAt", source = "updatedAt")
   @Mapping(target = "lastUpdatedAtPrison", source = "updatedAtPrison")
-  fun fromEntityToDomain(persistedEntity: FutureWorkInterestsEntity): FutureWorkInterests
+  abstract fun fromEntityToDomain(entity: FutureWorkInterestsEntity): FutureWorkInterests
+
+  @ExcludeJpaManagedFieldsIncludingDisplayNameFields
+  @ExcludeReferenceField
+  @Mapping(target = "createdAtPrison", ignore = true)
+  @Mapping(target = "updatedAtPrison", source = "prisonId")
+  @Mapping(target = "interests", expression = "java( updateInterests(entity, dto) )")
+  abstract fun updateEntityFromDto(@MappingTarget entity: FutureWorkInterestsEntity, dto: UpdateFutureWorkInterestsDto)
+
+  fun updateInterests(entity: FutureWorkInterestsEntity, dto: UpdateFutureWorkInterestsDto): List<WorkInterestEntity> {
+    val existingInterests = entity.interests!!
+    val updatedInterests = dto.interests
+
+    updateExistingInterests(existingInterests, updatedInterests)
+    addNewInterests(existingInterests, updatedInterests)
+    removeInterests(existingInterests, updatedInterests)
+
+    return existingInterests
+  }
+
+  /**
+   * Update the [WorkInterestEntity] whose work type matches the corresponding [WorkInterest].
+   */
+  private fun updateExistingInterests(
+    existingInterests: MutableList<WorkInterestEntity>,
+    updatedInterests: List<WorkInterest>,
+  ) {
+    val updatedWorkTypes = updatedInterests.map { it.workType.name }
+    existingInterests
+      .filter { interestEntity -> updatedWorkTypes.contains(interestEntity.workType!!.name) }
+      .onEach { interestEntity ->
+        workInterestEntityMapper.updateEntityFromDomain(
+          interestEntity,
+          updatedInterests.first { updatedInterestDto -> updatedInterestDto.workType.name == interestEntity.workType!!.name },
+        )
+      }
+  }
+
+  /**
+   * Add new [WorkInterestEntity]s from the list of updated [WorkInterest]s where the work type is not present in the list of [WorkInterestEntity]s.
+   */
+  private fun addNewInterests(
+    existingInterests: MutableList<WorkInterestEntity>,
+    updatedInterests: List<WorkInterest>,
+  ) {
+    val currentWorkInterestTypes = existingInterests.map { it.workType!!.name }
+    existingInterests.addAll(
+      updatedInterests
+        .filter { updatedInterestDto -> !currentWorkInterestTypes.contains(updatedInterestDto.workType.name) }
+        .map { newInterestDto -> workInterestEntityMapper.fromDomainToEntity(newInterestDto) },
+    )
+  }
+
+  /**
+   * Remove any [WorkInterestEntity]s whose work type is not in the list of updated [WorkInterest]s.
+   */
+  private fun removeInterests(
+    existingInterests: MutableList<WorkInterestEntity>,
+    updatedInterests: List<WorkInterest>,
+  ) {
+    val updatedInterestTypes = updatedInterests.map { it.workType.name }
+    existingInterests.removeIf { interestEntity ->
+      !updatedInterestTypes.contains(interestEntity.workType!!.name)
+    }
+  }
 }
 
 @Mapper
@@ -37,5 +107,9 @@ interface WorkInterestEntityMapper {
   @GenerateNewReference
   fun fromDomainToEntity(domain: WorkInterest): WorkInterestEntity
 
-  fun fromEntityToDomain(persistedEntity: WorkInterestEntity): WorkInterest
+  fun fromEntityToDomain(entity: WorkInterestEntity): WorkInterest
+
+  @ExcludeJpaManagedFields
+  @ExcludeReferenceField
+  fun updateEntityFromDomain(@MappingTarget entity: WorkInterestEntity, domain: WorkInterest)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapperTest.kt
@@ -32,7 +32,7 @@ class FutureWorkInterestsEntityMapperTest {
     val createWorkInterestsDto = aValidCreateFutureWorkInterestsDto()
     val expectedWorkInterestEntity = aValidWorkInterestEntity()
     val expected = aValidFutureWorkInterestsEntity(
-      interests = listOf(expectedWorkInterestEntity),
+      interests = mutableListOf(expectedWorkInterestEntity),
       createdAtPrison = "BXI",
       updatedAtPrison = "BXI",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateFutureWorkInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateFutureWorkInterestsEntityMapperTest.kt
@@ -1,0 +1,174 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidFutureWorkInterestsEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidWorkInterestEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.deepCopy
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidWorkInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateFutureWorkInterestsDto
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.WorkInterestType as WorkInterestTypeEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType as WorkInterestTypeDomain
+
+class UpdateFutureWorkInterestsEntityMapperTest {
+
+  private val mapper = FutureWorkInterestsEntityMapperImpl().also {
+    FutureWorkInterestsEntityMapper::class.java.getDeclaredField("workInterestEntityMapper").apply {
+      isAccessible = true
+      set(it, WorkInterestEntityMapperImpl())
+    }
+  }
+
+  @Test
+  fun `should update existing work interests`() {
+    val workInterestReference = UUID.randomUUID()
+    val existingEntity = aValidWorkInterestEntity(
+      reference = workInterestReference,
+      workType = WorkInterestTypeEntity.OTHER,
+      workTypeOther = "Any job I can get",
+      role = "Any role",
+    )
+    val futureWorkInterestsReference = UUID.randomUUID()
+    val existingFutureWorkInterestsEntity = aValidFutureWorkInterestsEntity(
+      reference = futureWorkInterestsReference,
+      interests = mutableListOf(existingEntity),
+    )
+
+    val updatedInterest = aValidWorkInterest(
+      workType = WorkInterestTypeDomain.OTHER,
+      workTypeOther = "Any job that pays ok",
+      role = null,
+    )
+    val updatedInterestsDto = aValidUpdateFutureWorkInterestsDto(
+      reference = futureWorkInterestsReference,
+      interests = listOf(updatedInterest),
+      prisonId = "MDI",
+    )
+
+    val expectedEntity = existingFutureWorkInterestsEntity.deepCopy().apply {
+      id
+      reference = reference
+      interests = mutableListOf(
+        existingEntity.deepCopy().apply {
+          workType = WorkInterestTypeEntity.OTHER
+          workTypeOther = "Any job that pays ok"
+          role = null
+        },
+      )
+      createdAtPrison = "BXI"
+      updatedAtPrison = "MDI"
+    }
+
+    // When
+    mapper.updateEntityFromDto(existingFutureWorkInterestsEntity, updatedInterestsDto)
+
+    // Then
+    assertThat(existingFutureWorkInterestsEntity).isEqualToComparingAllFields(expectedEntity)
+  }
+
+  @Test
+  fun `should add new work interest`() {
+    val workInterestReference = UUID.randomUUID()
+    val existingEntity = aValidWorkInterestEntity(
+      reference = workInterestReference,
+      workType = WorkInterestTypeEntity.OTHER,
+      workTypeOther = "Any job I can get",
+      role = "Any role",
+    )
+    val futureWorkInterestsReference = UUID.randomUUID()
+    val existingFutureWorkInterestsEntity = aValidFutureWorkInterestsEntity(
+      reference = futureWorkInterestsReference,
+      interests = mutableListOf(existingEntity),
+    )
+
+    val unchangedWorkInterestDomain = aValidWorkInterest(
+      workType = WorkInterestTypeDomain.OTHER,
+      workTypeOther = "Any job I can get",
+      role = "Any role",
+    )
+    val newWorkInterestDomain = aValidWorkInterest(
+      workType = WorkInterestTypeDomain.SPORTS,
+      workTypeOther = null,
+      role = "Professional football player",
+    )
+    val updatedFutureWorkInterestsDto = aValidUpdateFutureWorkInterestsDto(
+      reference = futureWorkInterestsReference,
+      interests = listOf(unchangedWorkInterestDomain, newWorkInterestDomain),
+      prisonId = "MDI",
+    )
+
+    val expectedEntity = existingFutureWorkInterestsEntity.deepCopy().apply {
+      id
+      reference = reference
+      interests = mutableListOf(
+        aValidWorkInterestEntity(
+          workType = WorkInterestTypeEntity.OTHER,
+          workTypeOther = "Any job I can get",
+          role = "Any role",
+        ),
+        aValidWorkInterestEntity(
+          workType = WorkInterestTypeEntity.SPORTS,
+          workTypeOther = null,
+          role = "Professional football player",
+        ),
+      )
+      createdAtPrison = "BXI"
+      updatedAtPrison = "MDI"
+    }
+
+    // When
+    mapper.updateEntityFromDto(existingFutureWorkInterestsEntity, updatedFutureWorkInterestsDto)
+
+    // Then
+    assertThat(existingFutureWorkInterestsEntity).isEqualToIgnoringInternallyManagedFields(expectedEntity)
+  }
+
+  @Test
+  fun `should remove work interests`() {
+    // Given
+    val workInterestReference = UUID.randomUUID()
+    val firstWorkInterestEntity = aValidWorkInterestEntity(
+      reference = workInterestReference,
+      workType = WorkInterestTypeEntity.OTHER,
+      workTypeOther = "Any job I can get",
+      role = "Any role",
+    )
+    val secondWorkInterestEntity = aValidWorkInterestEntity(
+      workType = WorkInterestTypeEntity.CONSTRUCTION,
+      workTypeOther = null,
+      role = "Bricklaying",
+    )
+    val futureWorkInterestsReference = UUID.randomUUID()
+    val existingFutureWorkInterestsEntity = aValidFutureWorkInterestsEntity(
+      reference = futureWorkInterestsReference,
+      interests = mutableListOf(firstWorkInterestEntity, secondWorkInterestEntity),
+    )
+
+    val updatedFutureWorkInterestsDto = aValidUpdateFutureWorkInterestsDto(
+      reference = futureWorkInterestsReference,
+      interests = listOf(
+        aValidWorkInterest(
+          workType = WorkInterestTypeDomain.OTHER, // only first interest above included
+          workTypeOther = "Any job I can get",
+          role = "Any role",
+        ),
+      ),
+      prisonId = "MDI",
+    )
+
+    val expectedEntity = existingFutureWorkInterestsEntity.deepCopy().apply {
+      id
+      reference = reference
+      interests = mutableListOf(firstWorkInterestEntity)
+      createdAtPrison = "BXI"
+      updatedAtPrison = "MDI"
+    }
+
+    // When
+    mapper.updateEntityFromDto(existingFutureWorkInterestsEntity, updatedFutureWorkInterestsDto)
+
+    // Then
+    assertThat(existingFutureWorkInterestsEntity).isEqualToComparingAllFields(expectedEntity)
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntityAssert.kt
@@ -15,6 +15,12 @@ class FutureWorkInterestsEntityAssert(actual: FutureWorkInterestsEntity?) :
     FutureWorkInterestsEntityAssert::class.java,
   ) {
 
+  companion object {
+    // JPA managed fields, plus the reference field, which are all managed/generated within the API
+    private val INTERNALLY_MANAGED_FIELDS =
+      arrayOf(".*id", ".*reference", ".*createdAt", ".*createdBy", ".*createdByDisplayName", ".*updatedAt", ".*updatedBy", ".*updatedByDisplayName")
+  }
+
   fun hasJpaManagedFieldsPopulated(): FutureWorkInterestsEntityAssert {
     isNotNull
     with(actual!!) {
@@ -85,6 +91,16 @@ class FutureWorkInterestsEntityAssert(actual: FutureWorkInterestsEntity?) :
     return this
   }
 
+  fun wasUpdatedAtPrison(expected: String): FutureWorkInterestsEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+
   fun hasAReference(): FutureWorkInterestsEntityAssert {
     isNotNull
     with(actual!!) {
@@ -92,6 +108,21 @@ class FutureWorkInterestsEntityAssert(actual: FutureWorkInterestsEntity?) :
         failWithMessage("Expected reference to be populated, but was $reference")
       }
     }
+    return this
+  }
+
+  fun isEqualToComparingAllFields(expected: FutureWorkInterestsEntity): FutureWorkInterestsEntityAssert {
+    assertThat(actual)
+      .usingRecursiveComparison()
+      .isEqualTo(expected)
+    return this
+  }
+
+  fun isEqualToIgnoringInternallyManagedFields(expected: FutureWorkInterestsEntity): FutureWorkInterestsEntityAssert {
+    assertThat(actual)
+      .usingRecursiveComparison()
+      .ignoringFieldsMatchingRegexes(*INTERNALLY_MANAGED_FIELDS)
+      .isEqualTo(expected)
     return this
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntityBuilder.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 fun aValidFutureWorkInterestsEntity(
   id: UUID? = null,
   reference: UUID? = UUID.randomUUID(),
-  interests: List<WorkInterestEntity> = listOf(aValidWorkInterestEntity()),
+  interests: MutableList<WorkInterestEntity> = mutableListOf(aValidWorkInterestEntity()),
   createdAt: Instant? = null,
   createdAtPrison: String = "BXI",
   createdBy: String? = null,
@@ -33,7 +33,7 @@ fun aValidFutureWorkInterestsEntity(
 fun aValidFutureWorkInterestsEntityWithJpaFieldsPopulated(
   id: UUID? = UUID.randomUUID(),
   reference: UUID? = UUID.randomUUID(),
-  interests: List<WorkInterestEntity> = listOf(aValidWorkInterestEntity()),
+  interests: MutableList<WorkInterestEntity> = mutableListOf(aValidWorkInterestEntity()),
   createdAt: Instant? = Instant.now(),
   createdAtPrison: String = "BXI",
   createdBy: String? = "asmith_gen",


### PR DESCRIPTION
This PR adds the necessary `MapStruct` implementation for updating an existing `FutureWorkInterestsEntity` from an incoming `UpdateFutureWorkInterestsDto`.

I've deliberately only done this for future work interests because a) this has already changed 8 files and b) I want to make sure we're happy with this approach.