### PR TITLE
RR-433 - Update induction controller & service, plus initial integration test

### DIFF
--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionPersistenceAdapter.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionPersistenceAdapter.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.se
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Induction
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateInductionDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateInductionDto
 
 /**
  * Persistence Adapter for [Induction] instances.
@@ -19,10 +20,15 @@ interface InductionPersistenceAdapter {
    *
    * @return The [Induction] with any newly generated values (if applicable).
    */
-  fun createInduction(induction: CreateInductionDto): Induction
+  fun createInduction(createInductionDto: CreateInductionDto): Induction
 
   /**
    * Retrieves an [Induction] for a given Prisoner. Returns `null` if the [Induction] does not exist.
    */
   fun getInduction(prisonNumber: String): Induction?
+
+  /**
+   * Updates an [Induction] identified by its `prisonNumber`.
+   */
+  fun updateInduction(updateInductionDto: UpdateInductionDto): Induction?
 }

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionService.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionService.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Ind
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InductionAlreadyExistsException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InductionNotFoundException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateInductionDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateInductionDto
 
 private val log = KotlinLogging.logger {}
 
@@ -41,4 +42,18 @@ class InductionService(
    */
   fun getInductionForPrisoner(prisonNumber: String): Induction =
     persistenceAdapter.getInduction(prisonNumber) ?: throw InductionNotFoundException(prisonNumber)
+
+  /**
+   * Updates an [Induction], identified by its `prisonNumber`, from the specified [UpdateInductionDto].
+   * Throws [InductionNotFoundException] if the [Induction] to be updated cannot be found.
+   */
+  fun updateInduction(updateInductionDto: UpdateInductionDto): Induction {
+    val prisonNumber = updateInductionDto.prisonNumber
+    log.info { "Updating Induction for prisoner [$prisonNumber]" }
+
+    return persistenceAdapter.updateInduction(updateInductionDto)
+      ?: throw InductionNotFoundException(prisonNumber).also {
+        log.info { "Induction for prisoner [$prisonNumber] not found" }
+      }
+  }
 }

--- a/domain/induction/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionServiceTest.kt
+++ b/domain/induction/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionServiceTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Ind
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InductionNotFoundException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInduction
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreateInductionDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateInductionDto
 
 @ExtendWith(MockitoExtension::class)
 class InductionServiceTest {
@@ -77,12 +78,11 @@ class InductionServiceTest {
   @Test
   fun `should fail to get induction for prisoner given induction does not exist`() {
     // Given
-    val prisonNumber = "A1234AB"
     given(persistenceAdapter.getInduction(any())).willReturn(null)
 
     // When
     val exception = catchThrowableOfType(
-      { service.getInductionForPrisoner(Companion.prisonNumber) },
+      { service.getInductionForPrisoner(prisonNumber) },
       InductionNotFoundException::class.java,
     )
 
@@ -90,5 +90,37 @@ class InductionServiceTest {
     assertThat(exception).hasMessage("Induction not found for prisoner [$prisonNumber]")
     assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
     verify(persistenceAdapter).getInduction(prisonNumber)
+  }
+
+  @Test
+  fun `should update induction`() {
+    // Given
+    val updateInductionDto = aValidUpdateInductionDto(prisonNumber = prisonNumber)
+    val expected = aValidInduction(prisonNumber = prisonNumber)
+    given(persistenceAdapter.updateInduction(any())).willReturn(expected)
+
+    // When
+    val actual = service.updateInduction(updateInductionDto)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+    verify(persistenceAdapter).updateInduction(updateInductionDto)
+  }
+
+  @Test
+  fun `should fail to update induction given it does not exist`() {
+    // Given
+    val updateInductionDto = aValidUpdateInductionDto(prisonNumber = prisonNumber)
+    given(persistenceAdapter.updateInduction(any())).willReturn(null)
+
+    // When
+    val exception = catchThrowableOfType(
+      { service.updateInduction(updateInductionDto) },
+      InductionNotFoundException::class.java,
+    )
+
+    // Then
+    assertThat(exception).hasMessage("Induction not found for prisoner [$prisonNumber]")
+    verify(persistenceAdapter).updateInduction(updateInductionDto)
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -23,7 +23,9 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.L
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateCiagInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
@@ -42,6 +44,7 @@ abstract class IntegrationTestBase {
     const val CREATE_ACTION_PLAN_URI_TEMPLATE = "/action-plans/{prisonNumber}"
     const val GET_ACTION_PLAN_URI_TEMPLATE = "/action-plans/{prisonNumber}"
     const val GET_TIMELINE_URI_TEMPLATE = "/timelines/{prisonNumber}"
+    const val INDUCTION_URI_TEMPLATE = "/ciag-inductions/{prisonNumber}"
 
     private val localStackContainer = LocalStackContainer.instance
 
@@ -126,5 +129,26 @@ abstract class IntegrationTestBase {
       .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
       .exchange()
       .returnResult(TimelineResponse::class.java)
+      .responseBody.blockFirst()!!
+
+  fun createInduction(prisonNumber: String, createCiagInductionRequest: CreateCiagInductionRequest) {
+    webTestClient.post()
+      .uri(INDUCTION_URI_TEMPLATE, prisonNumber)
+      .withBody(createCiagInductionRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
+  }
+
+  fun getInduction(prisonNumber: String): CiagInductionResponse =
+    webTestClient.get()
+      .uri(INDUCTION_URI_TEMPLATE, prisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(CiagInductionResponse::class.java)
       .responseBody.blockFirst()!!
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
@@ -47,7 +47,7 @@ class CreateInductionTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should fail to create induction no induction data provided`() {
+  fun `should fail to create induction given no induction data provided`() {
     val prisonNumber = aValidPrisonNumber()
 
     // When

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.NOT_FOUND
-import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
@@ -11,7 +10,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewA
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateCiagInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
@@ -22,7 +20,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induc
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidSkillsAndInterestsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.isEquivalentTo
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 
 class GetInductionTest : IntegrationTestBase() {
 
@@ -95,16 +92,5 @@ class GetInductionTest : IntegrationTestBase() {
     assertThat(actual.skillsAndInterests).isEquivalentTo(expectedSkillsAndInterests)
     assertThat(actual.qualificationsAndTraining).isEquivalentTo(expectedQualificationsAndTraining)
     assertThat(actual.inPrisonInterests).isEquivalentTo(expectedInPrisonInterests)
-  }
-
-  private fun createInduction(prisonNumber: String, createCiagInductionRequest: CreateCiagInductionRequest) {
-    webTestClient.post()
-      .uri(URI_TEMPLATE, prisonNumber)
-      .withBody(createCiagInductionRequest)
-      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
-      .contentType(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus()
-      .isCreated()
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -1,0 +1,307 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
+
+import aValidCreatePrisonWorkAndEducationRequest
+import aValidUpdatePrisonWorkAndEducationRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.MediaType.APPLICATION_JSON
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AbilityToWorkFactor
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HighestEducationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkill
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonNotToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateSkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidEducationAndQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPrisonWorkAndEducationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidSkillsAndInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateSkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkExperienceResource
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterests
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.isEquivalentTo
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
+
+class UpdateInductionTest : IntegrationTestBase() {
+
+  companion object {
+    private const val URI_TEMPLATE = "/ciag-inductions/{prisonNumber}"
+  }
+
+  @Test
+  fun `should return unauthorized given no bearer token`() {
+    webTestClient.put()
+      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `should return forbidden given bearer token with view only role`() {
+    webTestClient.put()
+      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .withBody(aValidUpdateCiagInductionRequest())
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should fail to update induction given no induction data provided`() {
+    val prisonNumber = aValidPrisonNumber()
+
+    // When
+    val response = webTestClient.put()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .bodyValue(
+        """
+          { }
+        """.trimIndent(),
+      )
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.BAD_REQUEST.value())
+      .hasUserMessageContaining("JSON parse error")
+      .hasUserMessageContaining("value failed for JSON property reference due to missing (therefore NULL) value for creator parameter reference")
+  }
+
+  @Test
+  fun `should fail to update induction given induction does not exist`() {
+    // Given
+    val prisonNumber = "A1234BC"
+    val updateInductionRequest = aValidUpdateCiagInductionRequest()
+
+    // When
+    val response = webTestClient.put()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(updateInductionRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isNotFound
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(NOT_FOUND.value())
+      .hasUserMessage("Induction not found for prisoner [$prisonNumber]")
+  }
+
+  @Test
+  fun `should update induction for prisoner`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    createInduction(prisonNumber, aValidCreateInductionRequestWithOtherReasons())
+    val persistedInduction = getInduction(prisonNumber)
+    val createdDateTime = persistedInduction.createdDateTime
+    val initialModifiedDateTime = persistedInduction.modifiedDateTime
+    val updateInductionRequest = aValidUpdateCiagInductionRequest(
+      reference = persistedInduction.reference,
+      hopingToGetWork = HopingToWork.YES,
+      prisonId = "MDI",
+      reasonToNotGetWorkOther = null,
+      abilityToWorkOther = null,
+      abilityToWork = emptySet(),
+      reasonToNotGetWork = emptySet(),
+      workExperience = aValidUpdatePreviousWorkRequest(
+        id = persistedInduction.workExperience!!.id!!,
+        typeOfWorkExperience = setOf(WorkType.CONSTRUCTION),
+        typeOfWorkExperienceOther = null,
+        workExperience = setOf(
+          aValidWorkExperienceResource(
+            typeOfWorkExperience = WorkType.CONSTRUCTION,
+            otherWork = null,
+            role = "Bricklayer",
+            details = "General brick work",
+          ),
+        ),
+        workInterests = aValidWorkInterests(
+          id = persistedInduction.workExperience!!.workInterests!!.id,
+          workInterests = setOf(WorkType.SPORTS),
+          workInterestsOther = null,
+          particularJobInterests = setOf(
+            WorkInterestDetail(
+              workInterest = WorkType.SPORTS,
+              role = "Football coach",
+            ),
+          ),
+        ),
+      ),
+      skillsAndInterests = aValidUpdateSkillsAndInterestsRequest(
+        id = persistedInduction.skillsAndInterests!!.id!!,
+        skills = setOf(PersonalSkill.COMMUNICATION),
+        skillsOther = null,
+        personalInterests = setOf(PersonalInterest.CRAFTS),
+        personalInterestsOther = null,
+      ),
+      qualificationsAndTraining = aValidUpdateEducationAndQualificationsRequest(
+        id = persistedInduction.qualificationsAndTraining!!.id!!,
+        educationLevel = HighestEducationLevel.PRIMARY_SCHOOL,
+        qualifications = emptySet(),
+        additionalTraining = setOf(TrainingType.CSCS_CARD),
+        additionalTrainingOther = null,
+      ),
+      inPrisonInterests = aValidUpdatePrisonWorkAndEducationRequest(
+        id = persistedInduction.inPrisonInterests!!.id!!,
+        inPrisonWork = setOf(InPrisonWorkType.PRISON_LIBRARY),
+        inPrisonWorkOther = null,
+        inPrisonEducation = setOf(InPrisonTrainingType.WELDING_AND_METALWORK),
+        inPrisonEducationOther = null,
+      ),
+    )
+
+    val expectedWorkExperience = aValidPreviousWorkResponse(
+      id = persistedInduction.workExperience!!.id!!,
+      typeOfWorkExperience = setOf(WorkType.CONSTRUCTION),
+      typeOfWorkExperienceOther = null,
+      workExperience = setOf(
+        aValidWorkExperienceResource(
+          typeOfWorkExperience = WorkType.CONSTRUCTION,
+          otherWork = null,
+          role = "Bricklayer",
+          details = "General brick work",
+        ),
+      ),
+      workInterests = aValidWorkInterests(
+        id = persistedInduction.workExperience!!.workInterests!!.id,
+        workInterests = setOf(WorkType.SPORTS),
+        workInterestsOther = null,
+        particularJobInterests = setOf(
+          WorkInterestDetail(
+            workInterest = WorkType.SPORTS,
+            role = "Football coach",
+          ),
+        ),
+      ),
+      modifiedBy = "auser_gen",
+    )
+    val expectedSkillsAndInterests = aValidSkillsAndInterestsResponse(
+      id = persistedInduction.skillsAndInterests!!.id!!,
+      skills = setOf(PersonalSkill.COMMUNICATION),
+      skillsOther = null,
+      personalInterests = setOf(PersonalInterest.CRAFTS),
+      personalInterestsOther = null,
+      modifiedBy = "auser_gen",
+    )
+    val expectedQualificationsAndTraining = aValidEducationAndQualificationsResponse(
+      id = persistedInduction.qualificationsAndTraining!!.id!!,
+      educationLevel = HighestEducationLevel.PRIMARY_SCHOOL,
+      qualifications = emptySet(),
+      additionalTraining = setOf(TrainingType.CSCS_CARD),
+      additionalTrainingOther = null,
+      modifiedBy = "auser_gen",
+    )
+    val expectedInPrisonInterests = aValidPrisonWorkAndEducationResponse(
+      id = persistedInduction.inPrisonInterests!!.id!!,
+      inPrisonWork = setOf(InPrisonWorkType.PRISON_LIBRARY),
+      inPrisonWorkOther = null,
+      inPrisonEducation = setOf(InPrisonTrainingType.WELDING_AND_METALWORK),
+      inPrisonEducationOther = null,
+      modifiedBy = "auser_gen",
+    )
+
+    // When
+    webTestClient.put()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(updateInductionRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    // Then
+    val updatedInduction = getInduction(prisonNumber)
+    assertThat(updatedInduction)
+      .hasReference(persistedInduction.reference)
+      .hasHopingToGetWork(HopingToWork.YES)
+      .hasPrisonId("MDI")
+      .hasNoReasonToNotGetWorkOther()
+      .hasNoAbilityToWorkOther()
+      .hasAbilityToWork(emptySet())
+      .hasReasonToNotGetWork(emptySet())
+      .wasModifiedBy("auser_gen")
+      .wasCreatedAt(createdDateTime)
+      .wasLastModifiedAfter(initialModifiedDateTime)
+    assertThat(updatedInduction.workExperience).isEquivalentTo(expectedWorkExperience)
+    assertThat(updatedInduction.skillsAndInterests).isEquivalentTo(expectedSkillsAndInterests)
+    assertThat(updatedInduction.qualificationsAndTraining).isEquivalentTo(expectedQualificationsAndTraining)
+    assertThat(updatedInduction.inPrisonInterests).isEquivalentTo(expectedInPrisonInterests)
+    // check last modified dates of child objects
+    assertThat(updatedInduction.workExperience!!.modifiedDateTime).isAfter(initialModifiedDateTime)
+    assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isAfter(initialModifiedDateTime)
+    assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isAfter(initialModifiedDateTime)
+    assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isAfter(initialModifiedDateTime)
+  }
+
+  private fun aValidCreateInductionRequestWithOtherReasons() = aValidCreateCiagInductionRequest(
+    hopingToGetWork = HopingToWork.NOT_SURE,
+    prisonId = "BXI",
+    reasonToNotGetWorkOther = "Crime pays",
+    abilityToWorkOther = "Lack of interest",
+    abilityToWork = setOf(AbilityToWorkFactor.OTHER),
+    reasonToNotGetWork = setOf(ReasonNotToWork.OTHER),
+    workExperience = aValidCreatePreviousWorkRequest(
+      typeOfWorkExperience = setOf(WorkType.OTHER),
+      typeOfWorkExperienceOther = "Scientist",
+      workExperience = setOf(aValidWorkExperienceResource()),
+      workInterests = aValidCreateWorkInterestsRequest(),
+    ),
+    skillsAndInterests = aValidCreateSkillsAndInterestsRequest(
+      skills = setOf(PersonalSkill.OTHER),
+      skillsOther = "Hidden skills",
+      personalInterests = setOf(PersonalInterest.OTHER),
+      personalInterestsOther = "Secret interests",
+    ),
+    qualificationsAndTraining = aValidCreateEducationAndQualificationsRequest(
+      educationLevel = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
+      qualifications = setOf(
+        aValidAchievedQualification(),
+      ),
+      additionalTraining = setOf(TrainingType.OTHER),
+      additionalTrainingOther = "Any training",
+    ),
+    inPrisonInterests = aValidCreatePrisonWorkAndEducationRequest(
+      inPrisonWork = setOf(InPrisonWorkType.OTHER),
+      inPrisonWorkOther = "Any in-prison work",
+      inPrisonEducation = setOf(InPrisonTrainingType.OTHER),
+      inPrisonEducationOther = "Any in-prison training",
+    ),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.map
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.InductionRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Induction
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateInductionDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateInductionDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionPersistenceAdapter
 
 @Component
@@ -25,4 +26,15 @@ class JpaInductionPersistenceAdapter(
     inductionRepository.findByPrisonNumber(prisonNumber)?.let {
       inductionMapper.fromEntityToDomain(it)
     }
+
+  @Transactional
+  override fun updateInduction(updateInductionDto: UpdateInductionDto): Induction? {
+    val inductionEntity = inductionRepository.findByPrisonNumber(updateInductionDto.prisonNumber)
+    return if (inductionEntity != null) {
+      inductionMapper.updateEntityFromDto(inductionEntity, updateInductionDto)
+      inductionMapper.fromEntityToDomain(inductionEntity)
+    } else {
+      null
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/InductionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/InductionController.kt
@@ -7,21 +7,25 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.CiagInductionResponseMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.CreateCiagInductionRequestMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.UpdateCiagInductionRequestMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateCiagInductionRequest
 
 @RestController
 @RequestMapping(value = ["/ciag-inductions"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class InductionController(
   private val inductionService: InductionService,
-  private val inductionRequestMapper: CreateCiagInductionRequestMapper,
+  private val createInductionRequestMapper: CreateCiagInductionRequestMapper,
+  private val updateInductionRequestMapper: UpdateCiagInductionRequestMapper,
   private val inductionResponseMapper: CiagInductionResponseMapper,
 ) {
 
@@ -34,7 +38,7 @@ class InductionController(
     request: CreateCiagInductionRequest,
     @PathVariable prisonNumber: String,
   ) {
-    inductionService.createInduction(inductionRequestMapper.toCreateInductionDto(prisonNumber, request))
+    inductionService.createInduction(createInductionRequestMapper.toCreateInductionDto(prisonNumber, request))
   }
 
   @GetMapping("/{prisonNumber}")
@@ -44,4 +48,16 @@ class InductionController(
     with(inductionService.getInductionForPrisoner(prisonNumber)) {
       inductionResponseMapper.fromDomainToModel(this)
     }
+
+  @PutMapping("/{prisonNumber}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PreAuthorize(HAS_EDIT_AUTHORITY)
+  fun updateInduction(
+    @Valid
+    @RequestBody
+    request: UpdateCiagInductionRequest,
+    @PathVariable prisonNumber: String,
+  ) {
+    inductionService.updateInduction(updateInductionRequestMapper.toUpdateInductionDto(prisonNumber, request))
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapperTest.kt
@@ -162,7 +162,7 @@ class InductionEntityMapperTest {
   }
 
   @Test
-  fun `should update induction`() {
+  fun `should update induction and call related mappers`() {
     // Given
     val inductionReference = UUID.randomUUID()
     val prisonNumber = aValidPrisonNumber()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapperTest.kt
@@ -73,6 +73,7 @@ class InPrisonInterestsResourceMapperTest {
       inPrisonEducation = setOf(InPrisonTrainingTypeApi.OTHER),
       inPrisonEducationOther = "Any in-prison training",
       modifiedDateTime = modifiedDateTime,
+      modifiedBy = "bjones_gen",
     )
 
     // When
@@ -98,6 +99,7 @@ class InPrisonInterestsResourceMapperTest {
       inPrisonEducation = emptySet(),
       inPrisonEducationOther = null,
       modifiedDateTime = modifiedDateTime,
+      modifiedBy = "bjones_gen",
     )
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapperTest.kt
@@ -92,6 +92,7 @@ class PreviousWorkExperiencesResourceMapperTest {
         ),
       ),
       modifiedDateTime = workExperiences.lastUpdatedAt!!.atOffset(ZoneOffset.UTC),
+      modifiedBy = "bjones_gen",
     )
 
     // When
@@ -130,6 +131,7 @@ class PreviousWorkExperiencesResourceMapperTest {
       ),
       workInterests = null,
       modifiedDateTime = workExperiences.lastUpdatedAt!!.atOffset(ZoneOffset.UTC),
+      modifiedBy = "bjones_gen",
     )
 
     // When
@@ -175,6 +177,7 @@ class PreviousWorkExperiencesResourceMapperTest {
         particularJobInterests = emptySet(),
       ),
       modifiedDateTime = workExperiences.lastUpdatedAt!!.atOffset(ZoneOffset.UTC),
+      modifiedBy = "bjones_gen",
     )
 
     // When

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ApiResponseAssertions.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/ApiResponseAssertions.kt
@@ -9,7 +9,6 @@ private val IGNORED_FIELDS = arrayOf(
   ".*createdDateTime",
   ".*updatedAt",
   ".*modifiedDateTime",
-  ".*modifiedBy",
 )
 
 /**

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/CiagInductionResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/CiagInductionResponseAssert.kt
@@ -5,6 +5,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Abili
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonNotToWork
+import java.time.OffsetDateTime
+import java.util.UUID
 
 fun assertThat(actual: CiagInductionResponse?) = CiagInductionResponseAssert(actual)
 
@@ -22,6 +24,16 @@ class CiagInductionResponseAssert(actual: CiagInductionResponse?) :
     with(actual!!) {
       if (reference == null) {
         failWithMessage("Expected reference to have a value, but was null")
+      }
+    }
+    return this
+  }
+
+  fun hasReference(expected: UUID): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
       }
     }
     return this
@@ -67,6 +79,16 @@ class CiagInductionResponseAssert(actual: CiagInductionResponse?) :
     return this
   }
 
+  fun hasNoReasonToNotGetWorkOther(): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reasonToNotGetWorkOther != null) {
+        failWithMessage("Expected reasonToNotGetWorkOther to be null, but was $reasonToNotGetWorkOther")
+      }
+    }
+    return this
+  }
+
   fun hasAbilityToWork(expected: Set<AbilityToWorkFactor>): CiagInductionResponseAssert {
     isNotNull
     with(actual!!) {
@@ -82,6 +104,16 @@ class CiagInductionResponseAssert(actual: CiagInductionResponse?) :
     with(actual!!) {
       if (abilityToWorkOther != expected) {
         failWithMessage("Expected abilityToWorkOther to be $expected, but was $abilityToWorkOther")
+      }
+    }
+    return this
+  }
+
+  fun hasNoAbilityToWorkOther(): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (abilityToWorkOther != null) {
+        failWithMessage("Expected abilityToWorkOther to be null, but was $abilityToWorkOther")
       }
     }
     return this
@@ -107,11 +139,31 @@ class CiagInductionResponseAssert(actual: CiagInductionResponse?) :
     return this
   }
 
+  fun wasCreatedAt(expected: OffsetDateTime): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdDateTime != expected) {
+        failWithMessage("Expected createdDateTime to be $expected, but was $createdDateTime")
+      }
+    }
+    return this
+  }
+
   fun hasAModifiedDateTime(): CiagInductionResponseAssert {
     isNotNull
     with(actual!!) {
       if (modifiedDateTime == null) {
         failWithMessage("Expected modifiedDateTime to have a value, but was null")
+      }
+    }
+    return this
+  }
+
+  fun wasLastModifiedAfter(dateTime: OffsetDateTime): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!modifiedDateTime.isAfter(dateTime)) {
+        failWithMessage("Expected modifiedDateTime to be after $dateTime, but was $modifiedDateTime")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/EducationAndQualificationsResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/EducationAndQualificationsResponseBuilder.kt
@@ -16,7 +16,7 @@ fun aValidEducationAndQualificationsResponse(
   ),
   additionalTraining: Set<TrainingType>? = setOf(TrainingType.CSCS_CARD, TrainingType.OTHER),
   additionalTrainingOther: String? = "Any training",
-  modifiedBy: String = "asmith_gen",
+  modifiedBy: String = "auser_gen",
   modifiedDateTime: OffsetDateTime = OffsetDateTime.now(),
 ): EducationAndQualificationResponse =
   EducationAndQualificationResponse(

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkResponseBuilder.kt
@@ -14,7 +14,7 @@ fun aValidPreviousWorkResponse(
   typeOfWorkExperienceOther: String? = "Scientist",
   workExperience: Set<WorkExperience>? = setOf(aValidWorkExperienceResource()),
   workInterests: WorkInterests? = aValidWorkInterests(),
-  modifiedBy: String = "bjones_gen",
+  modifiedBy: String = "auser_gen",
   modifiedDateTime: OffsetDateTime = OffsetDateTime.now(),
 ): PreviousWorkResponse =
   PreviousWorkResponse(

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PrisonWorkAndEducationResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PrisonWorkAndEducationResponseBuilder.kt
@@ -12,7 +12,7 @@ fun aValidPrisonWorkAndEducationResponse(
   inPrisonWorkOther: String? = "Any in-prison work",
   inPrisonEducation: Set<InPrisonTrainingType>? = setOf(InPrisonTrainingType.OTHER),
   inPrisonEducationOther: String? = "Any in-prison training",
-  modifiedBy: String = "bjones_gen",
+  modifiedBy: String = "auser_gen",
   modifiedDateTime: OffsetDateTime = OffsetDateTime.now(),
 ): PrisonWorkAndEducationResponse =
   PrisonWorkAndEducationResponse(

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/SkillsAndInterestsResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/SkillsAndInterestsResponseBuilder.kt
@@ -12,7 +12,7 @@ fun aValidSkillsAndInterestsResponse(
   skillsOther: String? = "Hidden skills",
   personalInterests: Set<PersonalInterest>? = setOf(PersonalInterest.OTHER),
   personalInterestsOther: String? = "Secret interests",
-  modifiedBy: String = "asmith_gen",
+  modifiedBy: String = "auser_gen",
   modifiedDateTime: OffsetDateTime = OffsetDateTime.now(),
 ): SkillsAndInterestsResponse =
   SkillsAndInterestsResponse(


### PR DESCRIPTION
This PR adds the required controller and service for updating an Induction. It also adds an integration test, which currently ensures that each "child" object is updated when a value to update it is provided (i.e. I am not yet testing updates with null child objects).