### PR TITLE
RR-496 - Basic CIAG API webClient and application event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ The following environment variables are required in order for the app to start:
 | HMPPS_SQS_QUEUES_EDUCATIONANDWORKPLAN_QUEUE_NAME | The queue to receive events from the domain-events topic.                 |
 | HMPPS_SQS_QUEUES_EDUCATIONANDWORKPLAN_DLQ_NAME   | The dead letter queue for any failed messages.                            |
 
+### APIs
+
+| Name                   | Description                                                                                     |
+|------------------------|-------------------------------------------------------------------------------------------------|
+| CIAG_INDUCTION_API_URL | The URL of the CIAG Induction API, used as part of the ETL for the CIAG Induction API migration |
+| CIAG_API_CLIENT_ID     | hmpps-auth oauth2 client-id for connecting to the CIAG Induction API                            |
+| CIAG_API_CLIENT_SECRET | hmpps-auth oauth2 client-secret for connecting to the CIAG Induction API                        |
+
 ## Monitoring, tracing and event reporting
 The API is instrumented with the opentelemetry and Application Insights java agent. Useful data can be found and reported
 on via the Azure Application Insights console, all under the `cloud_RoleName` property of `hmpps-education-and-work-plan-api`
@@ -195,3 +203,10 @@ The REST API endpoints exposed by this API are consumed by the service UI. Roles
 The CIAG Induction service UI consumes the `GET` endpoint in order to retrieve action plan details for a list of prison
 numbers (prisoners). The role required is `ROLE_EDUCATION_WORK_PLAN_VIEWER`
 
+## Feature Toggles
+Features can be toggled by setting the relevant environment variable.
+
+| Name                                  | Default Value | Type    | Description                                                                                                          |
+|---------------------------------------|---------------|---------|----------------------------------------------------------------------------------------------------------------------|
+| SOME_TOGGLE_ENABLED                   | false         | Boolean | Example feature toggle, for demonstration purposes.                                                                  |
+| CIAG_INDUCTION_DATA_MIGRATION_ENABLED | false         | Boolean | Set to true to enable the components that perform an ETL migration of CIAG Inductions from the CIAG API to this API. |

--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -25,6 +25,10 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     HMPPS_SQS_USE_WEB_TOKEN: true
+    # TODO - RR-502 - Remove `CIAG_INDUCTION_API_URL` and `CIAG_INDUCTION_DATA_MIGRATION_ENABLED`
+    CIAG_INDUCTION_API_URL: "https://ciag-induction-api.hmpps.service.justice.gov.uk"
+    CIAG_INDUCTION_DATA_MIGRATION_ENABLED: "false"
+
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -34,6 +38,9 @@ generic-service:
   namespace_secrets:
     hmpps-education-and-work-plan-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+      # TODO - RR-502 - Remove `CIAG_API_CLIENT_ID` and `CIAG_API_CLIENT_SECRET` - ensure HAAR team remove oauth client from hmpps-auth
+      CIAG_API_CLIENT_ID: "CIAG_API_CLIENT_ID"
+      CIAG_API_CLIENT_SECRET: "CIAG_API_CLIENT_SECRET"
     rds-postgresql-instance-output:
       DB_SERVER: "rds_instance_address"
       DB_NAME: "database_name"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,7 +17,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     # TODO - RR-502 - Remove `CIAG_INDUCTION_API_URL` and `CIAG_INDUCTION_DATA_MIGRATION_ENABLED`
     CIAG_INDUCTION_API_URL: "https://ciag-induction-api-dev.hmpps.service.justice.gov.uk"
-    CIAG_INDUCTION_DATA_MIGRATION_ENABLED: "false"
+    CIAG_INDUCTION_DATA_MIGRATION_ENABLED: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,6 +15,9 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    # TODO - RR-502 - Remove `CIAG_INDUCTION_API_URL` and `CIAG_INDUCTION_DATA_MIGRATION_ENABLED`
+    CIAG_INDUCTION_API_URL: "https://ciag-induction-api-dev.hmpps.service.justice.gov.uk"
+    CIAG_INDUCTION_DATA_MIGRATION_ENABLED: "false"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,6 +15,9 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    # TODO - RR-502 - Remove `CIAG_INDUCTION_API_URL` and `CIAG_INDUCTION_DATA_MIGRATION_ENABLED`
+    CIAG_INDUCTION_API_URL: "https://ciag-induction-api-preprod.hmpps.service.justice.gov.uk"
+    CIAG_INDUCTION_DATA_MIGRATION_ENABLED: "false"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/integrationTest/resources/application-integration-test.yml
+++ b/src/integrationTest/resources/application-integration-test.yml
@@ -41,3 +41,14 @@ hmpps.sqs:
   topics:
     domainevents:
       arn: arn:aws:sns:eu-west-2:000000000000:domainevents-topic
+
+# TODO - RR-502 - Remove `ciag-api` property inc. children
+ciag-api:
+  client:
+    id: ciag-api-client-id
+    secret: client-secret
+
+# TODO - RR-502 - Remove `apis` property inc. children
+apis:
+  ciag-induction:
+    url: http://localhost:9093

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/ApplicationStartupListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/ApplicationStartupListener.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.event.ApplicationStartedEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["featureToggles.ciag-induction-data-migration-enabled"], havingValue = "true")
+class ApplicationStartupListener(
+  private val ciagInductionMigrationService: CiagInductionMigrationService,
+) : ApplicationListener<ApplicationStartedEvent> {
+  override fun onApplicationEvent(event: ApplicationStartedEvent) {
+    ciagInductionMigrationService.migrateCiagInductions()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationService.kt
@@ -14,7 +14,7 @@ private val log = KotlinLogging.logger {}
 class CiagInductionMigrationService(private val ciagWebClient: WebClient) {
 
   fun migrateCiagInductions() {
-    log.debug { "Starting migration of CIAG Inductions from CIAG API to PLP API" }
+    log.info { "Starting migration of CIAG Inductions from CIAG API to PLP API" }
 
     try {
       val ciagInduction = ciagWebClient
@@ -24,7 +24,7 @@ class CiagInductionMigrationService(private val ciagWebClient: WebClient) {
         .bodyToMono(Map::class.java)
         .block()
 
-      log.debug { "CIAG Induction: $ciagInduction" }
+      log.info { "CIAG Induction: $ciagInduction" }
     } catch (e: Exception) {
       log.error("Error calling CIAG API to get CIAG Induction", e)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationService.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Service class to orchestrate calls to CIAG Induction API in order to migrate CIAG Inductions from the CIAG API to this
+ * API and database.
+ */
+@Service
+class CiagInductionMigrationService(private val ciagWebClient: WebClient) {
+
+  fun migrateCiagInductions() {
+    log.debug { "Starting migration of CIAG Inductions from CIAG API to PLP API" }
+
+    try {
+      val ciagInduction = ciagWebClient
+        .get()
+        .uri("/ciag/induction/A5077DY")
+        .retrieve()
+        .bodyToMono(Map::class.java)
+        .block()
+
+      log.debug { "CIAG Induction: $ciagInduction" }
+    } catch (e: Exception) {
+      log.error("Error calling CIAG API to get CIAG Induction", e)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/WebClientConfiguration.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import kotlin.apply as kotlinApply
+
+@Configuration
+class WebClientConfiguration(
+  @Value("\${apis.ciag-induction.url}") val ciagInductionApiUri: String,
+) {
+  @Bean
+  fun ciagApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient =
+    builder.authorisedWebClient(authorizedClientManager, registrationId = "ciag-api", url = ciagInductionApiUri)
+
+  @Bean
+  fun authorizedClientManager(
+    clientRegistrationRepository: ClientRegistrationRepository,
+    oAuth2AuthorizedClientService: OAuth2AuthorizedClientService,
+  ): OAuth2AuthorizedClientManager {
+    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
+    return AuthorizedClientServiceOAuth2AuthorizedClientManager(
+      clientRegistrationRepository,
+      oAuth2AuthorizedClientService,
+    ).kotlinApply { setAuthorizedClientProvider(authorizedClientProvider) }
+  }
+
+  private fun WebClient.Builder.authorisedWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, registrationId: String, url: String): WebClient {
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager).kotlinApply {
+      setDefaultClientRegistrationId(registrationId)
+    }
+
+    return baseUrl(url)
+      .clientConnector(ReactorClientHttpConnector(HttpClient.create()))
+      .filter(oauth2Client)
+      .build()
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,19 @@ spring:
         jwt:
           jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
 
+      # TODO - RR-502 - Remove `client` property inc. children
+      client:
+        registration:
+          ciag-api:
+            provider: hmpps-auth
+            client-id: ${ciag-api.client.id}
+            client-secret: ${ciag-api.client.secret}
+            authorization-grant-type: client_credentials
+            scope: read
+        provider:
+          hmpps-auth:
+            token-uri: ${hmpps.auth.url}/oauth/token
+
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
     serialization:
@@ -76,3 +89,12 @@ springdoc:
   # swagger specification file served via /swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config
   swagger-ui:
     url: '/openapi/EducationAndWorkPlanAPI.yml'
+
+# TODO - RR-502 - Remove `apis` property inc. children
+apis:
+  ciag-induction:
+    url: ${CIAG_INDUCTION_API_URL}
+
+# TODO - RR-502 - Remove `featureToggles` property inc. children
+featureToggles:
+  ciag-induction-data-migration-enabled: ${CIAG_INDUCTION_DATA_MIGRATION_ENABLED:false}


### PR DESCRIPTION
**DO NOT MERGE**

This PR provides a `WebClient` with a suitable authorizaton header that we will use to invoke the CIAG API for the purpose of CIAG Induction migration.
It also includes a `ApplicationStartedEvent` event listener (conditional on feature toggle) that in turn calls a basic service that we will build upon to actually perform the migration.

**DO NOT MERGE YET - we are too close to our private beta go-live to risk that release! We can merge this sometime next week**
