### PR TITLE
RR-503 - Services for importing Inductions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,10 @@ dependencies {
   testFixturesImplementation("io.jsonwebtoken:jjwt-impl:0.11.5")
   testFixturesImplementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
   testFixturesImplementation("com.nimbusds:nimbus-jose-jwt:9.31")
+
+  // TODO RR-502 - remove these dependencies once the CIAG data has been migrated
+  integrationTestImplementation("com.github.tomakehurst:wiremock-jre8-standalone:2.35.1")
+  testFixturesImplementation("com.github.tomakehurst:wiremock-jre8-standalone:2.35.1")
 }
 
 java {

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -2,7 +2,8 @@
 # Per environment values which override defaults in hmpps-education-and-work-plan-api/values.yaml
 
 generic-service:
-  replicaCount: 2
+  # TODO - RR-502 - Set this back to 2
+  replicaCount: 1
 
   ingress:
     host: learningandworkprogress-api-dev.hmpps.service.justice.gov.uk

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationServiceTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationServiceTest.kt
@@ -9,6 +9,15 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.anotherValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.entity.HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.entity.HopingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.entity.InPrisonTrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.entity.InPrisonWorkType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.entity.InterestType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.entity.SkillType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.entity.TrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.entity.WorkExperienceType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.entity.WorkInterestType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.repository.InductionMigrationRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model.aValidCiagInductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.TimelineEventEntity
@@ -57,10 +66,28 @@ class CiagInductionMigrationServiceTest : IntegrationTestBase() {
     val importedInduction1 = inductionMigrationRepository.findByPrisonNumber(prisonNumber1)
     assertThat(importedInduction1).isNotNull
     assertThat(importedInduction1!!.prisonNumber).isEqualTo(prisonNumber1)
+    assertThat(importedInduction1.workOnRelease!!.hopingToWork).isEqualTo(HopingToWork.NOT_SURE)
+    assertThat(importedInduction1.previousQualifications!!.educationLevel).isEqualTo(SECONDARY_SCHOOL_TOOK_EXAMS)
+    assertThat(importedInduction1.previousTraining!!.trainingTypes).containsExactly(TrainingType.OTHER)
+    assertThat(importedInduction1.previousWorkExperiences!!.experiences!![0].experienceType).isEqualTo(WorkExperienceType.OTHER)
+    assertThat(importedInduction1.inPrisonInterests!!.inPrisonWorkInterests!![0].workType).isEqualTo(InPrisonWorkType.OTHER)
+    assertThat(importedInduction1.inPrisonInterests!!.inPrisonTrainingInterests!![0].trainingType).isEqualTo(InPrisonTrainingType.OTHER)
+    assertThat(importedInduction1.personalSkillsAndInterests!!.skills!![0].skillType).isEqualTo(SkillType.OTHER)
+    assertThat(importedInduction1.personalSkillsAndInterests!!.interests!![0].interestType).isEqualTo(InterestType.OTHER)
+    assertThat(importedInduction1.futureWorkInterests!!.interests!![0].workType).isEqualTo(WorkInterestType.OTHER)
 
     val importedInduction2 = inductionMigrationRepository.findByPrisonNumber(prisonNumber2)
     assertThat(importedInduction2).isNotNull
     assertThat(importedInduction2!!.prisonNumber).isEqualTo(prisonNumber2)
+    assertThat(importedInduction2.workOnRelease!!.hopingToWork).isEqualTo(HopingToWork.NOT_SURE)
+    assertThat(importedInduction2.previousQualifications!!.educationLevel).isEqualTo(SECONDARY_SCHOOL_TOOK_EXAMS)
+    assertThat(importedInduction2.previousTraining!!.trainingTypes).containsExactly(TrainingType.OTHER)
+    assertThat(importedInduction2.previousWorkExperiences!!.experiences!![0].experienceType).isEqualTo(WorkExperienceType.OTHER)
+    assertThat(importedInduction2.inPrisonInterests!!.inPrisonWorkInterests!![0].workType).isEqualTo(InPrisonWorkType.OTHER)
+    assertThat(importedInduction2.inPrisonInterests!!.inPrisonTrainingInterests!![0].trainingType).isEqualTo(InPrisonTrainingType.OTHER)
+    assertThat(importedInduction2.personalSkillsAndInterests!!.skills!![0].skillType).isEqualTo(SkillType.OTHER)
+    assertThat(importedInduction2.personalSkillsAndInterests!!.interests!![0].interestType).isEqualTo(InterestType.OTHER)
+    assertThat(importedInduction2.futureWorkInterests!!.interests!![0].workType).isEqualTo(WorkInterestType.OTHER)
   }
 
   fun aValidInductionCreatedTimelineEntity(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationServiceTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationServiceTest.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.transaction.TestTransaction
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.anotherValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.repository.InductionMigrationRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model.aValidCiagInductionResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.TimelineEventEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.TimelineEventType.INDUCTION_CREATED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.aValidTimelineEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.aValidTimelineEventEntity
+
+class CiagInductionMigrationServiceTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var inductionMigrationService: CiagInductionMigrationService
+
+  @Autowired
+  private lateinit var inductionMigrationRepository: InductionMigrationRepository
+
+  @Autowired
+  private lateinit var wiremockService: WiremockService
+
+  @BeforeEach
+  fun resetWiremock() {
+    wiremockService.resetAllStubsAndMappings()
+  }
+
+  @Test
+  @Transactional
+  fun `should import CIAG Inductions`() {
+    // Given
+    val prisonNumber1 = aValidPrisonNumber()
+    val inductionCreatedEvent1 = aValidInductionCreatedTimelineEntity(prisonNumber = prisonNumber1)
+    val prisonNumber2 = anotherValidPrisonNumber()
+    val inductionCreatedEvent2 = aValidInductionCreatedTimelineEntity(prisonNumber = prisonNumber2)
+    timelineRepository.saveAll(listOf(inductionCreatedEvent1, inductionCreatedEvent2))
+    TestTransaction.flagForCommit()
+    TestTransaction.end()
+    TestTransaction.start()
+
+    val inductionResponse1 = aValidCiagInductionResponse(offenderId = prisonNumber1)
+    val inductionResponse2 = aValidCiagInductionResponse(offenderId = prisonNumber2)
+    wiremockService.stubGetInductionFromCiagApi(inductionResponse1)
+    wiremockService.stubGetInductionFromCiagApi(inductionResponse2)
+
+    // When
+    inductionMigrationService.migrateCiagInductions()
+
+    // Then
+    val importedInduction1 = inductionMigrationRepository.findByPrisonNumber(prisonNumber1)
+    assertThat(importedInduction1).isNotNull
+    assertThat(importedInduction1!!.prisonNumber).isEqualTo(prisonNumber1)
+
+    val importedInduction2 = inductionMigrationRepository.findByPrisonNumber(prisonNumber2)
+    assertThat(importedInduction2).isNotNull
+    assertThat(importedInduction2!!.prisonNumber).isEqualTo(prisonNumber2)
+  }
+
+  fun aValidInductionCreatedTimelineEntity(
+    prisonNumber: String = aValidPrisonNumber(),
+    events: MutableList<TimelineEventEntity> = mutableListOf(aValidTimelineEventEntity(eventType = INDUCTION_CREATED)),
+  ) = aValidTimelineEntity(
+    prisonNumber = prisonNumber,
+    events = events,
+  )
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/TestWebClientConfiguration.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/TestWebClientConfiguration.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class TestWebClientConfiguration {
+
+  /**
+   * Override the main [WebClient] configuration, as we do not need OAuth2 authorisation for Wiremock.
+   */
+  @Bean
+  @Primary
+  fun testCiagApiWebClient(
+    @Value("\${apis.ciag-induction.url}") ciagInductionApiUri: String,
+    builder: WebClient.Builder,
+  ): WebClient =
+    builder.baseUrl(ciagInductionApiUri).build()
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/WiremockConfiguration.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/WiremockConfiguration.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import com.github.tomakehurst.wiremock.http.Request
+import com.github.tomakehurst.wiremock.http.Response
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+private val logger = KotlinLogging.logger {}
+
+@Configuration
+class WiremockConfiguration {
+
+  @Bean
+  fun wireMockServer(
+    @Value("\${logWiremockRequests:false}") logWiremockRequests: Boolean,
+  ): WireMockServer =
+    WireMockServer(
+      options().port(9093),
+    ).apply {
+      if (logWiremockRequests) {
+        addMockServiceRequestListener { request: Request, _: Response ->
+          val formattedHeaders = request.headers.all().joinToString("\n") {
+            "${it.key()}: ${it.values().joinToString(", ")}"
+          }
+          val logMessage = StringBuilder()
+            .appendLine("Request sent to wiremock:")
+            .appendLine("${request.method} ${request.absoluteUrl}")
+            .appendLine(formattedHeaders)
+            .appendLine()
+            .appendLine(request.bodyAsString)
+          logger.info { logMessage }
+        }
+      }
+      start()
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionMigrationService.kt
@@ -16,6 +16,7 @@ private val log = KotlinLogging.logger {}
 @Service
 class CiagInductionMigrationService(
   private val timelineLookupService: PrisonerInductionTimelineLookupService,
+  private val inductionPersistenceService: CiagInductionPersistenceService,
   private val ciagWebClient: WebClient,
 ) {
 
@@ -32,7 +33,7 @@ class CiagInductionMigrationService(
         if (ciagInduction == null) {
           log.warn { "Unable to retrieve Induction for Prisoner $prisonNumber" }
         } else {
-          log.info { "Deserialized Induction for prisoner $prisonNumber" }
+          inductionPersistenceService.saveInduction(ciagInduction)
         }
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionPersistenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionPersistenceService.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.repository.InductionMigrationRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.mapper.InductionMigrationMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model.CiagInductionResponse
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class CiagInductionPersistenceService(
+  private val inductionMigrationRepository: InductionMigrationRepository,
+  private val inductionMigrationMapper: InductionMigrationMapper,
+) {
+
+  @Transactional
+  fun saveInduction(ciagInduction: CiagInductionResponse) {
+    val prisonNumber = ciagInduction.offenderId
+    if (inductionMigrationRepository.findByPrisonNumber(prisonNumber) != null) {
+      log.warn { "Induction for Prisoner $prisonNumber has already been migrated" }
+      return
+    }
+
+    log.info { "Migrating Induction for prisoner $prisonNumber" }
+    inductionMigrationRepository.save(inductionMigrationMapper.toInductionMigrationEntity(ciagInduction))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionPersistenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/CiagInductionPersistenceServiceTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.entity.aValidInductionMigrationEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.jpa.repository.InductionMigrationRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.mapper.InductionMigrationMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model.aValidCiagInductionResponse
+
+@ExtendWith(MockitoExtension::class)
+class CiagInductionPersistenceServiceTest {
+
+  @Mock
+  private lateinit var inductionMigrationRepository: InductionMigrationRepository
+
+  @Mock
+  private lateinit var inductionMigrationMapper: InductionMigrationMapper
+
+  @InjectMocks
+  private lateinit var inductionPersistenceService: CiagInductionPersistenceService
+
+  @Test
+  fun `should save induction given induction has not been imported`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val ciagInduction = aValidCiagInductionResponse(offenderId = prisonNumber)
+    val inductionEntity = aValidInductionMigrationEntity(prisonNumber = prisonNumber)
+    given(inductionMigrationRepository.findByPrisonNumber(any())).willReturn(null)
+    given(inductionMigrationMapper.toInductionMigrationEntity(any())).willReturn(inductionEntity)
+
+    // When
+    inductionPersistenceService.saveInduction(ciagInduction)
+
+    // Then
+    verify(inductionMigrationRepository).findByPrisonNumber(prisonNumber)
+    verify(inductionMigrationMapper).toInductionMigrationEntity(ciagInduction)
+    verify(inductionMigrationRepository).save(inductionEntity)
+  }
+
+  @Test
+  fun `should not save induction given induction has been imported`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val ciagInduction = aValidCiagInductionResponse(offenderId = prisonNumber)
+
+    given(inductionMigrationRepository.findByPrisonNumber(any())).willReturn(aValidInductionMigrationEntity())
+
+    // When
+    inductionPersistenceService.saveInduction(ciagInduction)
+
+    // Then
+    verify(inductionMigrationRepository).findByPrisonNumber(prisonNumber)
+    verifyNoInteractions(inductionMigrationMapper)
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/WiremockService.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/ciagmigration/WiremockService.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.ciagmigration.resource.model.CiagInductionResponse
+
+/**
+ * Service class to provide support to tests with setting up and managing wiremock stubs
+ */
+@Service
+class WiremockService(private val wireMockServer: WireMockServer) {
+
+  @Autowired
+  private lateinit var objectMapper: ObjectMapper
+
+  fun resetAllStubsAndMappings() {
+    wireMockServer.resetAll()
+  }
+
+  fun stubGetInductionFromCiagApi(ciagResponse: CiagInductionResponse) {
+    val prisonNumber = ciagResponse.offenderId
+    wireMockServer.stubFor(
+      get(urlPathMatching("/ciag/induction/$prisonNumber"))
+        .willReturn(
+          responseDefinition()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(ciagResponse)),
+        ),
+    )
+  }
+}


### PR DESCRIPTION
This PR implements the remaining functionality `CiagInductionMigrationService`, alongside a new service class: `CiagInductionPersistenceService`.

It also adds an integration test, which uses wiremock to simulate the retrieval of Inductions from the CIAG API.

As part of this PR, I've set the replica count to 1, as we may as well do this now. I'm planning on running this at least once before the UIs are ready to make sure everything is migrated across. I'll just need to delete the data inbetween.