### PR TITLE
RR-503 - CIAG migration - deserialise CIAG response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/ApplicationStartupListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/ApplicationStartupListener.kt
@@ -10,6 +10,13 @@ import org.springframework.stereotype.Component
 class ApplicationStartupListener(
   private val ciagInductionMigrationService: CiagInductionMigrationService,
 ) : ApplicationListener<ApplicationStartedEvent> {
+
+  /**
+   * Upon application start-up, a one-off request is made to the [CiagInductionMigrationService] to import data from the
+   * CIAG API. This is to enable us to switch from creating and maintaining Prisoner Inductions within the CIAG API to
+   * this API. Once this process has successfully completed, the `ciag-induction-data-migration-enabled` feature toggle
+   * will be disabled.
+   */
   override fun onApplicationEvent(event: ApplicationStartedEvent) {
     ciagInductionMigrationService.migrateCiagInductions()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationService.kt
@@ -25,7 +25,7 @@ class CiagInductionMigrationService(private val ciagWebClient: WebClient) {
         .bodyToMono(CiagInductionResponse::class.java)
         .block()
 
-      log.info { "CIAG Induction: $ciagInduction" }
+      log.info { "Deserialised CIAG Induction: $ciagInduction" }
     } catch (e: Exception) {
       log.error("Error calling CIAG API to get CIAG Induction", e)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model.CiagInductionResponse
 
 private val log = KotlinLogging.logger {}
 
@@ -21,7 +22,7 @@ class CiagInductionMigrationService(private val ciagWebClient: WebClient) {
         .get()
         .uri("/ciag/induction/A5077DY")
         .retrieve()
-        .bodyToMono(Map::class.java)
+        .bodyToMono(CiagInductionResponse::class.java)
         .block()
 
       log.info { "CIAG Induction: $ciagInduction" }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/AbilityToWorkFactor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/AbilityToWorkFactor.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Factors affecting a prisoner's ability to work.
+ */
+enum class AbilityToWorkFactor(val value: String) {
+
+  @JsonProperty("CARING_RESPONSIBILITIES")
+  CARING_RESPONSIBILITIES("CARING_RESPONSIBILITIES"),
+
+  @JsonProperty("LIMITED_BY_OFFENSE")
+  LIMITED_BY_OFFENSE("LIMITED_BY_OFFENSE"),
+
+  @JsonProperty("HEALTH_ISSUES")
+  HEALTH_ISSUES("HEALTH_ISSUES"),
+
+  @JsonProperty("NO_RIGHT_TO_WORK")
+  NO_RIGHT_TO_WORK("NO_RIGHT_TO_WORK"),
+
+  @JsonProperty("OTHER")
+  OTHER("OTHER"),
+
+  @JsonProperty("NONE")
+  NONE("NONE"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/AchievedQualification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/AchievedQualification.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * A qualification that a Prisoner has achieved.
+ */
+data class AchievedQualification(
+
+  @Schema(example = "null", description = "The subject of the qualification.")
+  @get:JsonProperty("subject")
+  val subject: String? = null,
+
+  @Schema(example = "null", description = "The level of the qualification (if known/relevant).")
+  @get:JsonProperty("level")
+  val level: Level? = null,
+
+  @Schema(example = "null", description = "The grade which was achieved (if known/relevant).")
+  @get:JsonProperty("grade")
+  val grade: String? = null,
+) {
+
+  /**
+   * The level of the qualification (if known/relevant).
+   * Values: ENTRY_LEVEL,LEVEL_1,LEVEL_2,LEVEL_3,LEVEL_4,LEVEL_5,LEVEL_6,LEVEL_7,LEVEL_8
+   */
+  enum class Level(val value: String) {
+
+    @JsonProperty("ENTRY_LEVEL")
+    ENTRY_LEVEL("ENTRY_LEVEL"),
+
+    @JsonProperty("LEVEL_1")
+    LEVEL_1("LEVEL_1"),
+
+    @JsonProperty("LEVEL_2")
+    LEVEL_2("LEVEL_2"),
+
+    @JsonProperty("LEVEL_3")
+    LEVEL_3("LEVEL_3"),
+
+    @JsonProperty("LEVEL_4")
+    LEVEL_4("LEVEL_4"),
+
+    @JsonProperty("LEVEL_5")
+    LEVEL_5("LEVEL_5"),
+
+    @JsonProperty("LEVEL_6")
+    LEVEL_6("LEVEL_6"),
+
+    @JsonProperty("LEVEL_7")
+    LEVEL_7("LEVEL_7"),
+
+    @JsonProperty("LEVEL_8")
+    LEVEL_8("LEVEL_8"),
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/CiagInductionResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/CiagInductionResponse.kt
@@ -11,14 +11,6 @@ import jakarta.validation.constraints.Pattern
  */
 data class CiagInductionResponse(
 
-  @Schema(
-    example = "814ade0a-a3b2-46a3-862f-79211ba13f7b",
-    required = true,
-    description = "The Induction's unique reference.",
-  )
-  @get:JsonProperty("reference", required = true)
-  val reference: java.util.UUID,
-
   @get:Pattern(regexp = "^[A-Z]\\d{4}[A-Z]{2}$")
   @Schema(example = "null", required = true, description = "The ID of the Prisoner. AKA the prison number.")
   @get:JsonProperty("offenderId", required = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/CiagInductionResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/CiagInductionResponse.kt
@@ -1,0 +1,118 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
+
+/**
+ * A Prisoner's CIAG Induction containing information, such as their education history and future work interests.
+ * This is a temporary class to enable us to import data from the CIAG API.
+ */
+data class CiagInductionResponse(
+
+  @Schema(
+    example = "814ade0a-a3b2-46a3-862f-79211ba13f7b",
+    required = true,
+    description = "The Induction's unique reference.",
+  )
+  @get:JsonProperty("reference", required = true)
+  val reference: java.util.UUID,
+
+  @get:Pattern(regexp = "^[A-Z]\\d{4}[A-Z]{2}$")
+  @Schema(example = "null", required = true, description = "The ID of the Prisoner. AKA the prison number.")
+  @get:JsonProperty("offenderId", required = true)
+  val offenderId: String,
+
+  @field:Valid
+  @Schema(example = "null", required = true, description = "")
+  @get:JsonProperty("hopingToGetWork", required = true)
+  val hopingToGetWork: HopingToWork,
+
+  @Schema(
+    example = "asmith_gen",
+    required = true,
+    description = "The DPS username of the person who created the Induction.",
+  )
+  @get:JsonProperty("createdBy", required = true)
+  val createdBy: String,
+
+  @Schema(
+    example = "2023-06-19T09:39:44Z",
+    required = true,
+    description = "An ISO-8601 timestamp representing when the Induction was created.",
+  )
+  @get:JsonProperty("createdDateTime", required = true)
+  val createdDateTime: java.time.OffsetDateTime,
+
+  @Schema(
+    example = "asmith_gen",
+    required = true,
+    description = "The DPS username of the person who last updated the Induction.",
+  )
+  @get:JsonProperty("modifiedBy", required = true)
+  val modifiedBy: String,
+
+  @Schema(
+    example = "2023-06-19T09:39:44Z",
+    required = true,
+    description = "An ISO-8601 timestamp representing when the Goal was last updated. This will be the same as the created date if it has not yet been updated.",
+  )
+  @get:JsonProperty("modifiedDateTime", required = true)
+  val modifiedDateTime: java.time.OffsetDateTime,
+
+  @Schema(example = "null", description = "The ID of the Prison that that Prisoner is currently at.")
+  @get:JsonProperty("prisonId")
+  val prisonId: String? = null,
+
+  @Schema(example = "null", description = "Whether the Prisoner wishes to work or not.")
+  @get:JsonProperty("desireToWork")
+  val desireToWork: Boolean? = null,
+
+  @Schema(
+    example = "null",
+    description = "The reason that is given when the Prisoner does not want to work. This is mandatory when 'reasonToNotGetWork' is set to 'OTHER'.",
+  )
+  @get:JsonProperty("reasonToNotGetWorkOther")
+  val reasonToNotGetWorkOther: String? = null,
+
+  @field:Valid
+  @Schema(example = "null", description = "One or more factors affecting the Prisoner's ability to work.")
+  @get:JsonProperty("abilityToWork")
+  val abilityToWork: Set<AbilityToWorkFactor>? = null,
+
+  @Schema(
+    example = "null",
+    description = "A specific factor affecting the Prisoner's ability to work. This is mandatory when 'abilityToWork' is set to 'OTHER'.",
+  )
+  @get:JsonProperty("abilityToWorkOther")
+  val abilityToWorkOther: String? = null,
+
+  @field:Valid
+  @Schema(
+    example = "null",
+    description = "One or more reasons the Prisoner has given not to get work after leaving Prison.",
+  )
+  @get:JsonProperty("reasonToNotGetWork")
+  val reasonToNotGetWork: Set<ReasonNotToWork>? = null,
+
+  @field:Valid
+  @Schema(example = "null", description = "")
+  @get:JsonProperty("workExperience")
+  val workExperience: PreviousWorkResponse? = null,
+
+  @field:Valid
+  @Schema(example = "null", description = "")
+  @get:JsonProperty("skillsAndInterests")
+  val skillsAndInterests: SkillsAndInterestsResponse? = null,
+
+  @field:Valid
+  @Schema(example = "null", description = "")
+  @get:JsonProperty("qualificationsAndTraining")
+  val qualificationsAndTraining: EducationAndQualificationResponse? = null,
+
+  @field:Valid
+  @Schema(example = "null", description = "")
+  @get:JsonProperty("inPrisonInterests")
+  val inPrisonInterests: PrisonWorkAndEducationResponse? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/EducationAndQualificationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/EducationAndQualificationResponse.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+
+/**
+ * A Prisoner's education and qualifications history. This is a temporary class to allow us to import data from the CIAG API.
+ */
+data class EducationAndQualificationResponse(
+
+  @Schema(
+    example = "asmith_gen",
+    required = true,
+    description = "The DPS username of the person who last updated this Prisoner's education and qualifications.",
+  )
+  @get:JsonProperty("modifiedBy", required = true)
+  val modifiedBy: String,
+
+  @Schema(
+    example = "2023-06-19T09:39:44Z",
+    required = true,
+    description = "An ISO-8601 timestamp representing when this Prisoner's education and qualifications was last updated. This will be the same as the created date if it has not yet been updated.",
+  )
+  @get:JsonProperty("modifiedDateTime", required = true)
+  val modifiedDateTime: java.time.OffsetDateTime,
+
+  @Schema(
+    example = "c88a6c48-97e2-4c04-93b5-98619966447b",
+    description = "A unique reference for this Prisoner's education and qualifications (not the database primary key).",
+  )
+  @get:JsonProperty("id")
+  val id: Integer,
+
+  @field:Valid
+  @Schema(example = "null", description = "")
+  @get:JsonProperty("educationLevel")
+  val educationLevel: HighestEducationLevel? = null,
+
+  @field:Valid
+  @Schema(example = "null", description = "A list of the Prisoner's previous qualifications")
+  @get:JsonProperty("qualifications")
+  val qualifications: Set<AchievedQualification>? = null,
+
+  @field:Valid
+  @Schema(example = "null", description = "Any additional training that the Prisoner has completed in the past.")
+  @get:JsonProperty("additionalTraining")
+  val additionalTraining: Set<TrainingType>? = null,
+
+  @Schema(
+    example = "null",
+    description = "A specific type of training that does not fit the given 'additionalTraining' types. Mandatory when 'additionalTraining' includes 'OTHER'.",
+  )
+  @get:JsonProperty("additionalTrainingOther")
+  val additionalTrainingOther: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/EducationAndQualificationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/EducationAndQualificationResponse.kt
@@ -25,13 +25,6 @@ data class EducationAndQualificationResponse(
   @get:JsonProperty("modifiedDateTime", required = true)
   val modifiedDateTime: java.time.OffsetDateTime,
 
-  @Schema(
-    example = "c88a6c48-97e2-4c04-93b5-98619966447b",
-    description = "A unique reference for this Prisoner's education and qualifications (not the database primary key).",
-  )
-  @get:JsonProperty("id")
-  val id: Integer,
-
   @field:Valid
   @Schema(example = "null", description = "")
   @get:JsonProperty("educationLevel")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/HighestEducationLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/HighestEducationLevel.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * The highest education level of a Prisoner.
+ */
+enum class HighestEducationLevel(val value: String) {
+
+  @JsonProperty("PRIMARY_SCHOOL")
+  PRIMARY_SCHOOL("PRIMARY_SCHOOL"),
+
+  @JsonProperty("SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS")
+  SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS("SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS"),
+
+  @JsonProperty("SECONDARY_SCHOOL_TOOK_EXAMS")
+  SECONDARY_SCHOOL_TOOK_EXAMS("SECONDARY_SCHOOL_TOOK_EXAMS"),
+
+  @JsonProperty("FURTHER_EDUCATION_COLLEGE")
+  FURTHER_EDUCATION_COLLEGE("FURTHER_EDUCATION_COLLEGE"),
+
+  @JsonProperty("UNDERGRADUATE_DEGREE_AT_UNIVERSITY")
+  UNDERGRADUATE_DEGREE_AT_UNIVERSITY("UNDERGRADUATE_DEGREE_AT_UNIVERSITY"),
+
+  @JsonProperty("POSTGRADUATE_DEGREE_AT_UNIVERSITY")
+  POSTGRADUATE_DEGREE_AT_UNIVERSITY("POSTGRADUATE_DEGREE_AT_UNIVERSITY"),
+
+  @JsonProperty("NOT_SURE")
+  NOT_SURE("NOT_SURE"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/HopingToWork.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/HopingToWork.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Whether the Prisoner hopes to get work.
+ */
+enum class HopingToWork(val value: String) {
+
+  @JsonProperty("YES")
+  YES("YES"),
+
+  @JsonProperty("NO")
+  NO("NO"),
+
+  @JsonProperty("NOT_SURE")
+  NOT_SURE("NOT_SURE"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/InPrisonTrainingType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/InPrisonTrainingType.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * The types of training that can be done whilst in prison.
+ */
+enum class InPrisonTrainingType(val value: String) {
+
+  @JsonProperty("BARBERING_AND_HAIRDRESSING")
+  BARBERING_AND_HAIRDRESSING("BARBERING_AND_HAIRDRESSING"),
+
+  @JsonProperty("CATERING")
+  CATERING("CATERING"),
+
+  @JsonProperty("COMMUNICATION_SKILLS")
+  COMMUNICATION_SKILLS("COMMUNICATION_SKILLS"),
+
+  @JsonProperty("ENGLISH_LANGUAGE_SKILLS")
+  ENGLISH_LANGUAGE_SKILLS("ENGLISH_LANGUAGE_SKILLS"),
+
+  @JsonProperty("FORKLIFT_DRIVING")
+  FORKLIFT_DRIVING("FORKLIFT_DRIVING"),
+
+  @JsonProperty("INTERVIEW_SKILLS")
+  INTERVIEW_SKILLS("INTERVIEW_SKILLS"),
+
+  @JsonProperty("MACHINERY_TICKETS")
+  MACHINERY_TICKETS("MACHINERY_TICKETS"),
+
+  @JsonProperty("NUMERACY_SKILLS")
+  NUMERACY_SKILLS("NUMERACY_SKILLS"),
+
+  @JsonProperty("RUNNING_A_BUSINESS")
+  RUNNING_A_BUSINESS("RUNNING_A_BUSINESS"),
+
+  @JsonProperty("SOCIAL_AND_LIFE_SKILLS")
+  SOCIAL_AND_LIFE_SKILLS("SOCIAL_AND_LIFE_SKILLS"),
+
+  @JsonProperty("WELDING_AND_METALWORK")
+  WELDING_AND_METALWORK("WELDING_AND_METALWORK"),
+
+  @JsonProperty("WOODWORK_AND_JOINERY")
+  WOODWORK_AND_JOINERY("WOODWORK_AND_JOINERY"),
+
+  @JsonProperty("OTHER")
+  OTHER("OTHER"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/InPrisonWorkType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/InPrisonWorkType.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Types of work that can be done whilst in prison.
+ */
+enum class InPrisonWorkType(val value: String) {
+
+  @JsonProperty("CLEANING_AND_HYGIENE")
+  CLEANING_AND_HYGIENE("CLEANING_AND_HYGIENE"),
+
+  @JsonProperty("COMPUTERS_OR_DESK_BASED")
+  COMPUTERS_OR_DESK_BASED("COMPUTERS_OR_DESK_BASED"),
+
+  @JsonProperty("GARDENING_AND_OUTDOORS")
+  GARDENING_AND_OUTDOORS("GARDENING_AND_OUTDOORS"),
+
+  @JsonProperty("KITCHENS_AND_COOKING")
+  KITCHENS_AND_COOKING("KITCHENS_AND_COOKING"),
+
+  @JsonProperty("MAINTENANCE")
+  MAINTENANCE("MAINTENANCE"),
+
+  @JsonProperty("PRISON_LAUNDRY")
+  PRISON_LAUNDRY("PRISON_LAUNDRY"),
+
+  @JsonProperty("PRISON_LIBRARY")
+  PRISON_LIBRARY("PRISON_LIBRARY"),
+
+  @JsonProperty("TEXTILES_AND_SEWING")
+  TEXTILES_AND_SEWING("TEXTILES_AND_SEWING"),
+
+  @JsonProperty("WELDING_AND_METALWORK")
+  WELDING_AND_METALWORK("WELDING_AND_METALWORK"),
+
+  @JsonProperty("WOODWORK_AND_JOINERY")
+  WOODWORK_AND_JOINERY("WOODWORK_AND_JOINERY"),
+
+  @JsonProperty("OTHER")
+  OTHER("OTHER"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PersonalInterest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PersonalInterest.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Represents a Prisoner's personal interest.
+ */
+enum class PersonalInterest(val value: String) {
+
+  @JsonProperty("COMMUNITY")
+  COMMUNITY("COMMUNITY"),
+
+  @JsonProperty("CRAFTS")
+  CRAFTS("CRAFTS"),
+
+  @JsonProperty("CREATIVE")
+  CREATIVE("CREATIVE"),
+
+  @JsonProperty("DIGITAL")
+  DIGITAL("DIGITAL"),
+
+  @JsonProperty("KNOWLEDGE_BASED")
+  KNOWLEDGE_BASED("KNOWLEDGE_BASED"),
+
+  @JsonProperty("MUSICAL")
+  MUSICAL("MUSICAL"),
+
+  @JsonProperty("OUTDOOR")
+  OUTDOOR("OUTDOOR"),
+
+  @JsonProperty("NATURE_AND_ANIMALS")
+  NATURE_AND_ANIMALS("NATURE_AND_ANIMALS"),
+
+  @JsonProperty("SOCIAL")
+  SOCIAL("SOCIAL"),
+
+  @JsonProperty("SOLO_ACTIVITIES")
+  SOLO_ACTIVITIES("SOLO_ACTIVITIES"),
+
+  @JsonProperty("SOLO_SPORTS")
+  SOLO_SPORTS("SOLO_SPORTS"),
+
+  @JsonProperty("TEAM_SPORTS")
+  TEAM_SPORTS("TEAM_SPORTS"),
+
+  @JsonProperty("WELLNESS")
+  WELLNESS("WELLNESS"),
+
+  @JsonProperty("OTHER")
+  OTHER("OTHER"),
+
+  @JsonProperty("NONE")
+  NONE("NONE"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PersonalSkill.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PersonalSkill.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Represents a Prisoner's personal skill.
+ */
+enum class PersonalSkill(val value: String) {
+
+  @JsonProperty("COMMUNICATION")
+  COMMUNICATION("COMMUNICATION"),
+
+  @JsonProperty("POSITIVE_ATTITUDE")
+  POSITIVE_ATTITUDE("POSITIVE_ATTITUDE"),
+
+  @JsonProperty("RESILIENCE")
+  RESILIENCE("RESILIENCE"),
+
+  @JsonProperty("SELF_MANAGEMENT")
+  SELF_MANAGEMENT("SELF_MANAGEMENT"),
+
+  @JsonProperty("TEAMWORK")
+  TEAMWORK("TEAMWORK"),
+
+  @JsonProperty("THINKING_AND_PROBLEM_SOLVING")
+  THINKING_AND_PROBLEM_SOLVING("THINKING_AND_PROBLEM_SOLVING"),
+
+  @JsonProperty("WILLINGNESS_TO_LEARN")
+  WILLINGNESS_TO_LEARN("WILLINGNESS_TO_LEARN"),
+
+  @JsonProperty("OTHER")
+  OTHER("OTHER"),
+
+  @JsonProperty("NONE")
+  NONE("NONE"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PreviousWorkResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PreviousWorkResponse.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
+
+/**
+ * A Prisoner's previous work experience. This is a temporary class to allow us to import data from the CIAG API.
+ */
+data class PreviousWorkResponse(
+
+  @Schema(example = "null", required = true, description = "")
+  @get:JsonProperty("hasWorkedBefore", required = true)
+  val hasWorkedBefore: Boolean,
+
+  @Schema(
+    example = "asmith_gen",
+    required = true,
+    description = "The DPS username of the person who last updated this Prisoner's previous work.",
+  )
+  @get:JsonProperty("modifiedBy", required = true)
+  val modifiedBy: String,
+
+  @Schema(
+    example = "2023-06-19T09:39:44Z",
+    required = true,
+    description = "An ISO-8601 timestamp representing when this Prisoner's previous work was last updated. This will be the same as the created date if it has not yet been updated.",
+  )
+  @get:JsonProperty("modifiedDateTime", required = true)
+  val modifiedDateTime: java.time.OffsetDateTime,
+
+  @Schema(
+    example = "c88a6c48-97e2-4c04-93b5-98619966447b",
+    description = "A unique reference for this Prisoner's previous work experience (not the database primary key).",
+  )
+  @get:JsonProperty("id")
+  val id: Integer,
+
+  @field:Valid
+  @get:Size(min = 1)
+  @Schema(example = "null", description = "A list of the Prisoner's type of previous work experience.")
+  @get:JsonProperty("typeOfWorkExperience")
+  val typeOfWorkExperience: Set<WorkType>? = null,
+
+  @Schema(
+    example = "null",
+    description = "A specific work experience type for the Prisoner. Mandatory when 'typeOfWorkExperience' includes 'OTHER'.",
+  )
+  @get:JsonProperty("typeOfWorkExperienceOther")
+  val typeOfWorkExperienceOther: String? = null,
+
+  @field:Valid
+  @get:Size(min = 1)
+  @Schema(example = "null", description = "A list of the Prisoner's previous work experience details.")
+  @get:JsonProperty("workExperience")
+  val workExperience: Set<WorkExperience>? = null,
+
+  @field:Valid
+  @Schema(example = "null", description = "")
+  @get:JsonProperty("workInterests")
+  val workInterests: WorkInterestsResponse? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PreviousWorkResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PreviousWorkResponse.kt
@@ -30,13 +30,6 @@ data class PreviousWorkResponse(
   @get:JsonProperty("modifiedDateTime", required = true)
   val modifiedDateTime: java.time.OffsetDateTime,
 
-  @Schema(
-    example = "c88a6c48-97e2-4c04-93b5-98619966447b",
-    description = "A unique reference for this Prisoner's previous work experience (not the database primary key).",
-  )
-  @get:JsonProperty("id")
-  val id: Integer,
-
   @field:Valid
   @get:Size(min = 1)
   @Schema(example = "null", description = "A list of the Prisoner's type of previous work experience.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PrisonWorkAndEducationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PrisonWorkAndEducationResponse.kt
@@ -26,13 +26,6 @@ data class PrisonWorkAndEducationResponse(
   @get:JsonProperty("modifiedDateTime", required = true)
   val modifiedDateTime: java.time.OffsetDateTime,
 
-  @Schema(
-    example = "c88a6c48-97e2-4c04-93b5-98619966447b",
-    description = "A unique reference for this Prisoner's in-prison work and education interests (not the database primary key).",
-  )
-  @get:JsonProperty("id")
-  val id: Integer,
-
   @field:Valid
   @get:Size(min = 1)
   @Schema(example = "null", description = "A list of in-prison work that the Prisoner is interested in.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PrisonWorkAndEducationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/PrisonWorkAndEducationResponse.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
+
+/**
+ * A Prisoner's in-prison work and education interests. This is a temporary class to allow us to import data from the CIAG API.
+ */
+data class PrisonWorkAndEducationResponse(
+
+  @Schema(
+    example = "asmith_gen",
+    required = true,
+    description = "The DPS username of the person who last updated this Prisoner's in-prison work and education interests.",
+  )
+  @get:JsonProperty("modifiedBy", required = true)
+  val modifiedBy: String,
+
+  @Schema(
+    example = "2023-06-19T09:39:44Z",
+    required = true,
+    description = "An ISO-8601 timestamp representing when this Prisoner's in-prison work and education interests was last updated. This will be the same as the created date if it has not yet been updated.",
+  )
+  @get:JsonProperty("modifiedDateTime", required = true)
+  val modifiedDateTime: java.time.OffsetDateTime,
+
+  @Schema(
+    example = "c88a6c48-97e2-4c04-93b5-98619966447b",
+    description = "A unique reference for this Prisoner's in-prison work and education interests (not the database primary key).",
+  )
+  @get:JsonProperty("id")
+  val id: Integer,
+
+  @field:Valid
+  @get:Size(min = 1)
+  @Schema(example = "null", description = "A list of in-prison work that the Prisoner is interested in.")
+  @get:JsonProperty("inPrisonWork")
+  val inPrisonWork: Set<InPrisonWorkType>? = null,
+
+  @Schema(
+    example = "null",
+    description = "A specific type of in-prison work that does not fit the given 'inPrisonWork' types. Mandatory when 'inPrisonWork' includes 'OTHER'.",
+  )
+  @get:JsonProperty("inPrisonWorkOther")
+  val inPrisonWorkOther: String? = null,
+
+  @field:Valid
+  @get:Size(min = 1)
+  @Schema(
+    example = "null",
+    description = "Any potential in-prison education/training that the Prisoner is interested in.",
+  )
+  @get:JsonProperty("inPrisonEducation")
+  val inPrisonEducation: Set<InPrisonTrainingType>? = null,
+
+  @Schema(
+    example = "null",
+    description = "A specific type of in-prison education/training that does not fit the given 'inPrisonEducation' types. Mandatory when 'inPrisonEducation' includes 'OTHER'.",
+  )
+  @get:JsonProperty("inPrisonEducationOther")
+  val inPrisonEducationOther: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/ReasonNotToWork.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/ReasonNotToWork.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Reasons the Prisoner has given not to get work after leaving Prison.
+ */
+enum class ReasonNotToWork(val value: String) {
+
+  @JsonProperty("LIMIT_THEIR_ABILITY")
+  LIMIT_THEIR_ABILITY("LIMIT_THEIR_ABILITY"),
+
+  @JsonProperty("FULL_TIME_CARER")
+  FULL_TIME_CARER("FULL_TIME_CARER"),
+
+  @JsonProperty("LACKS_CONFIDENCE_OR_MOTIVATION")
+  LACKS_CONFIDENCE_OR_MOTIVATION("LACKS_CONFIDENCE_OR_MOTIVATION"),
+
+  @JsonProperty("HEALTH")
+  HEALTH("HEALTH"),
+
+  @JsonProperty("RETIRED")
+  RETIRED("RETIRED"),
+
+  @JsonProperty("NO_RIGHT_TO_WORK")
+  NO_RIGHT_TO_WORK("NO_RIGHT_TO_WORK"),
+
+  @JsonProperty("NOT_SURE")
+  NOT_SURE("NOT_SURE"),
+
+  @JsonProperty("OTHER")
+  OTHER("OTHER"),
+
+  @JsonProperty("NO_REASON")
+  NO_REASON("NO_REASON"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/SkillsAndInterestsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/SkillsAndInterestsResponse.kt
@@ -26,13 +26,6 @@ data class SkillsAndInterestsResponse(
   @get:JsonProperty("modifiedDateTime", required = true)
   val modifiedDateTime: java.time.OffsetDateTime,
 
-  @Schema(
-    example = "c88a6c48-97e2-4c04-93b5-98619966447b",
-    description = "A unique reference for this Prisoner's skills and interests (not the database primary key).",
-  )
-  @get:JsonProperty("id")
-  val id: Integer,
-
   @field:Valid
   @get:Size(min = 1)
   @Schema(example = "null", description = "One or more skills that the Prisoner feels they have.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/SkillsAndInterestsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/SkillsAndInterestsResponse.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
+
+/**
+ * Represents the personal skills and interests of a Prisoner. This is a temporary class to allow us to import data from the CIAG API.
+ */
+data class SkillsAndInterestsResponse(
+
+  @Schema(
+    example = "asmith_gen",
+    required = true,
+    description = "The DPS username of the person who last updated this Prisoner's skills and interests.",
+  )
+  @get:JsonProperty("modifiedBy", required = true)
+  val modifiedBy: String,
+
+  @Schema(
+    example = "2023-06-19T09:39:44Z",
+    required = true,
+    description = "An ISO-8601 timestamp representing when this Prisoner's skills and interests was last updated. This will be the same as the created date if it has not yet been updated.",
+  )
+  @get:JsonProperty("modifiedDateTime", required = true)
+  val modifiedDateTime: java.time.OffsetDateTime,
+
+  @Schema(
+    example = "c88a6c48-97e2-4c04-93b5-98619966447b",
+    description = "A unique reference for this Prisoner's skills and interests (not the database primary key).",
+  )
+  @get:JsonProperty("id")
+  val id: Integer,
+
+  @field:Valid
+  @get:Size(min = 1)
+  @Schema(example = "null", description = "One or more skills that the Prisoner feels they have.")
+  @get:JsonProperty("skills")
+  val skills: Set<PersonalSkill>? = null,
+
+  @Schema(
+    example = "null",
+    description = "A specific type of a skill that the Prisoner feels they have. Mandatory when 'skills' includes 'OTHER'.",
+  )
+  @get:JsonProperty("skillsOther")
+  val skillsOther: String? = null,
+
+  @field:Valid
+  @get:Size(min = 1)
+  @Schema(example = "null", description = "One or more interests that the Prisoner feels they have.")
+  @get:JsonProperty("personalInterests")
+  val personalInterests: Set<PersonalInterest>? = null,
+
+  @Schema(
+    example = "null",
+    description = "A specific type of a interest that the Prisoner feels they have. Mandatory when 'personalInterests' includes 'OTHER'.",
+  )
+  @get:JsonProperty("personalInterestsOther")
+  val personalInterestsOther: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/TrainingType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/TrainingType.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Additional training types that a Prisoner may have done.
+ */
+enum class TrainingType(val value: String) {
+
+  @JsonProperty("CSCS_CARD")
+  CSCS_CARD("CSCS_CARD"),
+
+  @JsonProperty("FIRST_AID_CERTIFICATE")
+  FIRST_AID_CERTIFICATE("FIRST_AID_CERTIFICATE"),
+
+  @JsonProperty("FOOD_HYGIENE_CERTIFICATE")
+  FOOD_HYGIENE_CERTIFICATE("FOOD_HYGIENE_CERTIFICATE"),
+
+  @JsonProperty("FULL_UK_DRIVING_LICENCE")
+  FULL_UK_DRIVING_LICENCE("FULL_UK_DRIVING_LICENCE"),
+
+  @JsonProperty("HEALTH_AND_SAFETY")
+  HEALTH_AND_SAFETY("HEALTH_AND_SAFETY"),
+
+  @JsonProperty("HGV_LICENCE")
+  HGV_LICENCE("HGV_LICENCE"),
+
+  @JsonProperty("MACHINERY_TICKETS")
+  MACHINERY_TICKETS("MACHINERY_TICKETS"),
+
+  @JsonProperty("MANUAL_HANDLING")
+  MANUAL_HANDLING("MANUAL_HANDLING"),
+
+  @JsonProperty("TRADE_COURSE")
+  TRADE_COURSE("TRADE_COURSE"),
+
+  @JsonProperty("OTHER")
+  OTHER("OTHER"),
+
+  @JsonProperty("NONE")
+  NONE("NONE"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/WorkExperience.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/WorkExperience.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+
+/**
+ * A Prisoner's list of work experience details. This is a temporary class to allow us to import data from the CIAG API.
+ */
+data class WorkExperience(
+
+  @field:Valid
+  @Schema(example = "null", required = true, description = "")
+  @get:JsonProperty("typeOfWorkExperience", required = true)
+  val typeOfWorkExperience: WorkType,
+
+  @Schema(
+    example = "null",
+    description = "A work experience, which is not listed in 'typeOfWorkExperience' Enum. Mandatory when 'typeOfWorkExperience' includes 'OTHER'.",
+  )
+  @get:JsonProperty("otherWork")
+  val otherWork: String? = null,
+
+  @Schema(example = "null", description = "This is the role the Prisoner had.")
+  @get:JsonProperty("role")
+  val role: String? = null,
+
+  @Schema(example = "null", description = "Additional details of the work.")
+  @get:JsonProperty("details")
+  val details: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/WorkInterestDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/WorkInterestDetail.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+
+/**
+ * Detail about a Prisoner's work interest.
+ */
+data class WorkInterestDetail(
+
+  @field:Valid
+  @Schema(example = "null", required = true, description = "")
+  @get:JsonProperty("workInterest", required = true)
+  val workInterest: WorkType,
+
+  @Schema(example = "null", description = "The role within a Prisoner's area of work interest.")
+  @get:JsonProperty("role")
+  val role: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/WorkInterestsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/WorkInterestsResponse.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
+
+/**
+ * The Prisoner's work interests. This is a temporary class to allow us to import data from the CIAG API.
+ */
+data class WorkInterestsResponse(
+
+  @Schema(
+    example = "c88a6c48-97e2-4c04-93b5-98619966447b",
+    required = true,
+    description = "A unique reference for this Prisoner's work interests.",
+  )
+  @get:JsonProperty("id", required = true)
+  val id: java.util.UUID,
+
+  @Schema(
+    example = "asmith_gen",
+    required = true,
+    description = "The DPS username of the person who last updated the Induction.",
+  )
+  @get:JsonProperty("modifiedBy", required = true)
+  val modifiedBy: String,
+
+  @Schema(
+    example = "2023-06-19T09:39:44Z",
+    required = true,
+    description = "An ISO-8601 timestamp representing when the Goal was last updated. This will be the same as the created date if it has not yet been updated.",
+  )
+  @get:JsonProperty("modifiedDateTime", required = true)
+  val modifiedDateTime: java.time.OffsetDateTime,
+
+  @field:Valid
+  @get:Size(min = 1)
+  @Schema(example = "null", required = true, description = "A list of Prisoner's future work interests.")
+  @get:JsonProperty("workInterests", required = true)
+  val workInterests: Set<WorkType>,
+
+  @Schema(
+    example = "null",
+    description = "A work interest, which is not listed in 'workInterests' Enum. Mandatory when 'workInterests' includes 'OTHER'.",
+  )
+  @get:JsonProperty("workInterestsOther")
+  val workInterestsOther: String? = null,
+
+  @field:Valid
+  @Schema(example = "null", description = "A detailed list of work interests that a Prisoner has.")
+  @get:JsonProperty("particularJobInterests")
+  val particularJobInterests: Set<WorkInterestDetail>? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/WorkInterestsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/WorkInterestsResponse.kt
@@ -11,14 +11,6 @@ import jakarta.validation.constraints.Size
 data class WorkInterestsResponse(
 
   @Schema(
-    example = "c88a6c48-97e2-4c04-93b5-98619966447b",
-    required = true,
-    description = "A unique reference for this Prisoner's work interests.",
-  )
-  @get:JsonProperty("id", required = true)
-  val id: java.util.UUID,
-
-  @Schema(
     example = "asmith_gen",
     required = true,
     description = "The DPS username of the person who last updated the Induction.",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/WorkType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/resource/model/WorkType.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * The various categories of work that a Prisoner may have worked in, or be interested in working in the future.
+ */
+enum class WorkType(val value: String) {
+
+  @JsonProperty("OUTDOOR")
+  OUTDOOR("OUTDOOR"),
+
+  @JsonProperty("CONSTRUCTION")
+  CONSTRUCTION("CONSTRUCTION"),
+
+  @JsonProperty("DRIVING")
+  DRIVING("DRIVING"),
+
+  @JsonProperty("BEAUTY")
+  BEAUTY("BEAUTY"),
+
+  @JsonProperty("HOSPITALITY")
+  HOSPITALITY("HOSPITALITY"),
+
+  @JsonProperty("TECHNICAL")
+  TECHNICAL("TECHNICAL"),
+
+  @JsonProperty("MANUFACTURING")
+  MANUFACTURING("MANUFACTURING"),
+
+  @JsonProperty("OFFICE")
+  OFFICE("OFFICE"),
+
+  @JsonProperty("RETAIL")
+  RETAIL("RETAIL"),
+
+  @JsonProperty("SPORTS")
+  SPORTS("SPORTS"),
+
+  @JsonProperty("WAREHOUSING")
+  WAREHOUSING("WAREHOUSING"),
+
+  @JsonProperty("WASTE_MANAGEMENT")
+  WASTE_MANAGEMENT("WASTE_MANAGEMENT"),
+
+  @JsonProperty("EDUCATION_TRAINING")
+  EDUCATION_TRAINING("EDUCATION_TRAINING"),
+
+  @JsonProperty("CLEANING_AND_MAINTENANCE")
+  CLEANING_AND_MAINTENANCE("CLEANING_AND_MAINTENANCE"),
+
+  @JsonProperty("OTHER")
+  OTHER("OTHER"),
+}


### PR DESCRIPTION
This PR adds model objects to deserialise the CIAG response, so that we can then map the data to temporary entities (to follow in a subsequent PR).