### PR TITLE
RR-493 - Missing "modified" fields and optional reference field

### DIFF
--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateInductionDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateInductionDto.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dt
 import java.util.UUID
 
 data class UpdateInductionDto(
-  val reference: UUID,
+  val reference: UUID?,
   val prisonNumber: String,
   val workOnRelease: UpdateWorkOnReleaseDto,
   val previousQualifications: UpdatePreviousQualificationsDto?,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -43,8 +43,9 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induc
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateEducationAndQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateSkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkExperienceResource
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterests
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterestsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.isEquivalentTo
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
@@ -102,7 +103,7 @@ class UpdateInductionTest : IntegrationTestBase() {
     assertThat(actual)
       .hasStatus(HttpStatus.BAD_REQUEST.value())
       .hasUserMessageContaining("JSON parse error")
-      .hasUserMessageContaining("value failed for JSON property reference due to missing (therefore NULL) value for creator parameter reference")
+      .hasUserMessageContaining("value failed for JSON property prisonId due to missing (therefore NULL) value for creator parameter prisonId")
   }
 
   @Test
@@ -138,7 +139,7 @@ class UpdateInductionTest : IntegrationTestBase() {
     val createdDateTime = persistedInduction.createdDateTime
     val initialModifiedAt = persistedInduction.modifiedDateTime
     val updateInductionRequest = aValidUpdateCiagInductionRequest(
-      reference = persistedInduction.reference,
+      reference = null,
       hopingToGetWork = HopingToWork.YES,
       prisonId = "MDI",
       abilityToWork = null,
@@ -157,7 +158,7 @@ class UpdateInductionTest : IntegrationTestBase() {
             details = "General brick work",
           ),
         ),
-        workInterests = aValidWorkInterests(
+        workInterests = aValidUpdateWorkInterestsRequest(
           id = persistedInduction.workExperience!!.workInterests!!.id,
           workInterests = setOf(WorkType.SPORTS),
           workInterestsOther = null,
@@ -204,7 +205,7 @@ class UpdateInductionTest : IntegrationTestBase() {
           details = "General brick work",
         ),
       ),
-      workInterests = aValidWorkInterests(
+      workInterests = aValidWorkInterestsResponse(
         id = persistedInduction.workExperience!!.workInterests!!.id,
         workInterests = setOf(WorkType.SPORTS),
         workInterestsOther = null,
@@ -214,6 +215,7 @@ class UpdateInductionTest : IntegrationTestBase() {
             role = "Football coach",
           ),
         ),
+        modifiedBy = "auser_gen",
       ),
       modifiedBy = "auser_gen",
     )
@@ -241,6 +243,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       inPrisonEducationOther = null,
       modifiedBy = "auser_gen",
     )
+    shortDelayForTimestampChecking()
 
     // When
     webTestClient.put()
@@ -270,6 +273,7 @@ class UpdateInductionTest : IntegrationTestBase() {
     assertThat(updatedInduction.inPrisonInterests).isEquivalentTo(expectedInPrisonInterests)
     // check last modified dates of child objects
     assertThat(updatedInduction.workExperience!!.modifiedDateTime).isAfter(initialModifiedAt)
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isAfter(initialModifiedAt)
     assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isAfter(initialModifiedAt)
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isAfter(initialModifiedAt)
     assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isAfter(initialModifiedAt)
@@ -325,10 +329,11 @@ class UpdateInductionTest : IntegrationTestBase() {
       .wasCreatedAt(createdDateTime)
       .wasLastModifiedAfter(initialModifiedAt)
     // check last modified dates of child objects
-    assertThat(updatedInduction.workExperience!!.modifiedDateTime).isAfter(initialModifiedAt)
-    assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isAfter(initialModifiedAt)
-    assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isAfter(initialModifiedAt)
-    assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isAfter(initialModifiedAt)
+    assertThat(updatedInduction.workExperience!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
+    assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
+    assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
+    assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
   }
 
   @Test
@@ -382,6 +387,7 @@ class UpdateInductionTest : IntegrationTestBase() {
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isAfter(initialModifiedAt)
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.workExperience!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
   }
@@ -451,12 +457,13 @@ class UpdateInductionTest : IntegrationTestBase() {
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isAfter(initialModifiedAt)
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.workExperience!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
   }
 
   @Test
-  fun `should update induction with no previous work experience`() {
+  fun `should update induction with no previous work experience and modified work interests`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     createInduction(prisonNumber, aValidCreateCiagInductionRequest())
@@ -471,7 +478,7 @@ class UpdateInductionTest : IntegrationTestBase() {
         typeOfWorkExperience = null,
         typeOfWorkExperienceOther = null,
         workExperience = null,
-        workInterests = aValidWorkInterests(
+        workInterests = aValidUpdateWorkInterestsRequest(
           id = persistedInduction.workExperience!!.workInterests!!.id,
           workInterests = setOf(WorkType.SPORTS),
           workInterestsOther = null,
@@ -491,7 +498,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       typeOfWorkExperience = null,
       typeOfWorkExperienceOther = null,
       workExperience = null,
-      workInterests = aValidWorkInterests(
+      workInterests = aValidWorkInterestsResponse(
         id = persistedInduction.workExperience!!.workInterests!!.id,
         workInterests = setOf(WorkType.SPORTS),
         workInterestsOther = null,
@@ -526,6 +533,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       .wasLastModifiedAt(initialModifiedAt) // should be unchanged
     assertThat(updatedInduction.workExperience).isEquivalentTo(expectedWorkExperience)
     assertThat(updatedInduction.workExperience!!.modifiedDateTime).isAfter(initialModifiedAt)
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isAfter(initialModifiedAt)
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
@@ -558,7 +566,7 @@ class UpdateInductionTest : IntegrationTestBase() {
         typeOfWorkExperience = setOf(WorkType.OTHER),
         typeOfWorkExperienceOther = "Scientist",
         workExperience = setOf(aValidWorkExperienceResource()),
-        workInterests = aValidWorkInterests(),
+        workInterests = aValidUpdateWorkInterestsRequest(),
       ),
     )
 
@@ -567,7 +575,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       typeOfWorkExperience = setOf(WorkType.OTHER),
       typeOfWorkExperienceOther = "Scientist",
       workExperience = setOf(aValidWorkExperienceResource()),
-      workInterests = aValidWorkInterests(),
+      workInterests = aValidWorkInterestsResponse(),
       modifiedBy = "auser_gen",
     )
     shortDelayForTimestampChecking()
@@ -593,6 +601,7 @@ class UpdateInductionTest : IntegrationTestBase() {
     assertThat(updatedInduction.workExperience).isEquivalentTo(expectedWorkExperience)
     assertThat(updatedInduction.workExperience!!.modifiedDateTime).isAfter(initialModifiedAt)
     // other last modified dates should remain unchanged
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
@@ -650,6 +659,7 @@ class UpdateInductionTest : IntegrationTestBase() {
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.workExperience!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
   }
 
@@ -703,6 +713,7 @@ class UpdateInductionTest : IntegrationTestBase() {
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.workExperience!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
   }
 
@@ -758,6 +769,7 @@ class UpdateInductionTest : IntegrationTestBase() {
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.workExperience!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
   }
 
@@ -812,11 +824,8 @@ class UpdateInductionTest : IntegrationTestBase() {
     // other last modified dates should remain unchanged
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.workExperience!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
     assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isEqualToIgnoringNanos(initialModifiedAt)
-  }
-
-  private fun shortDelayForTimestampChecking() {
-    Thread.sleep(100)
   }
 
   private fun aValidUpdateInductionRequestBasedOn(
@@ -854,4 +863,8 @@ class UpdateInductionTest : IntegrationTestBase() {
       qualificationsAndTraining = qualificationsAndTraining,
       inPrisonInterests = inPrisonInterests,
     )
+
+  private fun shortDelayForTimestampChecking() {
+    Thread.sleep(200)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapper.kt
@@ -6,8 +6,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Wor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateFutureWorkInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateFutureWorkInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 
 @Component
@@ -20,7 +20,7 @@ class FutureWorkInterestsResourceMapper {
       )
     }
 
-  fun toUpdateFutureWorkInterestsDto(request: WorkInterests?, prisonId: String): UpdateFutureWorkInterestsDto? =
+  fun toUpdateFutureWorkInterestsDto(request: UpdateWorkInterestsRequest?, prisonId: String): UpdateFutureWorkInterestsDto? =
     request?.let {
       UpdateFutureWorkInterestsDto(
         reference = it.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapper.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -58,13 +58,15 @@ abstract class PreviousWorkExperiencesResourceMapper {
   @Mapping(target = "otherWork", source = "experienceTypeOther")
   abstract fun toWorkExperienceApi(workExperience: WorkExperienceDomain): WorkExperienceApi
 
-  private fun toWorkInterestsResponse(workInterests: FutureWorkInterests?): WorkInterests? {
+  private fun toWorkInterestsResponse(workInterests: FutureWorkInterests?): WorkInterestsResponse? {
     return workInterests?.let {
-      WorkInterests(
+      WorkInterestsResponse(
         id = workInterests.reference,
         workInterests = workInterests.interests.map { toWorkTypeApi(it.workType) }.toSet(),
         workInterestsOther = toWorkInterestsOther(workInterests),
         particularJobInterests = workInterests.interests.map { toWorkInterestDetail(it) }.toSet(),
+        modifiedBy = workInterests.lastUpdatedBy!!,
+        modifiedDateTime = toOffsetDateTime(workInterests.lastUpdatedAt)!!,
       )
     }
   }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.4.8'
+  version: '1.4.9'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -594,7 +594,7 @@ components:
           items:
             $ref: '#/components/schemas/WorkExperience'
         workInterests:
-          $ref: '#/components/schemas/WorkInterests'
+          $ref: '#/components/schemas/WorkInterestsResponse'
         modifiedBy:
           type: string
           description: The DPS username of the person who last updated this Prisoner's previous work.
@@ -729,6 +729,29 @@ components:
           description: An ISO-8601 timestamp representing when this Prisoner's in-prison work and education interests was last updated. This will be the same as the created date if it has not yet been updated.
           example: '2023-06-19T09:39:44Z'
       required:
+        - modifiedBy
+        - modifiedDateTime
+    WorkInterestsResponse:
+      description: The Prisoner's work interests. Migrated from hmpps-ciag-careers-induction-api.
+      allOf:
+        - $ref: '#/components/schemas/CreateWorkInterestsRequest'
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: A unique reference for this Prisoner's work interests.
+          example: c88a6c48-97e2-4c04-93b5-98619966447b
+        modifiedBy:
+          type: string
+          description: The DPS username of the person who last updated the Induction.
+          example: 'asmith_gen'
+        modifiedDateTime:
+          type: string
+          format: date-time
+          description: An ISO-8601 timestamp representing when the Goal was last updated. This will be the same as the created date if it has not yet been updated.
+          example: '2023-06-19T09:39:44Z'
+      required:
+        - id
         - modifiedBy
         - modifiedDateTime
 
@@ -1128,7 +1151,6 @@ components:
         inPrisonInterests:
           $ref: '#/components/schemas/UpdatePrisonWorkAndEducationRequest'
       required:
-        - reference
         - hopingToGetWork
         - prisonId
 
@@ -1161,7 +1183,7 @@ components:
           items:
             $ref: '#/components/schemas/WorkExperience'
         workInterests:
-          $ref: '#/components/schemas/WorkInterests'
+          $ref: '#/components/schemas/UpdateWorkInterestsRequest'
       required:
         - hasWorkedBefore
 
@@ -1217,15 +1239,15 @@ components:
       required:
         - typeOfWorkExperience
 
-    WorkInterests:
-      description: The Prisoner's work interests. Migrated from hmpps-ciag-careers-induction-api.
+    UpdateWorkInterestsRequest:
+      description: A request to update a Prisoner's work interests. Migrated from hmpps-ciag-careers-induction-api.
       allOf:
         - $ref: '#/components/schemas/CreateWorkInterestsRequest'
       properties:
         id:
           type: string
           format: uuid
-          description: A unique reference for this Prisoner's education and qualifications.
+          description: A unique reference for this Prisoner's work interests.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
       required:
         - id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkInterestsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterests
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateWorkInterestsRequest
 
 class FutureWorkInterestsResourceMapperTest {
   private val mapper = FutureWorkInterestsResourceMapper()
@@ -30,7 +30,7 @@ class FutureWorkInterestsResourceMapperTest {
   fun `should map to UpdateFutureWorkInterestsDto`() {
     // Given
     val prisonId = "BXI"
-    val request = aValidWorkInterests()
+    val request = aValidUpdateWorkInterestsRequest()
 
     // When
     val actual = mapper.toUpdateFutureWorkInterestsDto(request, prisonId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapperTest.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induc
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkExperienceResource
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterests
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterestsResponse
 import java.time.ZoneOffset
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkExperienceType as WorkExperienceTypeDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType as WorkInterestTypeDomain
@@ -80,7 +80,7 @@ class PreviousWorkExperiencesResourceMapperTest {
           details = "A labourer in varied industries",
         ),
       ),
-      workInterests = aValidWorkInterests(
+      workInterests = aValidWorkInterestsResponse(
         id = workInterests.reference,
         workInterests = setOf(WorkType.OTHER),
         workInterestsOther = "Varied interests",
@@ -90,6 +90,8 @@ class PreviousWorkExperiencesResourceMapperTest {
             role = "Labourer",
           ),
         ),
+        modifiedBy = workInterests.lastUpdatedBy!!,
+        modifiedDateTime = workInterests.lastUpdatedAt!!.atOffset(ZoneOffset.UTC),
       ),
       modifiedDateTime = workExperiences.lastUpdatedAt!!.atOffset(ZoneOffset.UTC),
       modifiedBy = "bjones_gen",
@@ -170,11 +172,13 @@ class PreviousWorkExperiencesResourceMapperTest {
       typeOfWorkExperience = null,
       typeOfWorkExperienceOther = null,
       workExperience = null,
-      workInterests = aValidWorkInterests(
+      workInterests = aValidWorkInterestsResponse(
         id = workInterests.reference,
         workInterests = emptySet(),
         workInterestsOther = null,
         particularJobInterests = emptySet(),
+        modifiedBy = workInterests.lastUpdatedBy!!,
+        modifiedDateTime = workInterests.lastUpdatedAt!!.atOffset(ZoneOffset.UTC),
       ),
       modifiedDateTime = workExperiences.lastUpdatedAt!!.atOffset(ZoneOffset.UTC),
       modifiedBy = "bjones_gen",

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkRequestBuilder.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.indu
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkExperience
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 import java.util.UUID
 
@@ -29,7 +29,7 @@ fun aValidUpdatePreviousWorkRequest(
   typeOfWorkExperience: Set<WorkType>? = setOf(WorkType.OTHER),
   typeOfWorkExperienceOther: String? = "Scientist",
   workExperience: Set<WorkExperience>? = setOf(aValidWorkExperienceResource()),
-  workInterests: WorkInterests? = aValidWorkInterests(),
+  workInterests: UpdateWorkInterestsRequest? = aValidUpdateWorkInterestsRequest(),
 ): UpdatePreviousWorkRequest =
   UpdatePreviousWorkRequest(
     id = id,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkResponseBuilder.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.indu
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkExperience
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -13,7 +13,7 @@ fun aValidPreviousWorkResponse(
   typeOfWorkExperience: Set<WorkType>? = setOf(WorkType.OTHER),
   typeOfWorkExperienceOther: String? = "Scientist",
   workExperience: Set<WorkExperience>? = setOf(aValidWorkExperienceResource()),
-  workInterests: WorkInterests? = aValidWorkInterests(),
+  workInterests: WorkInterestsResponse? = aValidWorkInterestsResponse(),
   modifiedBy: String = "auser_gen",
   modifiedDateTime: OffsetDateTime = OffsetDateTime.now(),
 ): PreviousWorkResponse =

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateCiagInductionRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateCiagInductionRequestBuilder.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Updat
 import java.util.UUID
 
 fun aValidUpdateCiagInductionRequest(
-  reference: UUID = UUID.randomUUID(),
+  reference: UUID? = UUID.randomUUID(),
   hopingToGetWork: HopingToWork = HopingToWork.NOT_SURE,
   prisonId: String = "BXI",
   abilityToWork: Set<AbilityToWorkFactor>? = setOf(AbilityToWorkFactor.OTHER),

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/WorkInterestsBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/WorkInterestsBuilder.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterests
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
+import java.time.OffsetDateTime
 import java.util.UUID
 
 fun aValidCreateWorkInterestsRequest(
@@ -22,7 +24,7 @@ fun aValidCreateWorkInterestsRequest(
     particularJobInterests = particularJobInterests,
   )
 
-fun aValidWorkInterests(
+fun aValidUpdateWorkInterestsRequest(
   id: UUID = UUID.randomUUID(),
   workInterests: Set<WorkType> = setOf(WorkType.OTHER),
   workInterestsOther: String? = "Any job I can get",
@@ -32,10 +34,32 @@ fun aValidWorkInterests(
       role = "Any role",
     ),
   ),
-): WorkInterests =
-  WorkInterests(
+): UpdateWorkInterestsRequest =
+  UpdateWorkInterestsRequest(
     id = id,
     workInterests = workInterests,
     workInterestsOther = workInterestsOther,
     particularJobInterests = particularJobInterests,
+  )
+
+fun aValidWorkInterestsResponse(
+  id: UUID = UUID.randomUUID(),
+  workInterests: Set<WorkType> = setOf(WorkType.OTHER),
+  workInterestsOther: String? = "Any job I can get",
+  particularJobInterests: Set<WorkInterestDetail>? = setOf(
+    WorkInterestDetail(
+      workInterest = WorkType.OTHER,
+      role = "Any role",
+    ),
+  ),
+  modifiedBy: String = "auser_gen",
+  modifiedDateTime: OffsetDateTime = OffsetDateTime.now(),
+): WorkInterestsResponse =
+  WorkInterestsResponse(
+    id = id,
+    workInterests = workInterests,
+    workInterestsOther = workInterestsOther,
+    particularJobInterests = particularJobInterests,
+    modifiedBy = modifiedBy,
+    modifiedDateTime = modifiedDateTime,
   )


### PR DESCRIPTION
This PR fixes two issues that would have resulted in breaking changes when migrating from the CIAG API to our API:

- Adds "modified" fields to the `WorkInterestsResponse` to make it match the CIAG API's response.
- Makes an Induction's `reference` field optional in the update request.

Once this is merged, I will scrutinise the JSON between the two APIs and make sure they match :)