### PR TITLE
RR-448 - Induction Timeline events

### DIFF
--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionEventService.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionEventService.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Induction
+
+/**
+ * Interface defining a series of Induction lifecycle event methods.
+ */
+interface InductionEventService {
+
+  /**
+   * Implementations providing custom code for when a [Induction] is created.
+   */
+  fun inductionCreated(createdInduction: Induction)
+
+  /**
+   * Implementations providing custom code for when a [Induction] is updated.
+   */
+  fun inductionUpdated(updatedInduction: Induction)
+}

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionService.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionService.kt
@@ -20,6 +20,7 @@ private val log = KotlinLogging.logger {}
  */
 class InductionService(
   private val persistenceAdapter: InductionPersistenceAdapter,
+  private val inductionEventService: InductionEventService,
 ) {
 
   /**
@@ -34,6 +35,9 @@ class InductionService(
       }
 
       return persistenceAdapter.createInduction(createInductionDto)
+        .also {
+          inductionEventService.inductionCreated(it)
+        }
     }
 
   /**
@@ -52,6 +56,9 @@ class InductionService(
     log.info { "Updating Induction for prisoner [$prisonNumber]" }
 
     return persistenceAdapter.updateInduction(updateInductionDto)
+      ?.also {
+        inductionEventService.inductionUpdated(it)
+      }
       ?: throw InductionNotFoundException(prisonNumber).also {
         log.info { "Induction for prisoner [$prisonNumber] not found" }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalEventService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalPersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionEventService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionPersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelinePersistenceAdapter
@@ -40,6 +41,9 @@ class DomainConfiguration {
     TimelineService(timelinePersistenceAdapter)
 
   @Bean
-  fun inductionDomainService(inductionPersistenceAdapter: InductionPersistenceAdapter): InductionService =
-    InductionService(inductionPersistenceAdapter)
+  fun inductionDomainService(
+    inductionPersistenceAdapter: InductionPersistenceAdapter,
+    inductionEventService: InductionEventService,
+  ): InductionService =
+    InductionService(inductionPersistenceAdapter, inductionEventService)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapter.kt
@@ -17,7 +17,7 @@ class JpaActionPlanPersistenceAdapter(
 
   @Transactional
   override fun createActionPlan(createActionPlanDto: CreateActionPlanDto): ActionPlan {
-    val persistedEntity = actionPlanRepository.save(actionPlanMapper.fromDtoToEntity(createActionPlanDto))
+    val persistedEntity = actionPlanRepository.saveAndFlush(actionPlanMapper.fromDtoToEntity(createActionPlanDto))
     return actionPlanMapper.fromEntityToDomain(persistedEntity)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
@@ -17,7 +17,7 @@ class JpaInductionPersistenceAdapter(
 
   @Transactional
   override fun createInduction(createInductionDto: CreateInductionDto): Induction {
-    val persistedEntity = inductionRepository.save(inductionMapper.fromCreateDtoToEntity(createInductionDto))
+    val persistedEntity = inductionRepository.saveAndFlush(inductionMapper.fromCreateDtoToEntity(createInductionDto))
     return inductionMapper.fromEntityToDomain(persistedEntity)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventService.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
+
+import kotlinx.coroutines.runBlocking
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Induction
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionEventService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEventType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelineService
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Implementation of [InductionEventService] for performing additional asynchronous actions related to [Induction] events.
+ */
+@Component
+class AsyncInductionEventService(
+  private val timelineService: TimelineService,
+) : InductionEventService {
+
+  override fun inductionCreated(createdInduction: Induction) {
+    runBlocking {
+      log.debug { "Induction created event for prisoner [${createdInduction.prisonNumber}]" }
+      timelineService.recordTimelineEvent(
+        createdInduction.prisonNumber,
+        buildInductionCreatedEvent(createdInduction),
+      )
+    }
+  }
+
+  override fun inductionUpdated(updatedInduction: Induction) {
+    runBlocking {
+      log.debug { "Induction updated event for prisoner [${updatedInduction.prisonNumber}]" }
+      timelineService.recordTimelineEvent(
+        updatedInduction.prisonNumber,
+        buildInductionUpdatedEvent(updatedInduction),
+      )
+    }
+  }
+
+  private fun buildInductionCreatedEvent(induction: Induction): TimelineEvent =
+    with(induction) {
+      TimelineEvent.newTimelineEvent(
+        sourceReference = reference.toString(),
+        eventType = TimelineEventType.INDUCTION_CREATED,
+        prisonId = createdAtPrison,
+        actionedBy = induction.createdBy!!,
+        actionedByDisplayName = induction.createdByDisplayName,
+        timestamp = induction.createdAt!!,
+      )
+    }
+
+  private fun buildInductionUpdatedEvent(induction: Induction): TimelineEvent =
+    with(induction) {
+      TimelineEvent.newTimelineEvent(
+        sourceReference = reference.toString(),
+        eventType = TimelineEventType.INDUCTION_UPDATED,
+        prisonId = lastUpdatedAtPrison,
+        actionedBy = induction.lastUpdatedBy!!,
+        actionedByDisplayName = induction.lastUpdatedByDisplayName,
+        timestamp = induction.lastUpdatedAt!!,
+      )
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaActionPlanPersistenceAdapterTest.kt
@@ -38,7 +38,7 @@ class JpaActionPlanPersistenceAdapterTest {
     val actionPlanDomain = aValidActionPlan(prisonNumber = prisonNumber)
     val actionPlanEntity = aValidActionPlanEntity(prisonNumber = prisonNumber)
     given(actionPlanMapper.fromDtoToEntity(any())).willReturn(actionPlanEntity)
-    given(actionPlanRepository.save(any<ActionPlanEntity>())).willReturn(actionPlanEntity)
+    given(actionPlanRepository.saveAndFlush(any<ActionPlanEntity>())).willReturn(actionPlanEntity)
     given(actionPlanMapper.fromEntityToDomain(any())).willReturn(actionPlanDomain)
 
     val createActionPlanDto = aValidCreateActionPlanDto(prisonNumber = prisonNumber)
@@ -48,7 +48,7 @@ class JpaActionPlanPersistenceAdapterTest {
 
     // Then
     assertThat(actual).isEqualTo(actionPlanDomain)
-    verify(actionPlanRepository).save(actionPlanEntity)
+    verify(actionPlanRepository).saveAndFlush(actionPlanEntity)
     verify(actionPlanMapper).fromDtoToEntity(createActionPlanDto)
     verify(actionPlanMapper).fromEntityToDomain(actionPlanEntity)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapterTest.kt
@@ -39,7 +39,7 @@ class JpaInductionPersistenceAdapterTest {
     val inductionEntity = aValidInductionEntity(prisonNumber = prisonNumber)
     val expected = aValidInduction(prisonNumber = prisonNumber)
     given(inductionMapper.fromCreateDtoToEntity(any())).willReturn(inductionEntity)
-    given(inductionRepository.save(any<InductionEntity>())).willReturn(inductionEntity)
+    given(inductionRepository.saveAndFlush(any<InductionEntity>())).willReturn(inductionEntity)
     given(inductionMapper.fromEntityToDomain(any())).willReturn(expected)
 
     // When
@@ -48,7 +48,7 @@ class JpaInductionPersistenceAdapterTest {
     // Then
     assertThat(actual).isEqualTo(expected)
     verify(inductionMapper).fromCreateDtoToEntity(createInductionDto)
-    verify(inductionRepository).save(inductionEntity)
+    verify(inductionRepository).saveAndFlush(inductionEntity)
     verify(inductionMapper).fromEntityToDomain(inductionEntity)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventServiceTest.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInduction
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEventType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelineService
+
+@ExtendWith(MockitoExtension::class)
+class AsyncInductionEventServiceTest {
+
+  companion object {
+    private val IGNORED_FIELDS = arrayOf("reference", "correlationId")
+  }
+
+  @InjectMocks
+  private lateinit var inductionEventService: AsyncInductionEventService
+
+  @Mock
+  private lateinit var timelineService: TimelineService
+
+  @Captor
+  private lateinit var timelineEventCaptor: ArgumentCaptor<TimelineEvent>
+
+  @Test
+  fun `should handle induction created`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val induction = aValidInduction(prisonNumber = prisonNumber)
+    val expectedTimelineEvent =
+      with(induction) {
+        TimelineEvent.newTimelineEvent(
+          sourceReference = reference.toString(),
+          eventType = TimelineEventType.INDUCTION_CREATED,
+          prisonId = createdAtPrison,
+          actionedBy = induction.createdBy!!,
+          actionedByDisplayName = induction.createdByDisplayName,
+          timestamp = induction.createdAt!!,
+        )
+      }
+
+    // When
+    inductionEventService.inductionCreated(induction)
+
+    // Then
+    verify(timelineService).recordTimelineEvent(eq(prisonNumber), capture(timelineEventCaptor))
+    assertThat(timelineEventCaptor.value).usingRecursiveComparison().ignoringFields(*IGNORED_FIELDS)
+      .isEqualTo(expectedTimelineEvent)
+  }
+
+  @Test
+  fun `should handle induction updated`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val induction = aValidInduction(prisonNumber = prisonNumber)
+    val expectedTimelineEvent =
+      with(induction) {
+        TimelineEvent.newTimelineEvent(
+          sourceReference = reference.toString(),
+          eventType = TimelineEventType.INDUCTION_UPDATED,
+          prisonId = lastUpdatedAtPrison,
+          actionedBy = induction.lastUpdatedBy!!,
+          actionedByDisplayName = induction.lastUpdatedByDisplayName,
+          timestamp = induction.lastUpdatedAt!!,
+        )
+      }
+
+    // When
+    inductionEventService.inductionUpdated(induction)
+
+    // Then
+    verify(timelineService).recordTimelineEvent(eq(prisonNumber), capture(timelineEventCaptor))
+    assertThat(timelineEventCaptor.value).usingRecursiveComparison().ignoringFields(*IGNORED_FIELDS)
+      .isEqualTo(expectedTimelineEvent)
+  }
+}


### PR DESCRIPTION
This PR ensures that `INDUCTION_CREATED` or `INDUCTION_UPDATED` events are added to a Prisoner's Timeline, whenever an Induction is created or updated via "our" API.

This now completes the functionality for creating and updating Inductions via our API (subject to more testing!). It also means that once we switch the CIAG UI to use our API, we can then remove all the SQS messaging code and config (including from cloud-platform-environments).