### PR TITLE
NO_JIRA - refactor CiagInductionEventBuilder to InboundEventBuilder in correct package

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/CiagInductionTimelineEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/CiagInductionTimelineEventTest.kt
@@ -9,8 +9,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.service.events.aValidCiagInductionCreatedEvent
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.service.events.aValidCiagInductionUpdatedEvent
 
 internal class CiagInductionTimelineEventTest : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsServiceTest.kt
@@ -15,8 +15,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelineService
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.service.events.aValidCiagInductionCreatedEvent
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.service.events.aValidCiagInductionUpdatedEvent
 
 @ExtendWith(MockitoExtension::class)
 internal class InboundEventsServiceTest {

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventBuilder.kt
@@ -1,11 +1,6 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.service.events
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.Identifier
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.InboundEvent
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.PersonReference
 import java.time.Instant
 import java.util.UUID
 


### PR DESCRIPTION
Moved `CiagInductionEventBuilder` to "correct" package and renamed it `InboundEventBuilder` (because thats what it builds 😁 )