### PR TITLE
RR-431 - Mappers for updating SkillsAndInterests and InPrisonInterests

### DIFF
--- a/domain/induction/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/InPrisonInterestsDtoBuilder.kt
+++ b/domain/induction/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/InPrisonInterestsDtoBuilder.kt
@@ -4,12 +4,25 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InP
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonWorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInPrisonTrainingInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInPrisonWorkInterest
+import java.util.UUID
 
 fun aValidCreateInPrisonInterestsDto(
   inPrisonWorkInterests: List<InPrisonWorkInterest> = listOf(aValidInPrisonWorkInterest()),
   inPrisonTrainingInterests: List<InPrisonTrainingInterest> = listOf(aValidInPrisonTrainingInterest()),
   prisonId: String = "BXI",
 ) = CreateInPrisonInterestsDto(
+  inPrisonWorkInterests = inPrisonWorkInterests,
+  inPrisonTrainingInterests = inPrisonTrainingInterests,
+  prisonId = prisonId,
+)
+
+fun aValidUpdateInPrisonInterestsDto(
+  reference: UUID = UUID.randomUUID(),
+  inPrisonWorkInterests: List<InPrisonWorkInterest> = listOf(aValidInPrisonWorkInterest()),
+  inPrisonTrainingInterests: List<InPrisonTrainingInterest> = listOf(aValidInPrisonTrainingInterest()),
+  prisonId: String = "BXI",
+) = UpdateInPrisonInterestsDto(
+  reference = reference,
   inPrisonWorkInterests = inPrisonWorkInterests,
   inPrisonTrainingInterests = inPrisonTrainingInterests,
   prisonId = prisonId,

--- a/domain/induction/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/PersonalSkillsAndInterestsDtoBuilder.kt
+++ b/domain/induction/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/PersonalSkillsAndInterestsDtoBuilder.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Per
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkill
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPersonalInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPersonalSkill
+import java.util.UUID
 
 fun aValidCreatePersonalSkillsAndInterestsDto(
   skills: List<PersonalSkill> = listOf(aValidPersonalSkill()),
@@ -11,6 +12,19 @@ fun aValidCreatePersonalSkillsAndInterestsDto(
   prisonId: String = "BXI",
 ) =
   CreatePersonalSkillsAndInterestsDto(
+    skills = skills,
+    interests = interests,
+    prisonId = prisonId,
+  )
+
+fun aValidUpdatePersonalSkillsAndInterestsDto(
+  reference: UUID = UUID.randomUUID(),
+  skills: List<PersonalSkill> = listOf(aValidPersonalSkill()),
+  interests: List<PersonalInterest> = listOf(aValidPersonalInterest()),
+  prisonId: String = "BXI",
+) =
+  UpdatePersonalSkillsAndInterestsDto(
+    reference = reference,
     skills = skills,
     interests = interests,
     prisonId = prisonId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
@@ -44,11 +44,11 @@ class InPrisonInterestsEntity(
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "interests_id", nullable = false)
-  var inPrisonWorkInterests: List<InPrisonWorkInterestEntity>? = null,
+  var inPrisonWorkInterests: MutableList<InPrisonWorkInterestEntity>? = null,
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "interests_id", nullable = false)
-  var inPrisonTrainingInterests: List<InPrisonTrainingInterestEntity>? = null,
+  var inPrisonTrainingInterests: MutableList<InPrisonTrainingInterestEntity>? = null,
 
   @Column(updatable = false)
   @CreationTimestamp

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
@@ -46,11 +46,11 @@ class PersonalSkillsAndInterestsEntity(
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "skills_interests_id", nullable = false)
-  var skills: List<PersonalSkillEntity>? = null,
+  var skills: MutableList<PersonalSkillEntity>? = null,
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "skills_interests_id", nullable = false)
-  var interests: List<PersonalInterestEntity>? = null,
+  var interests: MutableList<PersonalInterestEntity>? = null,
 
   @Column(updatable = false)
   @CreationTimestamp

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapper.kt
@@ -2,16 +2,20 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import org.mapstruct.MappingTarget
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonInterestsEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonTrainingInterestEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonWorkInterestEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeJpaManagedFields
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeJpaManagedFieldsIncludingDisplayNameFields
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeReferenceField
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.GenerateNewReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonTrainingInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonWorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateInPrisonInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateInPrisonInterestsDto
 
 @Mapper(
   uses = [
@@ -19,18 +23,135 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
     InPrisonTrainingInterestEntityMapper::class,
   ],
 )
-interface InPrisonInterestsEntityMapper {
+abstract class InPrisonInterestsEntityMapper {
+
+  @Autowired
+  private lateinit var inPrisonWorkInterestEntityMapper: InPrisonWorkInterestEntityMapper
+
+  @Autowired
+  private lateinit var inPrisonTrainingInterestEntityMapper: InPrisonTrainingInterestEntityMapper
+
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromCreateDtoToEntity(dto: CreateInPrisonInterestsDto): InPrisonInterestsEntity
+  abstract fun fromCreateDtoToEntity(dto: CreateInPrisonInterestsDto): InPrisonInterestsEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")
   @Mapping(target = "lastUpdatedAt", source = "updatedAt")
   @Mapping(target = "lastUpdatedAtPrison", source = "updatedAtPrison")
-  fun fromEntityToDomain(persistedEntity: InPrisonInterestsEntity): InPrisonInterests
+  abstract fun fromEntityToDomain(persistedEntity: InPrisonInterestsEntity): InPrisonInterests
+
+  @ExcludeJpaManagedFieldsIncludingDisplayNameFields
+  @ExcludeReferenceField
+  @Mapping(target = "createdAtPrison", ignore = true)
+  @Mapping(target = "updatedAtPrison", source = "prisonId")
+  @Mapping(target = "inPrisonWorkInterests", expression = "java( updateWorkInterests(entity, dto) )")
+  @Mapping(target = "inPrisonTrainingInterests", expression = "java( updateTrainingInterests(entity, dto) )")
+  abstract fun updateEntityFromDto(@MappingTarget entity: InPrisonInterestsEntity, dto: UpdateInPrisonInterestsDto)
+
+  fun updateWorkInterests(
+    entity: InPrisonInterestsEntity,
+    dto: UpdateInPrisonInterestsDto,
+  ): List<InPrisonWorkInterestEntity> {
+    val existingInterests = entity.inPrisonWorkInterests!!
+    val updatedInterests = dto.inPrisonWorkInterests
+
+    updateExistingWorkInterests(existingInterests, updatedInterests)
+    addNewWorkInterests(existingInterests, updatedInterests)
+    removeWorkInterests(existingInterests, updatedInterests)
+
+    return existingInterests
+  }
+
+  fun updateTrainingInterests(
+    entity: InPrisonInterestsEntity,
+    dto: UpdateInPrisonInterestsDto,
+  ): List<InPrisonTrainingInterestEntity> {
+    val existingInterests = entity.inPrisonTrainingInterests!!
+    val updatedInterests = dto.inPrisonTrainingInterests
+
+    updateExistingTrainingInterests(existingInterests, updatedInterests)
+    addNewTrainingInterests(existingInterests, updatedInterests)
+    removeTrainingInterests(existingInterests, updatedInterests)
+
+    return existingInterests
+  }
+
+  private fun updateExistingWorkInterests(
+    existingInterests: MutableList<InPrisonWorkInterestEntity>,
+    updatedInterests: List<InPrisonWorkInterest>,
+  ) {
+    val updatedWorkTypes = updatedInterests.map { it.workType.name }
+    existingInterests
+      .filter { interestEntity -> updatedWorkTypes.contains(interestEntity.workType!!.name) }
+      .onEach { interestEntity ->
+        inPrisonWorkInterestEntityMapper.updateEntityFromDomain(
+          interestEntity,
+          updatedInterests.first { updatedInterestDomain -> updatedInterestDomain.workType.name == interestEntity.workType!!.name },
+        )
+      }
+  }
+
+  private fun addNewWorkInterests(
+    existingInterests: MutableList<InPrisonWorkInterestEntity>,
+    updatedInterests: List<InPrisonWorkInterest>,
+  ) {
+    val currentWorkInterestTypes = existingInterests.map { it.workType!!.name }
+    existingInterests.addAll(
+      updatedInterests
+        .filter { updatedInterestDto -> !currentWorkInterestTypes.contains(updatedInterestDto.workType.name) }
+        .map { newInterestDto -> inPrisonWorkInterestEntityMapper.fromDomainToEntity(newInterestDto) },
+    )
+  }
+
+  private fun removeWorkInterests(
+    existingInterests: MutableList<InPrisonWorkInterestEntity>,
+    updatedInterests: List<InPrisonWorkInterest>,
+  ) {
+    val updatedInterestTypes = updatedInterests.map { it.workType.name }
+    existingInterests.removeIf { interestEntity ->
+      !updatedInterestTypes.contains(interestEntity.workType!!.name)
+    }
+  }
+
+  private fun updateExistingTrainingInterests(
+    existingInterests: MutableList<InPrisonTrainingInterestEntity>,
+    updatedInterests: List<InPrisonTrainingInterest>,
+  ) {
+    val updatedTrainingTypes = updatedInterests.map { it.trainingType.name }
+    existingInterests
+      .filter { interestEntity -> updatedTrainingTypes.contains(interestEntity.trainingType!!.name) }
+      .onEach { interestEntity ->
+        inPrisonTrainingInterestEntityMapper.updateEntityFromDomain(
+          interestEntity,
+          updatedInterests.first { updatedInterestDomain -> updatedInterestDomain.trainingType.name == interestEntity.trainingType!!.name },
+        )
+      }
+  }
+
+  private fun addNewTrainingInterests(
+    existingInterests: MutableList<InPrisonTrainingInterestEntity>,
+    updatedInterests: List<InPrisonTrainingInterest>,
+  ) {
+    val currentTrainingInterestTypes = existingInterests.map { it.trainingType!!.name }
+    existingInterests.addAll(
+      updatedInterests
+        .filter { updatedInterestDto -> !currentTrainingInterestTypes.contains(updatedInterestDto.trainingType.name) }
+        .map { newInterestDto -> inPrisonTrainingInterestEntityMapper.fromDomainToEntity(newInterestDto) },
+    )
+  }
+
+  private fun removeTrainingInterests(
+    existingInterests: MutableList<InPrisonTrainingInterestEntity>,
+    updatedInterests: List<InPrisonTrainingInterest>,
+  ) {
+    val updatedInterestTypes = updatedInterests.map { it.trainingType.name }
+    existingInterests.removeIf { interestEntity ->
+      !updatedInterestTypes.contains(interestEntity.trainingType!!.name)
+    }
+  }
 }
 
 @Mapper
@@ -40,6 +161,10 @@ interface InPrisonWorkInterestEntityMapper {
   fun fromDomainToEntity(domain: InPrisonWorkInterest): InPrisonWorkInterestEntity
 
   fun fromEntityToDomain(persistedEntity: InPrisonWorkInterestEntity): InPrisonWorkInterest
+
+  @ExcludeJpaManagedFields
+  @ExcludeReferenceField
+  fun updateEntityFromDomain(@MappingTarget entity: InPrisonWorkInterestEntity, domain: InPrisonWorkInterest)
 }
 
 @Mapper
@@ -49,4 +174,8 @@ interface InPrisonTrainingInterestEntityMapper {
   fun fromDomainToEntity(domain: InPrisonTrainingInterest): InPrisonTrainingInterestEntity
 
   fun fromEntityToDomain(persistedEntity: InPrisonTrainingInterestEntity): InPrisonTrainingInterest
+
+  @ExcludeJpaManagedFields
+  @ExcludeReferenceField
+  fun updateEntityFromDomain(@MappingTarget entity: InPrisonTrainingInterestEntity, domain: InPrisonTrainingInterest)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PersonalSkillsAndInterestsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PersonalSkillsAndInterestsEntityMapper.kt
@@ -2,16 +2,20 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import org.mapstruct.MappingTarget
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PersonalInterestEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PersonalSkillEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PersonalSkillsAndInterestsEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeJpaManagedFields
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeJpaManagedFieldsIncludingDisplayNameFields
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeReferenceField
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.GenerateNewReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkill
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkillsAndInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePersonalSkillsAndInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdatePersonalSkillsAndInterestsDto
 
 @Mapper(
   uses = [
@@ -19,18 +23,138 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
     PersonalInterestEntityMapper::class,
   ],
 )
-interface PersonalSkillsAndInterestsEntityMapper {
+abstract class PersonalSkillsAndInterestsEntityMapper {
+
+  @Autowired
+  private lateinit var personalSkillEntityMapper: PersonalSkillEntityMapper
+
+  @Autowired
+  private lateinit var personalInterestEntityMapper: PersonalInterestEntityMapper
+
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun fromCreateDtoToEntity(dto: CreatePersonalSkillsAndInterestsDto): PersonalSkillsAndInterestsEntity
+  abstract fun fromCreateDtoToEntity(dto: CreatePersonalSkillsAndInterestsDto): PersonalSkillsAndInterestsEntity
 
   @Mapping(target = "lastUpdatedBy", source = "updatedBy")
   @Mapping(target = "lastUpdatedByDisplayName", source = "updatedByDisplayName")
   @Mapping(target = "lastUpdatedAt", source = "updatedAt")
   @Mapping(target = "lastUpdatedAtPrison", source = "updatedAtPrison")
-  fun fromEntityToDomain(persistedEntity: PersonalSkillsAndInterestsEntity): PersonalSkillsAndInterests
+  abstract fun fromEntityToDomain(persistedEntity: PersonalSkillsAndInterestsEntity): PersonalSkillsAndInterests
+
+  @ExcludeJpaManagedFieldsIncludingDisplayNameFields
+  @ExcludeReferenceField
+  @Mapping(target = "createdAtPrison", ignore = true)
+  @Mapping(target = "updatedAtPrison", source = "prisonId")
+  @Mapping(target = "skills", expression = "java( updateSkills(entity, dto) )")
+  @Mapping(target = "interests", expression = "java( updateInterests(entity, dto) )")
+  abstract fun updateEntityFromDto(
+    @MappingTarget entity: PersonalSkillsAndInterestsEntity,
+    dto: UpdatePersonalSkillsAndInterestsDto,
+  )
+
+  fun updateSkills(
+    entity: PersonalSkillsAndInterestsEntity,
+    dto: UpdatePersonalSkillsAndInterestsDto,
+  ): List<PersonalSkillEntity> {
+    val existingSkills = entity.skills!!
+    val updatedSkills = dto.skills
+
+    updateExistingSkills(existingSkills, updatedSkills)
+    addNewSkills(existingSkills, updatedSkills)
+    removeSkills(existingSkills, updatedSkills)
+
+    return existingSkills
+  }
+
+  fun updateInterests(
+    entity: PersonalSkillsAndInterestsEntity,
+    dto: UpdatePersonalSkillsAndInterestsDto,
+  ): List<PersonalInterestEntity> {
+    val existingInterests = entity.interests!!
+    val updatedInterests = dto.interests
+
+    updateExistingInterests(existingInterests, updatedInterests)
+    addNewInterests(existingInterests, updatedInterests)
+    removeInterests(existingInterests, updatedInterests)
+
+    return existingInterests
+  }
+
+  private fun updateExistingSkills(
+    existingSkills: MutableList<PersonalSkillEntity>,
+    updatedSkills: List<PersonalSkill>,
+  ) {
+    val updatedSkillTypes = updatedSkills.map { it.skillType.name }
+    existingSkills
+      .filter { skillEntity -> updatedSkillTypes.contains(skillEntity.skillType!!.name) }
+      .onEach { skillEntity ->
+        personalSkillEntityMapper.updateEntityFromDomain(
+          skillEntity,
+          updatedSkills.first { updatedInterestDomain -> updatedInterestDomain.skillType.name == skillEntity.skillType!!.name },
+        )
+      }
+  }
+
+  private fun addNewSkills(
+    existingSkills: MutableList<PersonalSkillEntity>,
+    updatedSkills: List<PersonalSkill>,
+  ) {
+    val currentInterestTypes = existingSkills.map { it.skillType!!.name }
+    existingSkills.addAll(
+      updatedSkills
+        .filter { updatedInterestDto -> !currentInterestTypes.contains(updatedInterestDto.skillType.name) }
+        .map { newInterestDto -> personalSkillEntityMapper.fromDomainToEntity(newInterestDto) },
+    )
+  }
+
+  private fun removeSkills(
+    existingSkills: MutableList<PersonalSkillEntity>,
+    updatedSkills: List<PersonalSkill>,
+  ) {
+    val updatedInterestTypes = updatedSkills.map { it.skillType.name }
+    existingSkills.removeIf { skillEntity ->
+      !updatedInterestTypes.contains(skillEntity.skillType!!.name)
+    }
+  }
+
+  private fun updateExistingInterests(
+    existingInterests: MutableList<PersonalInterestEntity>,
+    updatedInterests: List<PersonalInterest>,
+  ) {
+    val updatedInterestTypes = updatedInterests.map { it.interestType.name }
+    existingInterests
+      .filter { interestEntity -> updatedInterestTypes.contains(interestEntity.interestType!!.name) }
+      .onEach { interestEntity ->
+        personalInterestEntityMapper.updateEntityFromDomain(
+          interestEntity,
+          updatedInterests.first { updatedInterestDomain -> updatedInterestDomain.interestType.name == interestEntity.interestType!!.name },
+        )
+      }
+  }
+
+  private fun addNewInterests(
+    existingInterests: MutableList<PersonalInterestEntity>,
+    updatedInterests: List<PersonalInterest>,
+  ) {
+    val currentInterestTypes = existingInterests.map { it.interestType!!.name }
+    existingInterests.addAll(
+      updatedInterests
+        .filter { updatedInterestDto -> !currentInterestTypes.contains(updatedInterestDto.interestType.name) }
+        .map { newInterestDto -> personalInterestEntityMapper.fromDomainToEntity(newInterestDto) },
+    )
+  }
+
+  private fun removeInterests(
+    existingInterests: MutableList<PersonalInterestEntity>,
+    updatedInterests: List<PersonalInterest>,
+  ) {
+    val updatedInterestTypes = updatedInterests.map { it.interestType.name }
+    existingInterests.removeIf { interestEntity ->
+      !updatedInterestTypes.contains(interestEntity.interestType!!.name)
+    }
+  }
 }
 
 @Mapper
@@ -40,6 +164,10 @@ interface PersonalSkillEntityMapper {
   fun fromDomainToEntity(domain: PersonalSkill): PersonalSkillEntity
 
   fun fromEntityToDomain(persistedEntity: PersonalSkillEntity): PersonalSkill
+
+  @ExcludeJpaManagedFields
+  @ExcludeReferenceField
+  fun updateEntityFromDomain(@MappingTarget entity: PersonalSkillEntity, domain: PersonalSkill)
 }
 
 @Mapper
@@ -49,4 +177,8 @@ interface PersonalInterestEntityMapper {
   fun fromDomainToEntity(domain: PersonalInterest): PersonalInterestEntity
 
   fun fromEntityToDomain(persistedEntity: PersonalInterestEntity): PersonalInterest
+
+  @ExcludeJpaManagedFields
+  @ExcludeReferenceField
+  fun updateEntityFromDomain(@MappingTarget entity: PersonalInterestEntity, domain: PersonalInterest)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapperTest.kt
@@ -38,8 +38,8 @@ class InPrisonInterestsEntityMapperTest {
     val expectedInPrisonWorkInterestEntity = aValidInPrisonWorkInterestEntity()
     val expectedInPrisonTrainingInterestEntity = aValidInPrisonTrainingInterestEntity()
     val expected = aValidInPrisonInterestsEntity(
-      inPrisonWorkInterests = listOf(expectedInPrisonWorkInterestEntity),
-      inPrisonTrainingInterests = listOf(expectedInPrisonTrainingInterestEntity),
+      inPrisonWorkInterests = mutableListOf(expectedInPrisonWorkInterestEntity),
+      inPrisonTrainingInterests = mutableListOf(expectedInPrisonTrainingInterestEntity),
       createdAtPrison = "BXI",
       updatedAtPrison = "BXI",
     )
@@ -70,8 +70,8 @@ class InPrisonInterestsEntityMapperTest {
     val expectedTrainingInterest = aValidInPrisonTrainingInterest()
     val expectedInPrisonInterests = aValidInPrisonInterests(
       reference = inPrisonInterestsEntity.reference!!,
-      inPrisonWorkInterests = listOf(expectedWorkInterest),
-      inPrisonTrainingInterests = listOf(expectedTrainingInterest),
+      inPrisonWorkInterests = mutableListOf(expectedWorkInterest),
+      inPrisonTrainingInterests = mutableListOf(expectedTrainingInterest),
       createdAt = inPrisonInterestsEntity.createdAt!!,
       createdAtPrison = inPrisonInterestsEntity.createdAtPrison!!,
       createdBy = inPrisonInterestsEntity.createdBy!!,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PersonalSkillsAndInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PersonalSkillsAndInterestsEntityMapperTest.kt
@@ -38,8 +38,8 @@ class PersonalSkillsAndInterestsEntityMapperTest {
     val expectedPersonalSkill = aValidPersonalSkillEntity()
     val expectedPersonalInterest = aValidPersonalInterestEntity()
     val expected = aValidPersonalSkillsAndInterestsEntity(
-      skills = listOf(expectedPersonalSkill),
-      interests = listOf(expectedPersonalInterest),
+      skills = mutableListOf(expectedPersonalSkill),
+      interests = mutableListOf(expectedPersonalInterest),
       createdAtPrison = "BXI",
       updatedAtPrison = "BXI",
     )
@@ -68,8 +68,8 @@ class PersonalSkillsAndInterestsEntityMapperTest {
     val expectedInterest = aValidPersonalInterest()
     val expectedSkillsAndInterests = aValidPersonalSkillsAndInterests(
       reference = personalSkillsAndInterestsEntity.reference!!,
-      skills = listOf(expectedSkill),
-      interests = listOf(expectedInterest),
+      skills = mutableListOf(expectedSkill),
+      interests = mutableListOf(expectedInterest),
       createdAt = personalSkillsAndInterestsEntity.createdAt!!,
       createdAtPrison = personalSkillsAndInterestsEntity.createdAtPrison!!,
       createdBy = personalSkillsAndInterestsEntity.createdBy!!,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateFutureWorkInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateFutureWorkInterestsEntityMapperTest.kt
@@ -22,6 +22,7 @@ class UpdateFutureWorkInterestsEntityMapperTest {
 
   @Test
   fun `should update existing work interests`() {
+    // Given
     val workInterestReference = UUID.randomUUID()
     val existingEntity = aValidWorkInterestEntity(
       reference = workInterestReference,
@@ -69,6 +70,7 @@ class UpdateFutureWorkInterestsEntityMapperTest {
 
   @Test
   fun `should add new work interest`() {
+    // Given
     val workInterestReference = UUID.randomUUID()
     val existingEntity = aValidWorkInterestEntity(
       reference = workInterestReference,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateInPrisonInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateInPrisonInterestsEntityMapperTest.kt
@@ -1,0 +1,234 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInPrisonInterestsEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInPrisonTrainingInterestEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInPrisonWorkInterestEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.deepCopy
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInPrisonTrainingInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInPrisonWorkInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateInPrisonInterestsDto
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonTrainingType as InPrisonTrainingTypeEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonWorkType as InPrisonWorkTypeEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonTrainingType as InPrisonTrainingTypeDomain
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonWorkType as InPrisonWorkTypeDomain
+
+class UpdateInPrisonInterestsEntityMapperTest {
+
+  private val mapper = InPrisonInterestsEntityMapperImpl().also {
+    InPrisonInterestsEntityMapper::class.java.getDeclaredField("inPrisonWorkInterestEntityMapper").apply {
+      isAccessible = true
+      set(it, InPrisonWorkInterestEntityMapperImpl())
+    }
+
+    InPrisonInterestsEntityMapper::class.java.getDeclaredField("inPrisonTrainingInterestEntityMapper").apply {
+      isAccessible = true
+      set(it, InPrisonTrainingInterestEntityMapperImpl())
+    }
+  }
+
+  @Test
+  fun `should update existing interests`() {
+    // Given
+    val workInterestReference = UUID.randomUUID()
+    val existingWorkInterestEntity = aValidInPrisonWorkInterestEntity(
+      reference = workInterestReference,
+      workType = InPrisonWorkTypeEntity.OTHER,
+      workTypeOther = "Any job I can get",
+    )
+    val trainingInterestReference = UUID.randomUUID()
+    val existingTrainingInterestEntity = aValidInPrisonTrainingInterestEntity(
+      reference = trainingInterestReference,
+      trainingType = InPrisonTrainingTypeEntity.OTHER,
+      trainingTypeOther = "Any training I can get",
+    )
+    val inPrisonInterestsReference = UUID.randomUUID()
+    val existingInPrisonInterestsEntity = aValidInPrisonInterestsEntity(
+      reference = inPrisonInterestsReference,
+      inPrisonWorkInterests = mutableListOf(existingWorkInterestEntity),
+      inPrisonTrainingInterests = mutableListOf(existingTrainingInterestEntity),
+    )
+
+    val updatedWorkInterest = aValidInPrisonWorkInterest(
+      workType = InPrisonWorkTypeDomain.OTHER,
+      workTypeOther = "The most popular work",
+    )
+    val updatedTrainingInterest = aValidInPrisonTrainingInterest(
+      trainingType = InPrisonTrainingTypeDomain.OTHER,
+      trainingTypeOther = "The most popular training",
+    )
+    val updatedInterestsDto = aValidUpdateInPrisonInterestsDto(
+      reference = inPrisonInterestsReference,
+      inPrisonWorkInterests = listOf(updatedWorkInterest),
+      inPrisonTrainingInterests = listOf(updatedTrainingInterest),
+      prisonId = "MDI",
+    )
+
+    val expectedEntity = existingInPrisonInterestsEntity.deepCopy().apply {
+      id
+      reference = reference
+      inPrisonWorkInterests = mutableListOf(
+        existingWorkInterestEntity.deepCopy().apply {
+          workType = InPrisonWorkTypeEntity.OTHER
+          workTypeOther = "The most popular work"
+        },
+      )
+      inPrisonTrainingInterests = mutableListOf(
+        existingTrainingInterestEntity.deepCopy().apply {
+          trainingType = InPrisonTrainingTypeEntity.OTHER
+          trainingTypeOther = "The most popular training"
+        },
+      )
+      createdAtPrison = "BXI"
+      updatedAtPrison = "MDI"
+    }
+
+    // When
+    mapper.updateEntityFromDto(existingInPrisonInterestsEntity, updatedInterestsDto)
+
+    // Then
+    assertThat(existingInPrisonInterestsEntity).isEqualToComparingAllFields(expectedEntity)
+  }
+
+  @Test
+  fun `should add new interests`() {
+    // Given
+    val workInterestReference = UUID.randomUUID()
+    val existingWorkInterestEntity = aValidInPrisonWorkInterestEntity(
+      reference = workInterestReference,
+      workType = InPrisonWorkTypeEntity.OTHER,
+      workTypeOther = "Any job I can get",
+    )
+    val trainingInterestReference = UUID.randomUUID()
+    val existingTrainingInterestEntity = aValidInPrisonTrainingInterestEntity(
+      reference = trainingInterestReference,
+      trainingType = InPrisonTrainingTypeEntity.OTHER,
+      trainingTypeOther = "Any training I can get",
+    )
+    val inPrisonInterestsReference = UUID.randomUUID()
+    val existingInPrisonInterestsEntity = aValidInPrisonInterestsEntity(
+      reference = inPrisonInterestsReference,
+      inPrisonWorkInterests = mutableListOf(existingWorkInterestEntity),
+      inPrisonTrainingInterests = mutableListOf(existingTrainingInterestEntity),
+    )
+
+    val existingWorkInterest = aValidInPrisonWorkInterest(
+      workType = InPrisonWorkTypeDomain.OTHER,
+      workTypeOther = "Any job I can get",
+    )
+    val existingTrainingInterest = aValidInPrisonTrainingInterest(
+      trainingType = InPrisonTrainingTypeDomain.OTHER,
+      trainingTypeOther = "Any training I can get",
+    )
+    val newWorkInterest = aValidInPrisonWorkInterest(
+      workType = InPrisonWorkTypeDomain.COMPUTERS_OR_DESK_BASED,
+      workTypeOther = null,
+    )
+    val newTrainingInterest = aValidInPrisonTrainingInterest(
+      trainingType = InPrisonTrainingTypeDomain.NUMERACY_SKILLS,
+      trainingTypeOther = null,
+    )
+    val updatedInterestsDto = aValidUpdateInPrisonInterestsDto(
+      reference = inPrisonInterestsReference,
+      inPrisonWorkInterests = listOf(existingWorkInterest, newWorkInterest),
+      inPrisonTrainingInterests = listOf(existingTrainingInterest, newTrainingInterest),
+      prisonId = "MDI",
+    )
+
+    val expectedEntity = existingInPrisonInterestsEntity.deepCopy().apply {
+      id
+      reference = reference
+      inPrisonWorkInterests = mutableListOf(
+        aValidInPrisonWorkInterestEntity(
+          workType = InPrisonWorkTypeEntity.OTHER,
+          workTypeOther = "Any job I can get",
+        ),
+        aValidInPrisonWorkInterestEntity(
+          workType = InPrisonWorkTypeEntity.COMPUTERS_OR_DESK_BASED,
+          workTypeOther = null,
+        ),
+      )
+      inPrisonTrainingInterests = mutableListOf(
+        aValidInPrisonTrainingInterestEntity(
+          trainingType = InPrisonTrainingTypeEntity.OTHER,
+          trainingTypeOther = "Any training I can get",
+        ),
+        aValidInPrisonTrainingInterestEntity(
+          trainingType = InPrisonTrainingTypeEntity.NUMERACY_SKILLS,
+          trainingTypeOther = null,
+        ),
+      )
+      createdAtPrison = "BXI"
+      updatedAtPrison = "MDI"
+    }
+
+    // When
+    mapper.updateEntityFromDto(existingInPrisonInterestsEntity, updatedInterestsDto)
+
+    // Then
+    assertThat(existingInPrisonInterestsEntity).isEqualToIgnoringInternallyManagedFields(expectedEntity)
+  }
+
+  @Test
+  fun `should remove interests`() {
+    // Given
+    val workInterestReference = UUID.randomUUID()
+    val firstWorkInterestEntity = aValidInPrisonWorkInterestEntity(
+      reference = workInterestReference,
+      workType = InPrisonWorkTypeEntity.OTHER,
+      workTypeOther = "Any job I can get",
+    )
+    val secondWorkInterestEntity = aValidInPrisonWorkInterestEntity(
+      workType = InPrisonWorkTypeEntity.CLEANING_AND_HYGIENE,
+      workTypeOther = null,
+    )
+    val trainingInterestReference = UUID.randomUUID()
+    val firstTrainingInterestEntity = aValidInPrisonTrainingInterestEntity(
+      reference = trainingInterestReference,
+      trainingType = InPrisonTrainingTypeEntity.OTHER,
+      trainingTypeOther = "Any training I can get",
+    )
+    val secondTrainingInterestEntity = aValidInPrisonTrainingInterestEntity(
+      trainingType = InPrisonTrainingTypeEntity.CATERING,
+      trainingTypeOther = null,
+    )
+    val inPrisonInterestsReference = UUID.randomUUID()
+    val existingInPrisonInterestsEntity = aValidInPrisonInterestsEntity(
+      reference = inPrisonInterestsReference,
+      inPrisonWorkInterests = mutableListOf(firstWorkInterestEntity, secondWorkInterestEntity),
+      inPrisonTrainingInterests = mutableListOf(firstTrainingInterestEntity, secondTrainingInterestEntity),
+    )
+
+    val existingWorkInterest = aValidInPrisonWorkInterest(
+      workType = InPrisonWorkTypeDomain.OTHER,
+      workTypeOther = "Any job I can get",
+    )
+    val existingTrainingInterest = aValidInPrisonTrainingInterest(
+      trainingType = InPrisonTrainingTypeDomain.OTHER,
+      trainingTypeOther = "Any training I can get",
+    )
+    val updatedInterestsDto = aValidUpdateInPrisonInterestsDto(
+      reference = inPrisonInterestsReference,
+      inPrisonWorkInterests = listOf(existingWorkInterest),
+      inPrisonTrainingInterests = listOf(existingTrainingInterest),
+      prisonId = "MDI",
+    )
+
+    val expectedEntity = existingInPrisonInterestsEntity.deepCopy().apply {
+      id
+      reference = reference
+      inPrisonWorkInterests = mutableListOf(firstWorkInterestEntity)
+      inPrisonTrainingInterests = mutableListOf(firstTrainingInterestEntity)
+      createdAtPrison = "BXI"
+      updatedAtPrison = "MDI"
+    }
+
+    // When
+    mapper.updateEntityFromDto(existingInPrisonInterestsEntity, updatedInterestsDto)
+
+    // Then
+    assertThat(existingInPrisonInterestsEntity).isEqualToComparingAllFields(expectedEntity)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePersonalSkillsAndInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePersonalSkillsAndInterestsEntityMapperTest.kt
@@ -1,0 +1,234 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPersonalInterestEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPersonalSkillEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPersonalSkillsAndInterestsEntityWithJpaFieldsPopulated
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.deepCopy
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPersonalInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPersonalSkill
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePersonalSkillsAndInterestsDto
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InterestType as InterestTypeEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.SkillType as SkillTypeEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InterestType as InterestTypeDomain
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.SkillType as SkillTypeDomain
+
+class UpdatePersonalSkillsAndInterestsEntityMapperTest {
+
+  private val mapper = PersonalSkillsAndInterestsEntityMapperImpl().also {
+    PersonalSkillsAndInterestsEntityMapper::class.java.getDeclaredField("personalSkillEntityMapper").apply {
+      isAccessible = true
+      set(it, PersonalSkillEntityMapperImpl())
+    }
+
+    PersonalSkillsAndInterestsEntityMapper::class.java.getDeclaredField("personalInterestEntityMapper").apply {
+      isAccessible = true
+      set(it, PersonalInterestEntityMapperImpl())
+    }
+  }
+
+  @Test
+  fun `should update existing skills and interests`() {
+    // Given
+    val skillReference = UUID.randomUUID()
+    val existingSkillEntity = aValidPersonalSkillEntity(
+      reference = skillReference,
+      skillType = SkillTypeEntity.OTHER,
+      skillTypeOther = "Too many skills to mention",
+    )
+    val interestReference = UUID.randomUUID()
+    val existingInterestEntity = aValidPersonalInterestEntity(
+      reference = interestReference,
+      interestType = InterestTypeEntity.OTHER,
+      interestTypeOther = "Lots of varied interests",
+    )
+    val skillsAndInterestsReference = UUID.randomUUID()
+    val existingSkillsAndInterestsEntity = aValidPersonalSkillsAndInterestsEntityWithJpaFieldsPopulated(
+      reference = skillsAndInterestsReference,
+      skills = mutableListOf(existingSkillEntity),
+      interests = mutableListOf(existingInterestEntity),
+    )
+
+    val updatedSkill = aValidPersonalSkill(
+      skillType = SkillTypeDomain.OTHER,
+      skillTypeOther = "Not that many skills actually",
+    )
+    val updatedInterest = aValidPersonalInterest(
+      interestType = InterestTypeDomain.OTHER,
+      interestTypeOther = "Not such varied interests actually",
+    )
+    val updateDto = aValidUpdatePersonalSkillsAndInterestsDto(
+      reference = skillsAndInterestsReference,
+      skills = listOf(updatedSkill),
+      interests = listOf(updatedInterest),
+      prisonId = "MDI",
+    )
+
+    val expectedEntity = existingSkillsAndInterestsEntity.deepCopy().apply {
+      id
+      reference = reference
+      skills = mutableListOf(
+        existingSkillEntity.deepCopy().apply {
+          skillType = SkillTypeEntity.OTHER
+          skillTypeOther = "Not that many skills actually"
+        },
+      )
+      interests = mutableListOf(
+        existingInterestEntity.deepCopy().apply {
+          interestType = InterestTypeEntity.OTHER
+          interestTypeOther = "Not such varied interests actually"
+        },
+      )
+      createdAtPrison = "BXI"
+      updatedAtPrison = "MDI"
+    }
+
+    // When
+    mapper.updateEntityFromDto(existingSkillsAndInterestsEntity, updateDto)
+
+    // Then
+    assertThat(existingSkillsAndInterestsEntity).isEqualToComparingAllFields(expectedEntity)
+  }
+
+  @Test
+  fun `should add new skills and interests`() {
+    // Given
+    val skillReference = UUID.randomUUID()
+    val existingSkillEntity = aValidPersonalSkillEntity(
+      reference = skillReference,
+      skillType = SkillTypeEntity.OTHER,
+      skillTypeOther = "Too many skills to mention",
+    )
+    val interestReference = UUID.randomUUID()
+    val existingInterestEntity = aValidPersonalInterestEntity(
+      reference = interestReference,
+      interestType = InterestTypeEntity.OTHER,
+      interestTypeOther = "Lots of varied interests",
+    )
+    val skillsAndInterestsReference = UUID.randomUUID()
+    val existingSkillsAndInterestsEntity = aValidPersonalSkillsAndInterestsEntityWithJpaFieldsPopulated(
+      reference = skillsAndInterestsReference,
+      skills = mutableListOf(existingSkillEntity),
+      interests = mutableListOf(existingInterestEntity),
+    )
+
+    val existingSkill = aValidPersonalSkill(
+      skillType = SkillTypeDomain.OTHER,
+      skillTypeOther = "Too many skills to mention",
+    )
+    val existingInterest = aValidPersonalInterest(
+      interestType = InterestTypeDomain.OTHER,
+      interestTypeOther = "Lots of varied interests",
+    )
+    val newSkill = aValidPersonalSkill(
+      skillType = SkillTypeDomain.COMMUNICATION,
+      skillTypeOther = null,
+    )
+    val newInterest = aValidPersonalInterest(
+      interestType = InterestTypeDomain.CRAFTS,
+      interestTypeOther = null,
+    )
+    val updateDto = aValidUpdatePersonalSkillsAndInterestsDto(
+      reference = skillsAndInterestsReference,
+      skills = listOf(existingSkill, newSkill),
+      interests = listOf(existingInterest, newInterest),
+      prisonId = "MDI",
+    )
+
+    val expectedEntity = existingSkillsAndInterestsEntity.deepCopy().apply {
+      id
+      reference = reference
+      skills = mutableListOf(
+        aValidPersonalSkillEntity(
+          skillType = SkillTypeEntity.OTHER,
+          skillTypeOther = "Too many skills to mention",
+        ),
+        aValidPersonalSkillEntity(
+          skillType = SkillTypeEntity.COMMUNICATION,
+          skillTypeOther = null,
+        ),
+      )
+      interests = mutableListOf(
+        aValidPersonalInterestEntity(
+          interestType = InterestTypeEntity.OTHER,
+          interestTypeOther = "Lots of varied interests",
+        ),
+        aValidPersonalInterestEntity(
+          interestType = InterestTypeEntity.CRAFTS,
+          interestTypeOther = null,
+        ),
+      )
+      createdAtPrison = "BXI"
+      updatedAtPrison = "MDI"
+    }
+
+    // When
+    mapper.updateEntityFromDto(existingSkillsAndInterestsEntity, updateDto)
+
+    // Then
+    assertThat(existingSkillsAndInterestsEntity).isEqualToIgnoringInternallyManagedFields(expectedEntity)
+  }
+
+  @Test
+  fun `should remove skills and interests`() {
+    // Given
+    val skillReference = UUID.randomUUID()
+    val firstSkillEntity = aValidPersonalSkillEntity(
+      reference = skillReference,
+      skillType = SkillTypeEntity.RESILIENCE,
+      skillTypeOther = null,
+    )
+    val secondSkillEntity = aValidPersonalSkillEntity(
+      skillType = SkillTypeEntity.COMMUNICATION,
+      skillTypeOther = null,
+    )
+    val interestReference = UUID.randomUUID()
+    val firstInterestEntity = aValidPersonalInterestEntity(
+      reference = interestReference,
+      interestType = InterestTypeEntity.CRAFTS,
+      interestTypeOther = null,
+    )
+    val secondInterestEntity = aValidPersonalInterestEntity(
+      interestType = InterestTypeEntity.NATURE_AND_ANIMALS,
+      interestTypeOther = null,
+    )
+    val skillsAndInterestsReference = UUID.randomUUID()
+    val existingSkillsAndInterestsEntity = aValidPersonalSkillsAndInterestsEntityWithJpaFieldsPopulated(
+      reference = skillsAndInterestsReference,
+      skills = mutableListOf(firstSkillEntity, secondSkillEntity),
+      interests = mutableListOf(firstInterestEntity, secondInterestEntity),
+    )
+
+    val existingSkill = aValidPersonalSkill(
+      skillType = SkillTypeDomain.RESILIENCE,
+      skillTypeOther = null,
+    )
+    val existingInterest = aValidPersonalInterest(
+      interestType = InterestTypeDomain.CRAFTS,
+      interestTypeOther = null,
+    )
+    val updateDto = aValidUpdatePersonalSkillsAndInterestsDto(
+      reference = skillsAndInterestsReference,
+      skills = listOf(existingSkill),
+      interests = listOf(existingInterest),
+      prisonId = "MDI",
+    )
+
+    val expectedEntity = existingSkillsAndInterestsEntity.deepCopy().apply {
+      id
+      reference = reference
+      skills = mutableListOf(firstSkillEntity)
+      interests = mutableListOf(firstInterestEntity)
+      createdAtPrison = "BXI"
+      updatedAtPrison = "MDI"
+    }
+
+    // When
+    mapper.updateEntityFromDto(existingSkillsAndInterestsEntity, updateDto)
+
+    // Then
+    assertThat(existingSkillsAndInterestsEntity).isEqualToComparingAllFields(expectedEntity)
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntityAssert.kt
@@ -15,6 +15,12 @@ class InPrisonInterestsEntityAssert(actual: InPrisonInterestsEntity?) :
     InPrisonInterestsEntityAssert::class.java,
   ) {
 
+  companion object {
+    // JPA managed fields, plus the reference field, which are all managed/generated within the API
+    private val INTERNALLY_MANAGED_FIELDS =
+      arrayOf(".*id", ".*reference", ".*createdAt", ".*createdBy", ".*createdByDisplayName", ".*updatedAt", ".*updatedBy", ".*updatedByDisplayName")
+  }
+
   fun hasJpaManagedFieldsPopulated(): InPrisonInterestsEntityAssert {
     isNotNull
     with(actual!!) {
@@ -92,6 +98,21 @@ class InPrisonInterestsEntityAssert(actual: InPrisonInterestsEntity?) :
         failWithMessage("Expected reference to be populated, but was $reference")
       }
     }
+    return this
+  }
+
+  fun isEqualToComparingAllFields(expected: InPrisonInterestsEntity): InPrisonInterestsEntityAssert {
+    assertThat(actual)
+      .usingRecursiveComparison()
+      .isEqualTo(expected)
+    return this
+  }
+
+  fun isEqualToIgnoringInternallyManagedFields(expected: InPrisonInterestsEntity): InPrisonInterestsEntityAssert {
+    assertThat(actual)
+      .usingRecursiveComparison()
+      .ignoringFieldsMatchingRegexes(*INTERNALLY_MANAGED_FIELDS)
+      .isEqualTo(expected)
     return this
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntityBuilder.kt
@@ -6,8 +6,8 @@ import java.util.UUID
 fun aValidInPrisonInterestsEntity(
   id: UUID? = null,
   reference: UUID = UUID.randomUUID(),
-  inPrisonWorkInterests: List<InPrisonWorkInterestEntity> = listOf(aValidInPrisonWorkInterestEntity()),
-  inPrisonTrainingInterests: List<InPrisonTrainingInterestEntity> = listOf(aValidInPrisonTrainingInterestEntity()),
+  inPrisonWorkInterests: MutableList<InPrisonWorkInterestEntity> = mutableListOf(aValidInPrisonWorkInterestEntity()),
+  inPrisonTrainingInterests: MutableList<InPrisonTrainingInterestEntity> = mutableListOf(aValidInPrisonTrainingInterestEntity()),
   createdAt: Instant? = null,
   createdAtPrison: String = "BXI",
   createdBy: String? = null,
@@ -35,8 +35,8 @@ fun aValidInPrisonInterestsEntity(
 fun aValidInPrisonInterestsEntityWithJpaFieldsPopulated(
   id: UUID? = UUID.randomUUID(),
   reference: UUID = UUID.randomUUID(),
-  inPrisonWorkInterests: List<InPrisonWorkInterestEntity> = listOf(aValidInPrisonWorkInterestEntity()),
-  inPrisonTrainingInterests: List<InPrisonTrainingInterestEntity> = listOf(aValidInPrisonTrainingInterestEntity()),
+  inPrisonWorkInterests: MutableList<InPrisonWorkInterestEntity> = mutableListOf(aValidInPrisonWorkInterestEntity()),
+  inPrisonTrainingInterests: MutableList<InPrisonTrainingInterestEntity> = mutableListOf(aValidInPrisonTrainingInterestEntity()),
   createdAt: Instant? = Instant.now(),
   createdAtPrison: String = "BXI",
   createdBy: String? = "asmith_gen",

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntityAssert.kt
@@ -15,6 +15,12 @@ class PersonalSkillsAndInterestsEntityAssert(actual: PersonalSkillsAndInterestsE
     PersonalSkillsAndInterestsEntityAssert::class.java,
   ) {
 
+  companion object {
+    // JPA managed fields, plus the reference field, which are all managed/generated within the API
+    private val INTERNALLY_MANAGED_FIELDS =
+      arrayOf(".*id", ".*reference", ".*createdAt", ".*createdBy", ".*createdByDisplayName", ".*updatedAt", ".*updatedBy", ".*updatedByDisplayName")
+  }
+
   fun hasJpaManagedFieldsPopulated(): PersonalSkillsAndInterestsEntityAssert {
     isNotNull
     with(actual!!) {
@@ -92,6 +98,21 @@ class PersonalSkillsAndInterestsEntityAssert(actual: PersonalSkillsAndInterestsE
         failWithMessage("Expected reference to be populated, but was $reference")
       }
     }
+    return this
+  }
+
+  fun isEqualToComparingAllFields(expected: PersonalSkillsAndInterestsEntity): PersonalSkillsAndInterestsEntityAssert {
+    assertThat(actual)
+      .usingRecursiveComparison()
+      .isEqualTo(expected)
+    return this
+  }
+
+  fun isEqualToIgnoringInternallyManagedFields(expected: PersonalSkillsAndInterestsEntity): PersonalSkillsAndInterestsEntityAssert {
+    assertThat(actual)
+      .usingRecursiveComparison()
+      .ignoringFieldsMatchingRegexes(*INTERNALLY_MANAGED_FIELDS)
+      .isEqualTo(expected)
     return this
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntityBuilder.kt
@@ -6,8 +6,8 @@ import java.util.UUID
 fun aValidPersonalSkillsAndInterestsEntity(
   id: UUID? = null,
   reference: UUID = UUID.randomUUID(),
-  skills: List<PersonalSkillEntity> = listOf(aValidPersonalSkillEntity()),
-  interests: List<PersonalInterestEntity> = listOf(aValidPersonalInterestEntity()),
+  skills: MutableList<PersonalSkillEntity> = mutableListOf(aValidPersonalSkillEntity()),
+  interests: MutableList<PersonalInterestEntity> = mutableListOf(aValidPersonalInterestEntity()),
   createdAt: Instant? = null,
   createdAtPrison: String = "BXI",
   createdBy: String? = null,
@@ -35,8 +35,8 @@ fun aValidPersonalSkillsAndInterestsEntity(
 fun aValidPersonalSkillsAndInterestsEntityWithJpaFieldsPopulated(
   id: UUID? = UUID.randomUUID(),
   reference: UUID = UUID.randomUUID(),
-  skills: List<PersonalSkillEntity> = listOf(aValidPersonalSkillEntity()),
-  interests: List<PersonalInterestEntity> = listOf(aValidPersonalInterestEntity()),
+  skills: MutableList<PersonalSkillEntity> = mutableListOf(aValidPersonalSkillEntity()),
+  interests: MutableList<PersonalInterestEntity> = mutableListOf(aValidPersonalInterestEntity()),
   createdAt: Instant? = Instant.now(),
   createdAtPrison: String = "BXI",
   createdBy: String? = "asmith_gen",


### PR DESCRIPTION
This PR introduces the required `MapStruct` methods to update `PersonalSkillsAndInterests` and `InPrisonInterests`. Since both of the respective mappers use two internal "child" mappers, it made sense to do these at the same time. 

Unfortunately it's resulted in a lot of repetitive code and long test methods, which I'll see if I can do something about once I've finished the rest of the mapping.