### PR TITLE
RR-493 - Fix mapping when initial object is null

### DIFF
--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/Induction.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/Induction.kt
@@ -28,10 +28,10 @@ data class Induction(
    */
   val previousQualifications: PreviousQualifications?,
   /**
-   * Any additional training that the Prisoner may have done previously. Null if the Prisoner has not been asked about
-   * their additional training.
+   * Any additional training that the Prisoner may have done previously. Mandatory as the Prisoner is always asked about
+   * it.
    */
-  val previousTraining: PreviousTraining?,
+  val previousTraining: PreviousTraining,
   /**
    * Details of any previous work experience that the Prisoner may have had. Null if the Prisoner has not been asked
    * about their work history.

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateFutureWorkInterestsDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateFutureWorkInterestsDto.kt
@@ -4,7 +4,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Wor
 import java.util.UUID
 
 data class UpdateFutureWorkInterestsDto(
-  val reference: UUID,
+  val reference: UUID?,
   val interests: List<WorkInterest>,
   val prisonId: String,
 )

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateInPrisonInterestsDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateInPrisonInterestsDto.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InP
 import java.util.UUID
 
 data class UpdateInPrisonInterestsDto(
-  val reference: UUID,
+  val reference: UUID?,
   val inPrisonWorkInterests: List<InPrisonWorkInterest>,
   val inPrisonTrainingInterests: List<InPrisonTrainingInterest>,
   val prisonId: String,

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePersonalSkillsAndInterestsDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePersonalSkillsAndInterestsDto.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Per
 import java.util.UUID
 
 data class UpdatePersonalSkillsAndInterestsDto(
-  val reference: UUID,
+  val reference: UUID?,
   val skills: List<PersonalSkill>,
   val interests: List<PersonalInterest>,
   val prisonId: String,

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousQualificationsDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousQualificationsDto.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Qua
 import java.util.UUID
 
 data class UpdatePreviousQualificationsDto(
-  val reference: UUID,
+  val reference: UUID?,
   val educationLevel: HighestEducationLevel?,
   val qualifications: List<Qualification>,
   val prisonId: String,

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousTrainingDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousTrainingDto.kt
@@ -4,7 +4,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Tra
 import java.util.UUID
 
 data class UpdatePreviousTrainingDto(
-  val reference: UUID,
+  val reference: UUID?,
   val trainingTypes: List<TrainingType>,
   val trainingTypeOther: String?,
   val prisonId: String,

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousWorkExperiencesDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdatePreviousWorkExperiencesDto.kt
@@ -4,7 +4,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Wor
 import java.util.UUID
 
 data class UpdatePreviousWorkExperiencesDto(
-  val reference: UUID,
+  val reference: UUID?,
   val experiences: List<WorkExperience>,
   val prisonId: String,
 )

--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateWorkOnReleaseDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateWorkOnReleaseDto.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Not
 import java.util.UUID
 
 data class UpdateWorkOnReleaseDto(
-  val reference: UUID,
+  val reference: UUID?,
   val hopingToWork: HopingToWork,
   val notHopingToWorkReasons: List<NotHopingToWorkReason>,
   val notHopingToWorkOtherReason: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapper.kt
@@ -62,6 +62,24 @@ abstract class FutureWorkInterestsEntityMapper {
     dto: UpdateFutureWorkInterestsDto?,
   )
 
+  @ExcludeJpaManagedFieldsIncludingDisplayNameFields
+  @GenerateNewReference
+  @Mapping(target = "createdAtPrison", source = "prisonId")
+  @Mapping(target = "updatedAtPrison", source = "prisonId")
+  @Mapping(target = "interests", ignore = true)
+  abstract fun fromUpdateDtoToEntity(dto: UpdateFutureWorkInterestsDto?): FutureWorkInterestsEntity
+
+  @AfterMapping
+  fun addInterests(dto: UpdateFutureWorkInterestsDto, @MappingTarget entity: FutureWorkInterestsEntity) {
+    val existingTypes = entity.interests?.map { it.key() }
+    dto.interests.forEach {
+      // ensure we only add new interests
+      if (existingTypes == null || !existingTypes.contains(it.key())) {
+        entity.addChild(workInterestEntityMapper.fromDomainToEntity(it), entity.interests())
+      }
+    }
+  }
+
   fun updateInterests(entity: FutureWorkInterestsEntity, dto: UpdateFutureWorkInterestsDto): List<WorkInterestEntity> {
     val existingInterests = entity.interests!!
     val updatedInterests = dto.interests

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapper.kt
@@ -39,7 +39,7 @@ abstract class InductionEntityMapper {
   private lateinit var inPrisonInterestsEntityMapper: InPrisonInterestsEntityMapper
 
   @Autowired
-  private lateinit var personalSkillsAndInterestsEntityMapper: PersonalSkillsAndInterestsEntityMapper
+  private lateinit var skillsAndInterestsEntityMapper: PersonalSkillsAndInterestsEntityMapper
 
   @Autowired
   private lateinit var previousQualificationsEntityMapper: PreviousQualificationsEntityMapper
@@ -48,7 +48,7 @@ abstract class InductionEntityMapper {
   private lateinit var previousTrainingEntityMapper: PreviousTrainingEntityMapper
 
   @Autowired
-  private lateinit var previousWorkExperiencesEntityMapper: PreviousWorkExperiencesEntityMapper
+  private lateinit var workExperiencesEntityMapper: PreviousWorkExperiencesEntityMapper
 
   @Autowired
   private lateinit var workOnReleaseEntityMapper: WorkOnReleaseEntityMapper
@@ -78,31 +78,61 @@ abstract class InductionEntityMapper {
   @Mapping(target = "workOnRelease", expression = "java( updateWorkOnRelease(entity, dto) )")
   abstract fun updateEntityFromDto(@MappingTarget entity: InductionEntity, dto: UpdateInductionDto)
 
-  fun updateFutureWorkInterests(entity: InductionEntity, dto: UpdateInductionDto): FutureWorkInterestsEntity? =
-    futureWorkInterestsEntityMapper.updateEntityFromDto(entity.futureWorkInterests, dto.futureWorkInterests)
-      .let { entity.futureWorkInterests }
+  fun updateFutureWorkInterests(entity: InductionEntity, dto: UpdateInductionDto): FutureWorkInterestsEntity? {
+    return if (entity.futureWorkInterests == null) {
+      futureWorkInterestsEntityMapper.fromUpdateDtoToEntity(dto.futureWorkInterests)
+    } else {
+      futureWorkInterestsEntityMapper.updateEntityFromDto(entity.futureWorkInterests, dto.futureWorkInterests)
+        .let { entity.futureWorkInterests }
+    }
+  }
 
-  fun updateInPrisonInterests(entity: InductionEntity, dto: UpdateInductionDto): InPrisonInterestsEntity? =
-    inPrisonInterestsEntityMapper.updateEntityFromDto(entity.inPrisonInterests, dto.inPrisonInterests)
-      .let { entity.inPrisonInterests }
+  fun updateInPrisonInterests(entity: InductionEntity, dto: UpdateInductionDto): InPrisonInterestsEntity? {
+    return if (entity.inPrisonInterests == null) {
+      inPrisonInterestsEntityMapper.fromUpdateDtoToEntity(dto.inPrisonInterests)
+    } else {
+      inPrisonInterestsEntityMapper.updateEntityFromDto(entity.inPrisonInterests, dto.inPrisonInterests)
+        .let { entity.inPrisonInterests }
+    }
+  }
 
-  fun updatePersonalSkillsAndInterests(entity: InductionEntity, dto: UpdateInductionDto): PersonalSkillsAndInterestsEntity? =
-    personalSkillsAndInterestsEntityMapper.updateEntityFromDto(entity.personalSkillsAndInterests, dto.personalSkillsAndInterests)
-      .let { entity.personalSkillsAndInterests }
+  fun updatePersonalSkillsAndInterests(entity: InductionEntity, dto: UpdateInductionDto): PersonalSkillsAndInterestsEntity? {
+    return if (entity.personalSkillsAndInterests == null) {
+      skillsAndInterestsEntityMapper.fromUpdateDtoToEntity(dto.personalSkillsAndInterests)
+    } else {
+      skillsAndInterestsEntityMapper.updateEntityFromDto(entity.personalSkillsAndInterests, dto.personalSkillsAndInterests)
+        .let { entity.personalSkillsAndInterests }
+    }
+  }
 
-  fun updatePreviousQualifications(entity: InductionEntity, dto: UpdateInductionDto): PreviousQualificationsEntity? =
-    previousQualificationsEntityMapper.updateEntityFromDto(entity.previousQualifications, dto.previousQualifications)
-      .let { entity.previousQualifications }
+  fun updatePreviousQualifications(entity: InductionEntity, dto: UpdateInductionDto): PreviousQualificationsEntity? {
+    return if (entity.previousQualifications == null) {
+      previousQualificationsEntityMapper.fromUpdateDtoToEntity(dto.previousQualifications)
+    } else {
+      previousQualificationsEntityMapper.updateEntityFromDto(entity.previousQualifications, dto.previousQualifications)
+        .let { entity.previousQualifications }
+    }
+  }
 
-  fun updatePreviousTraining(entity: InductionEntity, dto: UpdateInductionDto): PreviousTrainingEntity? =
-    previousTrainingEntityMapper.updateEntityFromDto(entity.previousTraining, dto.previousTraining)
-      .let { entity.previousTraining }
+  fun updatePreviousTraining(entity: InductionEntity, dto: UpdateInductionDto): PreviousTrainingEntity? {
+    return if (entity.previousTraining == null) {
+      previousTrainingEntityMapper.fromUpdateDtoToEntity(dto.previousTraining)
+    } else {
+      previousTrainingEntityMapper.updateEntityFromDto(entity.previousTraining, dto.previousTraining)
+        .let { entity.previousTraining }
+    }
+  }
 
-  fun updatePreviousWorkExperiences(entity: InductionEntity, dto: UpdateInductionDto): PreviousWorkExperiencesEntity? =
-    previousWorkExperiencesEntityMapper.updateEntityFromDto(entity.previousWorkExperiences, dto.previousWorkExperiences)
-      .let { entity.previousWorkExperiences }
+  fun updatePreviousWorkExperiences(entity: InductionEntity, dto: UpdateInductionDto): PreviousWorkExperiencesEntity? {
+    return if (entity.previousWorkExperiences == null) {
+      workExperiencesEntityMapper.fromUpdateDtoToEntity(dto.previousWorkExperiences)
+    } else {
+      workExperiencesEntityMapper.updateEntityFromDto(entity.previousWorkExperiences, dto.previousWorkExperiences)
+        .let { entity.previousWorkExperiences }
+    }
+  }
 
   fun updateWorkOnRelease(entity: InductionEntity, dto: UpdateInductionDto): WorkOnReleaseEntity? =
-    workOnReleaseEntityMapper.updateEntityFromDto(entity.workOnRelease, dto.workOnRelease)
+    workOnReleaseEntityMapper.updateEntityFromDto(entity.workOnRelease!!, dto.workOnRelease)
       .let { entity.workOnRelease }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapper.kt
@@ -76,6 +76,27 @@ abstract class PreviousQualificationsEntityMapper {
 
     return existingQualifications
   }
+
+  @ExcludeJpaManagedFieldsIncludingDisplayNameFields
+  @GenerateNewReference
+  @Mapping(target = "createdAtPrison", source = "prisonId")
+  @Mapping(target = "updatedAtPrison", source = "prisonId")
+  @Mapping(target = "qualifications", ignore = true)
+  abstract fun fromUpdateDtoToEntity(previousQualifications: UpdatePreviousQualificationsDto?): PreviousQualificationsEntity?
+
+  @AfterMapping
+  fun addQualifications(dto: UpdatePreviousQualificationsDto, @MappingTarget entity: PreviousQualificationsEntity) {
+    val existingSubjects = entity.qualifications().map { it.key() }
+    dto.qualifications.forEach {
+      // ensure we only add new ones
+      if (!existingSubjects.contains(it.key())) {
+        entity.addChild(
+          qualificationEntityMapper.fromDomainToEntity(it),
+          entity.qualifications(),
+        )
+      }
+    }
+  }
 }
 
 @Mapper

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapper.kt
@@ -37,6 +37,12 @@ interface PreviousTrainingEntityMapper {
   @Mapping(target = "createdAtPrison", ignore = true)
   @Mapping(target = "updatedAtPrison", source = "prisonId")
   fun updateEntityFromDto(@MappingTarget entity: PreviousTrainingEntity?, dto: UpdatePreviousTrainingDto?)
+
+  @ExcludeJpaManagedFieldsIncludingDisplayNameFields
+  @GenerateNewReference
+  @Mapping(target = "createdAtPrison", source = "prisonId")
+  @Mapping(target = "updatedAtPrison", source = "prisonId")
+  fun fromUpdateDtoToEntity(previousTraining: UpdatePreviousTrainingDto?): PreviousTrainingEntity?
 }
 
 @Mapper

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/WorkOnReleaseEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/WorkOnReleaseEntityMapper.kt
@@ -30,5 +30,5 @@ interface WorkOnReleaseEntityMapper {
   @ExcludeReferenceField
   @Mapping(target = "createdAtPrison", ignore = true)
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun updateEntityFromDto(@MappingTarget entity: WorkOnReleaseEntity?, dto: UpdateWorkOnReleaseDto?)
+  fun updateEntityFromDto(@MappingTarget entity: WorkOnReleaseEntity, dto: UpdateWorkOnReleaseDto)
 }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.4.7'
+  version: '1.4.8'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -1163,7 +1163,6 @@ components:
         workInterests:
           $ref: '#/components/schemas/WorkInterests'
       required:
-        - id
         - hasWorkedBefore
 
     UpdateSkillsAndInterestsRequest:
@@ -1176,8 +1175,6 @@ components:
           format: uuid
           description: A unique reference for this Prisoner's personal skills and interests.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
-      required:
-        - id
 
     UpdateEducationAndQualificationsRequest:
       description: A request to update a Prisoner's education and qualifications. Migrated from hmpps-ciag-careers-induction-api.
@@ -1190,8 +1187,6 @@ components:
           format: uuid
           description: A unique reference for this Prisoner's education and qualifications.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
-      required:
-        - id
 
     UpdatePrisonWorkAndEducationRequest:
       description: A request to update a Prisoner's in-prison work and education interests. Migrated from hmpps-ciag-careers-induction-api.
@@ -1203,8 +1198,6 @@ components:
           format: uuid
           description: A unique reference for this Prisoner's in-prison work and education interests.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
-      required:
-        - id
 
     WorkExperience:
       description: A Prisoner's list of work experience details. Migrated from hmpps-ciag-careers-induction-api.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapperTest.kt
@@ -193,6 +193,6 @@ class InductionEntityMapperTest {
     verify(previousQualificationsEntityMapper).updateEntityFromDto(existingInductionEntity.previousQualifications, updateInductionDto.previousQualifications)
     verify(previousTrainingEntityMapper).updateEntityFromDto(existingInductionEntity.previousTraining, updateInductionDto.previousTraining)
     verify(previousWorkExperiencesEntityMapper).updateEntityFromDto(existingInductionEntity.previousWorkExperiences, updateInductionDto.previousWorkExperiences)
-    verify(workOnReleaseEntityMapper).updateEntityFromDto(existingInductionEntity.workOnRelease, updateInductionDto.workOnRelease)
+    verify(workOnReleaseEntityMapper).updateEntityFromDto(existingInductionEntity.workOnRelease!!, updateInductionDto.workOnRelease)
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/EducationAndQualificationsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/EducationAndQualificationsRequestBuilder.kt
@@ -23,7 +23,7 @@ fun aValidCreateEducationAndQualificationsRequest(
 )
 
 fun aValidUpdateEducationAndQualificationsRequest(
-  id: UUID = UUID.randomUUID(),
+  id: UUID? = UUID.randomUUID(),
   educationLevel: HighestEducationLevel? = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
   qualifications: Set<AchievedQualification>? = setOf(
     aValidAchievedQualification(),

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkRequestBuilder.kt
@@ -24,7 +24,7 @@ fun aValidCreatePreviousWorkRequest(
   )
 
 fun aValidUpdatePreviousWorkRequest(
-  id: UUID = UUID.randomUUID(),
+  id: UUID? = UUID.randomUUID(),
   hasWorkedBefore: Boolean = true,
   typeOfWorkExperience: Set<WorkType>? = setOf(WorkType.OTHER),
   typeOfWorkExperienceOther: String? = "Scientist",

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PrisonWorkAndEducationRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PrisonWorkAndEducationRequestBuilder.kt
@@ -18,7 +18,7 @@ fun aValidCreatePrisonWorkAndEducationRequest(
   )
 
 fun aValidUpdatePrisonWorkAndEducationRequest(
-  id: UUID = UUID.randomUUID(),
+  id: UUID? = UUID.randomUUID(),
   inPrisonWork: Set<InPrisonWorkType>? = setOf(InPrisonWorkType.OTHER),
   inPrisonWorkOther: String? = "Any in-prison work",
   inPrisonEducation: Set<InPrisonTrainingType>? = setOf(InPrisonTrainingType.OTHER),

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/SkillsAndInterestsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/SkillsAndInterestsRequestBuilder.kt
@@ -20,7 +20,7 @@ fun aValidCreateSkillsAndInterestsRequest(
   )
 
 fun aValidUpdateSkillsAndInterestsRequest(
-  id: UUID = UUID.randomUUID(),
+  id: UUID? = UUID.randomUUID(),
   skills: Set<PersonalSkill>? = setOf(PersonalSkill.OTHER),
   skillsOther: String? = "Hidden skills",
   personalInterests: Set<PersonalInterest>? = setOf(PersonalInterest.OTHER),


### PR DESCRIPTION
This PR fixes an issue where the domain objects could not be updated if they were null originally. It also ensures that a reference is not mandatory in the incoming update request objects!

Some of the logic is quite complex, so I've added comments to try and explain it.