### PR TITLE
RR-469 - Centralised approach for updating lists within Induction entities

### DIFF
--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/DomainKeyAware.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/DomainKeyAware.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction
+
+/**
+ * Interface for domain model classes that enables them to provide a key to help identify them, or potentially to sort
+ * them within Collections.
+ */
+interface DomainKeyAware {
+  fun key(): String
+}

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/InPrisonInterests.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/InPrisonInterests.kt
@@ -28,12 +28,16 @@ data class InPrisonInterests(
 data class InPrisonWorkInterest(
   val workType: InPrisonWorkType,
   val workTypeOther: String?,
-)
+) : DomainKeyAware {
+  override fun key(): String = workType.name
+}
 
 data class InPrisonTrainingInterest(
   val trainingType: InPrisonTrainingType,
   val trainingTypeOther: String?,
-)
+) : DomainKeyAware {
+  override fun key(): String = trainingType.name
+}
 
 enum class InPrisonWorkType {
   CLEANING_AND_HYGIENE,

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/PersonalSkillsAndInterests.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/PersonalSkillsAndInterests.kt
@@ -25,12 +25,16 @@ data class PersonalSkillsAndInterests(
 data class PersonalSkill(
   val skillType: SkillType,
   val skillTypeOther: String?,
-)
+) : DomainKeyAware {
+  override fun key(): String = skillType.name
+}
 
 data class PersonalInterest(
   val interestType: InterestType,
   val interestTypeOther: String?,
-)
+) : DomainKeyAware {
+  override fun key(): String = interestType.name
+}
 
 enum class SkillType {
   COMMUNICATION,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -320,6 +320,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       .wasCreatedAt(createdDateTime)
       .wasLastModifiedAt(initialModifiedAt) // should be unchanged
     assertThat(updatedInduction.qualificationsAndTraining).isEquivalentTo(expectedQualificationsAndTraining)
+    // TODO RR-469 - modifiedDateTime is not updated if only the lists of qualifications is updated
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isAfter(initialModifiedAt)
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.workExperience!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
@@ -398,7 +399,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       .wasCreatedAt(createdDateTime)
       .wasLastModifiedAt(initialModifiedAt) // should be unchanged
     assertThat(updatedInduction.workExperience).isEquivalentTo(expectedWorkExperience)
-    // TODO - modifiedDateTime of workExperience is not being updated
+    // TODO RR-469 - modifiedDateTime of workExperience is not being updated
     // assertThat(updatedInduction.workExperience!!.modifiedDateTime).isAfter(initialModifiedAt)
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
@@ -455,6 +456,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       .wasCreatedAt(createdDateTime)
       .wasLastModifiedAt(initialModifiedAt) // should be unchanged
     assertThat(updatedInduction.skillsAndInterests).isEquivalentTo(expectedSkillsAndInterests)
+    // TODO RR-469 - modifiedDateTime of skillsAndInterests is not being updated
     // assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isAfter(initialModifiedAt)
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
@@ -511,6 +513,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       .wasCreatedAt(createdDateTime)
       .wasLastModifiedAt(initialModifiedAt) // should be unchanged
     assertThat(updatedInduction.inPrisonInterests).isEquivalentTo(expectedInPrisonInterests)
+    // TODO RR-469 - modifiedDateTime of inPrisonInterests is not being updated
     // assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isAfter(initialModifiedAt)
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/EntityKeyAware.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/EntityKeyAware.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+/**
+ * Interface for entity model classes that enables them to provide a key to help identify them, or potentially to sort
+ * them within Collections.
+ */
+interface EntityKeyAware {
+
+  fun key(): String
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
@@ -82,6 +82,7 @@ class InPrisonInterestsEntity(
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
 ) {
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
@@ -133,7 +134,10 @@ class InPrisonWorkInterestEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-) {
+) : EntityKeyAware {
+
+  override fun key(): String = workType!!.name
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
@@ -185,7 +189,10 @@ class InPrisonTrainingInterestEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-) {
+) : EntityKeyAware {
+
+  override fun key(): String = trainingType!!.name
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
@@ -84,6 +84,7 @@ class PersonalSkillsAndInterestsEntity(
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
 ) {
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
@@ -135,7 +136,10 @@ class PersonalSkillEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-) {
+) : EntityKeyAware {
+
+  override fun key(): String = skillType!!.name
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
@@ -187,7 +191,10 @@ class PersonalInterestEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null,
-) {
+) : EntityKeyAware {
+
+  override fun key(): String = interestType!!.name
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityListManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityListManager.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Dom
 
 /**
  * Provides a centralised place to update, add or remove existing JPA entities (and thereby apply changes to the
- * database). Manages changes between lists of domain model objects (provided via the REST API) and the equivalent
+ * database). Manages changes between lists of domain model objects (provided via the external API) and the equivalent
  * lists of existing JPA entities.
  */
 @Component

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityListManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityListManager.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.EntityKeyAware
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.DomainKeyAware
+
+/**
+ * Provides a centralised place to update, add or remove existing JPA entities (and thereby apply changes to the
+ * database). Manages changes between lists of domain model objects (provided via the REST API) and the equivalent
+ * lists of existing JPA entities.
+ */
+@Component
+class InductionEntityListManager<ENTITY : EntityKeyAware, DOMAIN : DomainKeyAware> {
+
+  fun updateExisting(
+    existingEntities: MutableList<ENTITY>,
+    updatedDomain: List<DOMAIN>,
+    mapper: KeyAwareEntityMapper<ENTITY, DOMAIN>,
+  ) {
+    val updatedDomainKeys = updatedDomain.map { it.key() }
+    existingEntities
+      .filter { entity -> updatedDomainKeys.contains(entity.key()) }
+      .onEach { entity ->
+        mapper.updateEntityFromDomain(
+          entity,
+          updatedDomain.first { dto -> dto.key() == entity.key() },
+        )
+      }
+  }
+
+  fun addNew(
+    existingEntities: MutableList<ENTITY>,
+    updatedDomain: List<DOMAIN>,
+    mapper: KeyAwareEntityMapper<ENTITY, DOMAIN>,
+  ) {
+    val currentIdentifiers = existingEntities.map { it.key() }
+
+    val newEntities = updatedDomain
+      .filter { dto -> !currentIdentifiers.contains(dto.key()) }
+      .map { newDto -> mapper.fromDomainToEntity(newDto) }
+
+    if (newEntities.isNotEmpty()) {
+      existingEntities.addAll(newEntities)
+    }
+  }
+
+  fun deleteRemoved(
+    existingEntities: MutableList<ENTITY>,
+    updatedDomain: List<DOMAIN>,
+  ) {
+    val updatedIdentifiers = updatedDomain.map { it.key() }
+
+    val removedEntities = existingEntities.filter { entity -> !updatedIdentifiers.contains(entity.key()) }
+    if (removedEntities.isNotEmpty()) {
+      existingEntities.removeAll(removedEntities)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/KeyAwareEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/KeyAwareEntityMapper.kt
@@ -9,5 +9,5 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Dom
 interface KeyAwareEntityMapper<ENTITY : EntityKeyAware, DOMAIN : DomainKeyAware> {
   fun updateEntityFromDomain(entity: ENTITY, domain: DOMAIN)
 
-  fun fromDomainToEntity(dto: DOMAIN): ENTITY
+  fun fromDomainToEntity(domain: DOMAIN): ENTITY
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/KeyAwareEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/KeyAwareEntityMapper.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.EntityKeyAware
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.DomainKeyAware
+
+/**
+ * Interface for mapping between entity and domain objects that adhere to the 'KeyAware' interfaces.
+ */
+interface KeyAwareEntityMapper<ENTITY : EntityKeyAware, DOMAIN : DomainKeyAware> {
+  fun updateEntityFromDomain(entity: ENTITY, domain: DOMAIN)
+
+  fun fromDomainToEntity(dto: DOMAIN): ENTITY
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapperTest.kt
@@ -23,13 +23,13 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
 class InPrisonInterestsEntityMapperTest {
 
   @InjectMocks
-  private lateinit var mapper: InPrisonInterestsEntityMapperImpl
+  private val mapper = InPrisonInterestsEntityMapperImpl()
 
   @Mock
-  private lateinit var inPrisonWorkInterestEntityMapper: InPrisonWorkInterestEntityMapper
+  private lateinit var workInterestEntityMapper: InPrisonWorkInterestEntityMapper
 
   @Mock
-  private lateinit var inPrisonTrainingInterestEntityMapper: InPrisonTrainingInterestEntityMapper
+  private lateinit var trainingInterestEntityMapper: InPrisonTrainingInterestEntityMapper
 
   @Test
   fun `should map from dto to entity`() {
@@ -43,8 +43,8 @@ class InPrisonInterestsEntityMapperTest {
       createdAtPrison = "BXI",
       updatedAtPrison = "BXI",
     )
-    given(inPrisonWorkInterestEntityMapper.fromDomainToEntity(any())).willReturn(expectedInPrisonWorkInterestEntity)
-    given(inPrisonTrainingInterestEntityMapper.fromDomainToEntity(any())).willReturn(
+    given(workInterestEntityMapper.fromDomainToEntity(any())).willReturn(expectedInPrisonWorkInterestEntity)
+    given(trainingInterestEntityMapper.fromDomainToEntity(any())).willReturn(
       expectedInPrisonTrainingInterestEntity,
     )
 
@@ -58,8 +58,8 @@ class InPrisonInterestsEntityMapperTest {
       .usingRecursiveComparison()
       .ignoringFieldsMatchingRegexes(".*reference")
       .isEqualTo(expected)
-    verify(inPrisonWorkInterestEntityMapper).fromDomainToEntity(createInPrisonInterestsDto.inPrisonWorkInterests[0])
-    verify(inPrisonTrainingInterestEntityMapper).fromDomainToEntity(createInPrisonInterestsDto.inPrisonTrainingInterests[0])
+    verify(workInterestEntityMapper).fromDomainToEntity(createInPrisonInterestsDto.inPrisonWorkInterests[0])
+    verify(trainingInterestEntityMapper).fromDomainToEntity(createInPrisonInterestsDto.inPrisonTrainingInterests[0])
   }
 
   @Test
@@ -82,15 +82,15 @@ class InPrisonInterestsEntityMapperTest {
       lastUpdatedByDisplayName = inPrisonInterestsEntity.updatedByDisplayName!!,
     )
 
-    given(inPrisonWorkInterestEntityMapper.fromEntityToDomain(any())).willReturn(expectedWorkInterest)
-    given(inPrisonTrainingInterestEntityMapper.fromEntityToDomain(any())).willReturn(expectedTrainingInterest)
+    given(workInterestEntityMapper.fromEntityToDomain(any())).willReturn(expectedWorkInterest)
+    given(trainingInterestEntityMapper.fromEntityToDomain(any())).willReturn(expectedTrainingInterest)
 
     // When
     val actual = mapper.fromEntityToDomain(inPrisonInterestsEntity)
 
     // Then
     assertThat(actual).isEqualTo(expectedInPrisonInterests)
-    verify(inPrisonWorkInterestEntityMapper).fromEntityToDomain(inPrisonInterestsEntity.inPrisonWorkInterests!![0])
-    verify(inPrisonTrainingInterestEntityMapper).fromEntityToDomain(inPrisonInterestsEntity.inPrisonTrainingInterests!![0])
+    verify(workInterestEntityMapper).fromEntityToDomain(inPrisonInterestsEntity.inPrisonWorkInterests!![0])
+    verify(trainingInterestEntityMapper).fromEntityToDomain(inPrisonInterestsEntity.inPrisonTrainingInterests!![0])
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapperTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
 class InPrisonInterestsEntityMapperTest {
 
   @InjectMocks
-  private val mapper = InPrisonInterestsEntityMapperImpl()
+  private lateinit var mapper: InPrisonInterestsEntityMapperImpl
 
   @Mock
   private lateinit var workInterestEntityMapper: InPrisonWorkInterestEntityMapper

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateInPrisonInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateInPrisonInterestsEntityMapperTest.kt
@@ -1,11 +1,15 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
 
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInPrisonInterestsEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonTrainingInterestEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonWorkInterestEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInPrisonInterestsEntityWithJpaFieldsPopulated
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInPrisonTrainingInterestEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInPrisonWorkInterestEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.deepCopy
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonTrainingInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonWorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInPrisonTrainingInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInPrisonWorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateInPrisonInterestsDto
@@ -18,14 +22,24 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InP
 class UpdateInPrisonInterestsEntityMapperTest {
 
   private val mapper = InPrisonInterestsEntityMapperImpl().also {
-    InPrisonInterestsEntityMapper::class.java.getDeclaredField("inPrisonWorkInterestEntityMapper").apply {
+    InPrisonInterestsEntityMapper::class.java.getDeclaredField("workInterestEntityMapper").apply {
       isAccessible = true
       set(it, InPrisonWorkInterestEntityMapperImpl())
     }
 
-    InPrisonInterestsEntityMapper::class.java.getDeclaredField("inPrisonTrainingInterestEntityMapper").apply {
+    InPrisonInterestsEntityMapper::class.java.getDeclaredField("trainingInterestEntityMapper").apply {
       isAccessible = true
       set(it, InPrisonTrainingInterestEntityMapperImpl())
+    }
+
+    InPrisonInterestsEntityMapper::class.java.getDeclaredField("workInterestEntityListManager").apply {
+      isAccessible = true
+      set(it, InductionEntityListManager<InPrisonWorkInterestEntity, InPrisonWorkInterest>())
+    }
+
+    InPrisonInterestsEntityMapper::class.java.getDeclaredField("trainingInterestEntityListManager").apply {
+      isAccessible = true
+      set(it, InductionEntityListManager<InPrisonTrainingInterestEntity, InPrisonTrainingInterest>())
     }
   }
 
@@ -45,11 +59,12 @@ class UpdateInPrisonInterestsEntityMapperTest {
       trainingTypeOther = "Any training I can get",
     )
     val inPrisonInterestsReference = UUID.randomUUID()
-    val existingInPrisonInterestsEntity = aValidInPrisonInterestsEntity(
+    val existingInPrisonInterestsEntity = aValidInPrisonInterestsEntityWithJpaFieldsPopulated(
       reference = inPrisonInterestsReference,
       inPrisonWorkInterests = mutableListOf(existingWorkInterestEntity),
       inPrisonTrainingInterests = mutableListOf(existingTrainingInterestEntity),
     )
+    val initialUpdatedAt = existingInPrisonInterestsEntity.updatedAt!!
 
     val updatedWorkInterest = aValidInPrisonWorkInterest(
       workType = InPrisonWorkTypeDomain.OTHER,
@@ -89,7 +104,9 @@ class UpdateInPrisonInterestsEntityMapperTest {
     mapper.updateEntityFromDto(existingInPrisonInterestsEntity, updatedInterestsDto)
 
     // Then
-    assertThat(existingInPrisonInterestsEntity).isEqualToComparingAllFields(expectedEntity)
+    assertThat(existingInPrisonInterestsEntity).isEqualToIgnoringInternallyManagedFields(expectedEntity)
+    // TODO RR-469 - fix updatedAt timestamp
+    // assertThat(existingInPrisonInterestsEntity).wasUpdatedAfter(initialUpdatedAt)
   }
 
   @Test
@@ -108,11 +125,12 @@ class UpdateInPrisonInterestsEntityMapperTest {
       trainingTypeOther = "Any training I can get",
     )
     val inPrisonInterestsReference = UUID.randomUUID()
-    val existingInPrisonInterestsEntity = aValidInPrisonInterestsEntity(
+    val existingInPrisonInterestsEntity = aValidInPrisonInterestsEntityWithJpaFieldsPopulated(
       reference = inPrisonInterestsReference,
       inPrisonWorkInterests = mutableListOf(existingWorkInterestEntity),
       inPrisonTrainingInterests = mutableListOf(existingTrainingInterestEntity),
     )
+    val initialUpdatedAt = existingInPrisonInterestsEntity.updatedAt!!
 
     val existingWorkInterest = aValidInPrisonWorkInterest(
       workType = InPrisonWorkTypeDomain.OTHER,
@@ -169,6 +187,8 @@ class UpdateInPrisonInterestsEntityMapperTest {
 
     // Then
     assertThat(existingInPrisonInterestsEntity).isEqualToIgnoringInternallyManagedFields(expectedEntity)
+    // TODO RR-469 - fix updatedAt timestamp
+    // assertThat(existingInPrisonInterestsEntity).wasUpdatedAfter(initialUpdatedAt)
   }
 
   @Test
@@ -195,11 +215,12 @@ class UpdateInPrisonInterestsEntityMapperTest {
       trainingTypeOther = null,
     )
     val inPrisonInterestsReference = UUID.randomUUID()
-    val existingInPrisonInterestsEntity = aValidInPrisonInterestsEntity(
+    val existingInPrisonInterestsEntity = aValidInPrisonInterestsEntityWithJpaFieldsPopulated(
       reference = inPrisonInterestsReference,
       inPrisonWorkInterests = mutableListOf(firstWorkInterestEntity, secondWorkInterestEntity),
       inPrisonTrainingInterests = mutableListOf(firstTrainingInterestEntity, secondTrainingInterestEntity),
     )
+    val initialUpdatedAt = existingInPrisonInterestsEntity.updatedAt!!
 
     val existingWorkInterest = aValidInPrisonWorkInterest(
       workType = InPrisonWorkTypeDomain.OTHER,
@@ -229,6 +250,8 @@ class UpdateInPrisonInterestsEntityMapperTest {
     mapper.updateEntityFromDto(existingInPrisonInterestsEntity, updatedInterestsDto)
 
     // Then
-    assertThat(existingInPrisonInterestsEntity).isEqualToComparingAllFields(expectedEntity)
+    assertThat(existingInPrisonInterestsEntity).isEqualToIgnoringInternallyManagedFields(expectedEntity)
+    // TODO RR-469 - fix updatedAt timestamp
+    // assertThat(existingInPrisonInterestsEntity).wasUpdatedAfter(initialUpdatedAt)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateInPrisonInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateInPrisonInterestsEntityMapperTest.kt
@@ -64,7 +64,7 @@ class UpdateInPrisonInterestsEntityMapperTest {
       inPrisonWorkInterests = mutableListOf(existingWorkInterestEntity),
       inPrisonTrainingInterests = mutableListOf(existingTrainingInterestEntity),
     )
-    val initialUpdatedAt = existingInPrisonInterestsEntity.updatedAt!!
+    // val initialUpdatedAt = existingInPrisonInterestsEntity.updatedAt!!
 
     val updatedWorkInterest = aValidInPrisonWorkInterest(
       workType = InPrisonWorkTypeDomain.OTHER,
@@ -130,7 +130,7 @@ class UpdateInPrisonInterestsEntityMapperTest {
       inPrisonWorkInterests = mutableListOf(existingWorkInterestEntity),
       inPrisonTrainingInterests = mutableListOf(existingTrainingInterestEntity),
     )
-    val initialUpdatedAt = existingInPrisonInterestsEntity.updatedAt!!
+    // val initialUpdatedAt = existingInPrisonInterestsEntity.updatedAt!!
 
     val existingWorkInterest = aValidInPrisonWorkInterest(
       workType = InPrisonWorkTypeDomain.OTHER,
@@ -220,7 +220,7 @@ class UpdateInPrisonInterestsEntityMapperTest {
       inPrisonWorkInterests = mutableListOf(firstWorkInterestEntity, secondWorkInterestEntity),
       inPrisonTrainingInterests = mutableListOf(firstTrainingInterestEntity, secondTrainingInterestEntity),
     )
-    val initialUpdatedAt = existingInPrisonInterestsEntity.updatedAt!!
+    // val initialUpdatedAt = existingInPrisonInterestsEntity.updatedAt!!
 
     val existingWorkInterest = aValidInPrisonWorkInterest(
       workType = InPrisonWorkTypeDomain.OTHER,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePersonalSkillsAndInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePersonalSkillsAndInterestsEntityMapperTest.kt
@@ -1,11 +1,15 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
 
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PersonalInterestEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PersonalSkillEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPersonalInterestEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPersonalSkillEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPersonalSkillsAndInterestsEntityWithJpaFieldsPopulated
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.deepCopy
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkill
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPersonalInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPersonalSkill
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePersonalSkillsAndInterestsDto
@@ -26,6 +30,16 @@ class UpdatePersonalSkillsAndInterestsEntityMapperTest {
     PersonalSkillsAndInterestsEntityMapper::class.java.getDeclaredField("personalInterestEntityMapper").apply {
       isAccessible = true
       set(it, PersonalInterestEntityMapperImpl())
+    }
+
+    PersonalSkillsAndInterestsEntityMapper::class.java.getDeclaredField("personalSkillEntityListManager").apply {
+      isAccessible = true
+      set(it, InductionEntityListManager<PersonalSkillEntity, PersonalSkill>())
+    }
+
+    PersonalSkillsAndInterestsEntityMapper::class.java.getDeclaredField("personalInterestEntityListManager").apply {
+      isAccessible = true
+      set(it, InductionEntityListManager<PersonalInterestEntity, PersonalInterest>())
     }
   }
 
@@ -50,6 +64,7 @@ class UpdatePersonalSkillsAndInterestsEntityMapperTest {
       skills = mutableListOf(existingSkillEntity),
       interests = mutableListOf(existingInterestEntity),
     )
+    val initialUpdatedAt = existingSkillsAndInterestsEntity.updatedAt!!
 
     val updatedSkill = aValidPersonalSkill(
       skillType = SkillTypeDomain.OTHER,
@@ -89,7 +104,9 @@ class UpdatePersonalSkillsAndInterestsEntityMapperTest {
     mapper.updateEntityFromDto(existingSkillsAndInterestsEntity, updateDto)
 
     // Then
-    assertThat(existingSkillsAndInterestsEntity).isEqualToComparingAllFields(expectedEntity)
+    assertThat(existingSkillsAndInterestsEntity).isEqualToIgnoringInternallyManagedFields(expectedEntity)
+    // TODO RR-469 - fix updatedAt timestamp
+    // assertThat(existingSkillsAndInterestsEntity).wasUpdatedAfter(initialUpdatedAt)
   }
 
   @Test
@@ -113,6 +130,7 @@ class UpdatePersonalSkillsAndInterestsEntityMapperTest {
       skills = mutableListOf(existingSkillEntity),
       interests = mutableListOf(existingInterestEntity),
     )
+    val initialUpdatedAt = existingSkillsAndInterestsEntity.updatedAt!!
 
     val existingSkill = aValidPersonalSkill(
       skillType = SkillTypeDomain.OTHER,
@@ -169,6 +187,8 @@ class UpdatePersonalSkillsAndInterestsEntityMapperTest {
 
     // Then
     assertThat(existingSkillsAndInterestsEntity).isEqualToIgnoringInternallyManagedFields(expectedEntity)
+    // TODO RR-469 - fix updatedAt timestamp
+    // assertThat(existingSkillsAndInterestsEntity).wasUpdatedAfter(initialUpdatedAt)
   }
 
   @Test
@@ -200,6 +220,7 @@ class UpdatePersonalSkillsAndInterestsEntityMapperTest {
       skills = mutableListOf(firstSkillEntity, secondSkillEntity),
       interests = mutableListOf(firstInterestEntity, secondInterestEntity),
     )
+    val initialUpdatedAt = existingSkillsAndInterestsEntity.updatedAt!!
 
     val existingSkill = aValidPersonalSkill(
       skillType = SkillTypeDomain.RESILIENCE,
@@ -229,6 +250,8 @@ class UpdatePersonalSkillsAndInterestsEntityMapperTest {
     mapper.updateEntityFromDto(existingSkillsAndInterestsEntity, updateDto)
 
     // Then
-    assertThat(existingSkillsAndInterestsEntity).isEqualToComparingAllFields(expectedEntity)
+    assertThat(existingSkillsAndInterestsEntity).isEqualToIgnoringInternallyManagedFields(expectedEntity)
+    // TODO RR-469 - fix updatedAt timestamp
+    // assertThat(existingSkillsAndInterestsEntity).wasUpdatedAfter(initialUpdatedAt)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePersonalSkillsAndInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePersonalSkillsAndInterestsEntityMapperTest.kt
@@ -64,7 +64,7 @@ class UpdatePersonalSkillsAndInterestsEntityMapperTest {
       skills = mutableListOf(existingSkillEntity),
       interests = mutableListOf(existingInterestEntity),
     )
-    val initialUpdatedAt = existingSkillsAndInterestsEntity.updatedAt!!
+    // val initialUpdatedAt = existingSkillsAndInterestsEntity.updatedAt!!
 
     val updatedSkill = aValidPersonalSkill(
       skillType = SkillTypeDomain.OTHER,
@@ -130,7 +130,7 @@ class UpdatePersonalSkillsAndInterestsEntityMapperTest {
       skills = mutableListOf(existingSkillEntity),
       interests = mutableListOf(existingInterestEntity),
     )
-    val initialUpdatedAt = existingSkillsAndInterestsEntity.updatedAt!!
+    // val initialUpdatedAt = existingSkillsAndInterestsEntity.updatedAt!!
 
     val existingSkill = aValidPersonalSkill(
       skillType = SkillTypeDomain.OTHER,
@@ -220,7 +220,7 @@ class UpdatePersonalSkillsAndInterestsEntityMapperTest {
       skills = mutableListOf(firstSkillEntity, secondSkillEntity),
       interests = mutableListOf(firstInterestEntity, secondInterestEntity),
     )
-    val initialUpdatedAt = existingSkillsAndInterestsEntity.updatedAt!!
+    // val initialUpdatedAt = existingSkillsAndInterestsEntity.updatedAt!!
 
     val existingSkill = aValidPersonalSkill(
       skillType = SkillTypeDomain.RESILIENCE,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntityAssert.kt
@@ -91,6 +91,16 @@ class InPrisonInterestsEntityAssert(actual: InPrisonInterestsEntity?) :
     return this
   }
 
+  fun wasUpdatedAfter(dateTime: Instant): InPrisonInterestsEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt!!.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
   fun hasAReference(): InPrisonInterestsEntityAssert {
     isNotNull
     with(actual!!) {

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntityAssert.kt
@@ -91,6 +91,16 @@ class PersonalSkillsAndInterestsEntityAssert(actual: PersonalSkillsAndInterestsE
     return this
   }
 
+  fun wasUpdatedAfter(dateTime: Instant): PersonalSkillsAndInterestsEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt!!.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
   fun hasAReference(): PersonalSkillsAndInterestsEntityAssert {
     isNotNull
     with(actual!!) {


### PR DESCRIPTION
This PR introduces `InductionEntityListManager`, which provides a centralised place for updating lists within Induction entities.

To minimise the size of this PR, I'm just starting with `InPrisonInterestsEntity` and `PersonalSkillsAndInterestsEntity`. I'll apply this approach to the remaining entities in subsequent PRs.

I might consider extending this for lists of entities outside of the Induction domain (primarily for Steps), but that would require a common module, which is shared between the domain model and is beyond the scope of this PR.