### PR TITLE
RR-508 - Change paths to match that of current implementation in CIAG API

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -46,7 +46,7 @@ abstract class IntegrationTestBase {
     const val CREATE_ACTION_PLAN_URI_TEMPLATE = "/action-plans/{prisonNumber}"
     const val GET_ACTION_PLAN_URI_TEMPLATE = "/action-plans/{prisonNumber}"
     const val GET_TIMELINE_URI_TEMPLATE = "/timelines/{prisonNumber}"
-    const val INDUCTION_URI_TEMPLATE = "/ciag-inductions/{prisonNumber}"
+    const val INDUCTION_URI_TEMPLATE = "/ciag/induction/{prisonNumber}"
 
     private val localStackContainer = LocalStackContainer.instance
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 class CreateInductionTest : IntegrationTestBase() {
 
   companion object {
-    private const val URI_TEMPLATE = "/ciag-inductions/{prisonNumber}"
+    private const val URI_TEMPLATE = "/ciag/induction/{prisonNumber}"
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.isEqu
 class GetInductionTest : IntegrationTestBase() {
 
   companion object {
-    private const val URI_TEMPLATE = "/ciag-inductions/{prisonNumber}"
+    private const val URI_TEMPLATE = "/ciag/induction/{prisonNumber}"
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -54,7 +54,7 @@ import java.util.UUID
 class UpdateInductionTest : IntegrationTestBase() {
 
   companion object {
-    private const val URI_TEMPLATE = "/ciag-inductions/{prisonNumber}"
+    private const val URI_TEMPLATE = "/ciag/induction/{prisonNumber}"
   }
 
   @Test

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/InductionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/InductionController.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateCiagInductionRequest
 
 @RestController
-@RequestMapping(value = ["/ciag-inductions"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(value = ["/ciag/induction"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class InductionController(
   private val inductionService: InductionService,
   private val createInductionRequestMapper: CreateCiagInductionRequestMapper,

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.4.9'
+  version: '1.5.0'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -158,7 +158,7 @@ paths:
     #
     # CIAG Inductions (Inherited from the CIAG Team)
     #
-  '/ciag-inductions/{prisonNumber}':
+  '/ciag/induction/{prisonNumber}':
     parameters:
       - name: prisonNumber
         description: The number of the Prisoner who may have relevant Induction data.


### PR DESCRIPTION
We know these paths are not ideal, but having the paths the same as the current CIAG API will make migrating the clients much much easier.
We will look to change the paths (and the request and response objects) when we re-design the API once we have migrated the UI clients