### PR TITLE
RR-510 - App Insights events for Inductions

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
@@ -157,10 +157,10 @@ class CreateInductionTest : IntegrationTestBase() {
       )
       val createInductionEventProperties = eventPropertiesCaptor.firstValue
       assertThat(createInductionEventProperties)
-        .containsEntry("prisonNumber", prisonNumber)
         .containsEntry("prisonId", prisonId)
         .containsEntry("userId", dpsUsername)
         .containsKey("correlationId")
+        .containsKey("reference")
         .containsKey("timestamp")
     }
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
@@ -151,7 +151,7 @@ class CreateInductionTest : IntegrationTestBase() {
     await.untilAsserted {
       val eventPropertiesCaptor = ArgumentCaptor.forClass(Map::class.java as Class<Map<String, String>>)
       verify(telemetryClient, times(1)).trackEvent(
-        eq("induction-created"),
+        eq("INDUCTION_CREATED"),
         capture(eventPropertiesCaptor),
         eq(null),
       )
@@ -159,9 +159,7 @@ class CreateInductionTest : IntegrationTestBase() {
       assertThat(createInductionEventProperties)
         .containsEntry("prisonId", prisonId)
         .containsEntry("userId", dpsUsername)
-        .containsKey("correlationId")
         .containsKey("reference")
-        .containsKey("timestamp")
     }
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -286,7 +286,7 @@ class UpdateInductionTest : IntegrationTestBase() {
     await.untilAsserted {
       val eventPropertiesCaptor = ArgumentCaptor.forClass(Map::class.java as Class<Map<String, String>>)
       verify(telemetryClient, times(1)).trackEvent(
-        eq("induction-updated"),
+        eq("INDUCTION_UPDATED"),
         capture(eventPropertiesCaptor),
         eq(null),
       )
@@ -294,9 +294,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       assertThat(createInductionEventProperties)
         .containsEntry("prisonId", "MDI")
         .containsEntry("userId", "auser_gen")
-        .containsKey("correlationId")
         .containsKey("reference")
-        .containsKey("timestamp")
     }
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -292,10 +292,10 @@ class UpdateInductionTest : IntegrationTestBase() {
       )
       val createInductionEventProperties = eventPropertiesCaptor.firstValue
       assertThat(createInductionEventProperties)
-        .containsEntry("prisonNumber", prisonNumber)
         .containsEntry("prisonId", "MDI")
         .containsEntry("userId", "auser_gen")
         .containsKey("correlationId")
+        .containsKey("reference")
         .containsKey("timestamp")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
@@ -17,25 +18,22 @@ private val log = KotlinLogging.logger {}
 @Component
 class AsyncInductionEventService(
   private val timelineService: TimelineService,
+  private val telemetryService: TelemetryService,
 ) : InductionEventService {
 
   override fun inductionCreated(createdInduction: Induction) {
     runBlocking {
       log.debug { "Induction created event for prisoner [${createdInduction.prisonNumber}]" }
-      timelineService.recordTimelineEvent(
-        createdInduction.prisonNumber,
-        buildInductionCreatedEvent(createdInduction),
-      )
+      launch { timelineService.recordTimelineEvent(createdInduction.prisonNumber, buildInductionCreatedEvent(createdInduction)) }
+      launch { telemetryService.trackInductionCreated(induction = createdInduction) }
     }
   }
 
   override fun inductionUpdated(updatedInduction: Induction) {
     runBlocking {
       log.debug { "Induction updated event for prisoner [${updatedInduction.prisonNumber}]" }
-      timelineService.recordTimelineEvent(
-        updatedInduction.prisonNumber,
-        buildInductionUpdatedEvent(updatedInduction),
-      )
+      launch { timelineService.recordTimelineEvent(updatedInduction.prisonNumber, buildInductionUpdatedEvent(updatedInduction)) }
+      launch { telemetryService.trackInductionUpdated(induction = updatedInduction) }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalTelemetryEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalTelemetryEventType.kt
@@ -8,7 +8,7 @@ import java.util.UUID
  *   * a text field `value` that is the name of the customEvent recorded in App Insights.
  *   * a function `customDimensions` that returns the customDimensions that are recorded with the App Insights event.
  */
-enum class TelemetryEventType(val value: String, val customDimensions: (goal: Goal, correlationId: UUID) -> Map<String, String>) {
+enum class GoalTelemetryEventType(val value: String, val customDimensions: (goal: Goal, correlationId: UUID) -> Map<String, String>) {
   GOAL_CREATED(
     "goal-created",
     { goal, correlationId ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/InductionTelemetryEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/InductionTelemetryEventType.kt
@@ -17,7 +17,7 @@ enum class InductionTelemetryEventType(
     { induction, correlationId ->
       mapOf(
         "correlationId" to correlationId.toString(),
-        "prisonNumber" to induction.prisonNumber,
+        "reference" to induction.reference.toString(),
         "prisonId" to induction.createdAtPrison,
         "userId" to induction.createdBy!!,
         "timestamp" to induction.createdAt.toString(),
@@ -30,7 +30,7 @@ enum class InductionTelemetryEventType(
     { induction, correlationId ->
       mapOf(
         "correlationId" to correlationId.toString(),
-        "prisonNumber" to induction.prisonNumber,
+        "reference" to induction.reference.toString(),
         "prisonId" to induction.lastUpdatedAtPrison,
         "userId" to induction.lastUpdatedBy!!,
         "timestamp" to induction.lastUpdatedAt.toString(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/InductionTelemetryEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/InductionTelemetryEventType.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Induction
+import java.util.UUID
+
+/**
+ * An enumeration of the types of Induction events that can be sent to the Telemetry Service, where each item has:
+ *   * a text field `value` that is the name of the customEvent recorded in App Insights.
+ *   * a function `customDimensions` that returns the customDimensions that are recorded with the App Insights event.
+ */
+enum class InductionTelemetryEventType(
+  val value: String,
+  val customDimensions: (induction: Induction, correlationId: UUID) -> Map<String, String>,
+) {
+  INDUCTION_CREATED(
+    "induction-created",
+    { induction, correlationId ->
+      mapOf(
+        "correlationId" to correlationId.toString(),
+        "prisonNumber" to induction.prisonNumber,
+        "prisonId" to induction.createdAtPrison,
+        "userId" to induction.createdBy!!,
+        "timestamp" to induction.createdAt.toString(),
+      )
+    },
+  ),
+
+  INDUCTION_UPDATED(
+    "induction-updated",
+    { induction, correlationId ->
+      mapOf(
+        "correlationId" to correlationId.toString(),
+        "prisonNumber" to induction.prisonNumber,
+        "prisonId" to induction.lastUpdatedAtPrison,
+        "userId" to induction.lastUpdatedBy!!,
+        "timestamp" to induction.lastUpdatedAt.toString(),
+      )
+    },
+  ),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/InductionTelemetryEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/InductionTelemetryEventType.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Induction
-import java.util.UUID
 
 /**
  * An enumeration of the types of Induction events that can be sent to the Telemetry Service, where each item has:
@@ -10,30 +9,26 @@ import java.util.UUID
  */
 enum class InductionTelemetryEventType(
   val value: String,
-  val customDimensions: (induction: Induction, correlationId: UUID) -> Map<String, String>,
+  val customDimensions: (induction: Induction) -> Map<String, String>,
 ) {
   INDUCTION_CREATED(
-    "induction-created",
-    { induction, correlationId ->
+    "INDUCTION_CREATED",
+    { induction ->
       mapOf(
-        "correlationId" to correlationId.toString(),
         "reference" to induction.reference.toString(),
         "prisonId" to induction.createdAtPrison,
         "userId" to induction.createdBy!!,
-        "timestamp" to induction.createdAt.toString(),
       )
     },
   ),
 
   INDUCTION_UPDATED(
-    "induction-updated",
-    { induction, correlationId ->
+    "INDUCTION_UPDATED",
+    { induction ->
       mapOf(
-        "correlationId" to correlationId.toString(),
         "reference" to induction.reference.toString(),
         "prisonId" to induction.lastUpdatedAtPrison,
         "userId" to induction.lastUpdatedBy!!,
-        "timestamp" to induction.lastUpdatedAt.toString(),
       )
     },
   ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryEventTypeResolver.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryEventTypeResolver.kt
@@ -1,16 +1,16 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_ARCHIVED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_COMPLETED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_STARTED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_UPDATED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_ADDED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_COMPLETED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_NOT_STARTED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_REMOVED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_STARTED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_UPDATED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_ARCHIVED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_COMPLETED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_STARTED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_UPDATED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_ADDED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_COMPLETED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_NOT_STARTED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_REMOVED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_STARTED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_UPDATED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStat
 class TelemetryEventTypeResolver {
 
   /**
-   * Compares two [Goal]s and returns a list of [TelemetryEventType] reflecting the types of updates
+   * Compares two [Goal]s and returns a list of [GoalTelemetryEventType] reflecting the types of updates
    * between the two [Goal]s.
    *
    * Depending on the type and number of updates between the two [Goal]s it is possible for the returned list to contain
@@ -30,8 +30,8 @@ class TelemetryEventTypeResolver {
    * This method is deliberately marked as `internal` as there are no envisaged use cases for it outside the domain
    * module.
    */
-  internal fun resolveUpdateEventTypes(previousGoal: Goal, updatedGoal: Goal): List<TelemetryEventType> {
-    val updateTypes = mutableListOf<TelemetryEventType>()
+  internal fun resolveUpdateEventTypes(previousGoal: Goal, updatedGoal: Goal): List<GoalTelemetryEventType> {
+    val updateTypes = mutableListOf<GoalTelemetryEventType>()
     // check if the goal itself was updated, excluding its steps and status
     if (hasGoalBeenUpdated(previousGoal = previousGoal, updatedGoal = updatedGoal)) {
       updateTypes.add(GOAL_UPDATED)
@@ -87,7 +87,7 @@ class TelemetryEventTypeResolver {
   private fun hasGoalStatusChanged(previousGoal: Goal, updatedGoal: Goal) =
     updatedGoal.status != previousGoal.status
 
-  private fun getTelemetryUpdateEventTypeForGoalStatusChange(updatedGoal: Goal): TelemetryEventType =
+  private fun getTelemetryUpdateEventTypeForGoalStatusChange(updatedGoal: Goal): GoalTelemetryEventType =
     when (updatedGoal.status) {
       GoalStatus.COMPLETED -> GOAL_COMPLETED
       GoalStatus.ACTIVE -> GOAL_STARTED
@@ -101,7 +101,7 @@ class TelemetryEventTypeResolver {
   private fun hasStepStatusChanged(previousStep: Step, updatedStep: Step) =
     previousStep.status != updatedStep.status
 
-  private fun getTelemetryUpdateEventTypeForStepStatusChange(step: Step): TelemetryEventType =
+  private fun getTelemetryUpdateEventTypeForStepStatusChange(step: Step): GoalTelemetryEventType =
     when (step.status) {
       StepStatus.NOT_STARTED -> STEP_NOT_STARTED
       StepStatus.ACTIVE -> STEP_STARTED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
@@ -3,10 +3,13 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 import com.microsoft.applicationinsights.TelemetryClient
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.trackEvent
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_CREATED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_UPDATED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_REMOVED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_CREATED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_UPDATED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_REMOVED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.InductionTelemetryEventType.INDUCTION_CREATED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.InductionTelemetryEventType.INDUCTION_UPDATED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Induction
 import java.util.UUID
 
 /**
@@ -42,6 +45,22 @@ class TelemetryService(
     )
   }
 
+  fun trackInductionCreated(induction: Induction, correlationId: UUID = UUID.randomUUID()) {
+    sendTelemetryEventForInduction(
+      induction = induction,
+      correlationId = correlationId,
+      telemetryEventType = INDUCTION_CREATED,
+    )
+  }
+
+  fun trackInductionUpdated(induction: Induction, correlationId: UUID = UUID.randomUUID()) {
+    sendTelemetryEventForInduction(
+      induction = induction,
+      correlationId = correlationId,
+      telemetryEventType = INDUCTION_UPDATED,
+    )
+  }
+
   /**
    * Sends all goal update telemetry tracking events based on the differences between the previousGoal and the
    * updatedGoal.
@@ -59,6 +78,9 @@ class TelemetryService(
     }
   }
 
-  private fun sendTelemetryEventForGoal(goal: Goal, correlationId: UUID, telemetryEventType: TelemetryEventType) =
+  private fun sendTelemetryEventForGoal(goal: Goal, correlationId: UUID, telemetryEventType: GoalTelemetryEventType) =
     telemetryClient.trackEvent(telemetryEventType.value, telemetryEventType.customDimensions(goal, correlationId))
+
+  private fun sendTelemetryEventForInduction(induction: Induction, correlationId: UUID, telemetryEventType: InductionTelemetryEventType) =
+    telemetryClient.trackEvent(telemetryEventType.value, telemetryEventType.customDimensions(induction, correlationId))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryService.kt
@@ -45,18 +45,16 @@ class TelemetryService(
     )
   }
 
-  fun trackInductionCreated(induction: Induction, correlationId: UUID = UUID.randomUUID()) {
+  fun trackInductionCreated(induction: Induction) {
     sendTelemetryEventForInduction(
       induction = induction,
-      correlationId = correlationId,
       telemetryEventType = INDUCTION_CREATED,
     )
   }
 
-  fun trackInductionUpdated(induction: Induction, correlationId: UUID = UUID.randomUUID()) {
+  fun trackInductionUpdated(induction: Induction) {
     sendTelemetryEventForInduction(
       induction = induction,
-      correlationId = correlationId,
       telemetryEventType = INDUCTION_UPDATED,
     )
   }
@@ -81,6 +79,6 @@ class TelemetryService(
   private fun sendTelemetryEventForGoal(goal: Goal, correlationId: UUID, telemetryEventType: GoalTelemetryEventType) =
     telemetryClient.trackEvent(telemetryEventType.value, telemetryEventType.customDimensions(goal, correlationId))
 
-  private fun sendTelemetryEventForInduction(induction: Induction, correlationId: UUID, telemetryEventType: InductionTelemetryEventType) =
-    telemetryClient.trackEvent(telemetryEventType.value, telemetryEventType.customDimensions(induction, correlationId))
+  private fun sendTelemetryEventForInduction(induction: Induction, telemetryEventType: InductionTelemetryEventType) =
+    telemetryClient.trackEvent(telemetryEventType.value, telemetryEventType.customDimensions(induction))
 }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -172,7 +172,7 @@ paths:
       description: |
         Creates an Induction for a Prisoner (if it does not already exist). This endpoint has been migrated from the
         `hmpps-ciag-careers-induction-api` and the data structure has been kept the same in order to prevent breaking
-        the UI when it is ports to this endpoint.
+        the UI when it points to this endpoint.
       tags:
         - Induction
       responses:
@@ -203,7 +203,7 @@ paths:
         information provided in the update request. If a field is not included in the update request, it will be removed from the 
         database, effectively making the update request the authoritative source of information. This endpoint has been migrated
         from the `hmpps-ciag-careers-induction-api` and the data structure has been kept the same in order to prevent breaking
-        the CIAG UI when it is ports to this endpoint.
+        the CIAG UI when it points to this endpoint.
       tags:
         - Induction
       responses:
@@ -225,7 +225,7 @@ paths:
         prisoner. If the returned data does not include summary data for a given prisoner it can be inferred that the
         prisoner does not have a CIAG Induction.
         This endpoint has been migrated from the `hmpps-ciag-careers-induction-api` and the data structure has been 
-        kept the same in order to prevent breaking the UI when it is ports to this endpoint.
+        kept the same in order to prevent breaking the UI when it points to this endpoint.
       tags:
         - Induction
       responses:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventServiceTest.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aVa
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelineService
-import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
 class AsyncInductionEventServiceTest {
@@ -36,9 +35,6 @@ class AsyncInductionEventServiceTest {
 
   @Captor
   private lateinit var timelineEventCaptor: ArgumentCaptor<TimelineEvent>
-
-  @Captor
-  private lateinit var telemetryCorrelationIdCaptor: ArgumentCaptor<UUID>
 
   @Test
   fun `should handle induction created`() {
@@ -62,9 +58,8 @@ class AsyncInductionEventServiceTest {
 
     // Then
     verify(timelineService).recordTimelineEvent(eq(prisonNumber), capture(timelineEventCaptor))
-    verify(telemetryService).trackInductionCreated(eq(induction), capture(telemetryCorrelationIdCaptor))
+    verify(telemetryService).trackInductionCreated(induction)
     assertThat(timelineEventCaptor.value).usingRecursiveComparison().ignoringFields(*IGNORED_FIELDS).isEqualTo(expectedTimelineEvent)
-    assertThat(telemetryCorrelationIdCaptor.value).isNotNull()
   }
 
   @Test
@@ -89,8 +84,7 @@ class AsyncInductionEventServiceTest {
 
     // Then
     verify(timelineService).recordTimelineEvent(eq(prisonNumber), capture(timelineEventCaptor))
-    verify(telemetryService).trackInductionUpdated(eq(induction), capture(telemetryCorrelationIdCaptor))
+    verify(telemetryService).trackInductionUpdated(induction)
     assertThat(timelineEventCaptor.value).usingRecursiveComparison().ignoringFields(*IGNORED_FIELDS).isEqualTo(expectedTimelineEvent)
-    assertThat(telemetryCorrelationIdCaptor.value).isNotNull()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventServiceTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aVa
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelineService
+import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
 class AsyncInductionEventServiceTest {
@@ -30,8 +31,14 @@ class AsyncInductionEventServiceTest {
   @Mock
   private lateinit var timelineService: TimelineService
 
+  @Mock
+  private lateinit var telemetryService: TelemetryService
+
   @Captor
   private lateinit var timelineEventCaptor: ArgumentCaptor<TimelineEvent>
+
+  @Captor
+  private lateinit var telemetryCorrelationIdCaptor: ArgumentCaptor<UUID>
 
   @Test
   fun `should handle induction created`() {
@@ -55,8 +62,9 @@ class AsyncInductionEventServiceTest {
 
     // Then
     verify(timelineService).recordTimelineEvent(eq(prisonNumber), capture(timelineEventCaptor))
-    assertThat(timelineEventCaptor.value).usingRecursiveComparison().ignoringFields(*IGNORED_FIELDS)
-      .isEqualTo(expectedTimelineEvent)
+    verify(telemetryService).trackInductionCreated(eq(induction), capture(telemetryCorrelationIdCaptor))
+    assertThat(timelineEventCaptor.value).usingRecursiveComparison().ignoringFields(*IGNORED_FIELDS).isEqualTo(expectedTimelineEvent)
+    assertThat(telemetryCorrelationIdCaptor.value).isNotNull()
   }
 
   @Test
@@ -81,7 +89,8 @@ class AsyncInductionEventServiceTest {
 
     // Then
     verify(timelineService).recordTimelineEvent(eq(prisonNumber), capture(timelineEventCaptor))
-    assertThat(timelineEventCaptor.value).usingRecursiveComparison().ignoringFields(*IGNORED_FIELDS)
-      .isEqualTo(expectedTimelineEvent)
+    verify(telemetryService).trackInductionUpdated(eq(induction), capture(telemetryCorrelationIdCaptor))
+    assertThat(timelineEventCaptor.value).usingRecursiveComparison().ignoringFields(*IGNORED_FIELDS).isEqualTo(expectedTimelineEvent)
+    assertThat(telemetryCorrelationIdCaptor.value).isNotNull()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryEventTypeResolverTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryEventTypeResolverTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidReference
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_ADDED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_REMOVED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_ADDED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_REMOVED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.StepStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
@@ -37,7 +37,7 @@ class TelemetryEventTypeResolverTest {
       steps = updatedSteps,
     )
 
-    val expectedTelemetryEventTypes = emptyList<TelemetryEventType>()
+    val expectedTelemetryEventTypes = emptyList<GoalTelemetryEventType>()
 
     // When
     val actual = resolver.resolveUpdateEventTypes(previousGoal, updatedGoal)
@@ -64,7 +64,7 @@ class TelemetryEventTypeResolverTest {
       title = "Learn Spanish",
       steps = updatedSteps,
     )
-    val expectedTelemetryEventTypes = listOf(TelemetryEventType.GOAL_UPDATED)
+    val expectedTelemetryEventTypes = listOf(GoalTelemetryEventType.GOAL_UPDATED)
 
     // When
     val actual = resolver.resolveUpdateEventTypes(previousGoal, updatedGoal)
@@ -93,7 +93,7 @@ class TelemetryEventTypeResolverTest {
       steps = updatedSteps,
       notes = "A suitable course is available from May",
     )
-    val expectedTelemetryEventTypes = listOf(TelemetryEventType.GOAL_UPDATED)
+    val expectedTelemetryEventTypes = listOf(GoalTelemetryEventType.GOAL_UPDATED)
 
     // When
     val actual = resolver.resolveUpdateEventTypes(previousGoal, updatedGoal)
@@ -122,7 +122,7 @@ class TelemetryEventTypeResolverTest {
       steps = updatedSteps,
       lastUpdatedAtPrison = "BXI",
     )
-    val expectedTelemetryEventTypes = listOf(TelemetryEventType.GOAL_UPDATED)
+    val expectedTelemetryEventTypes = listOf(GoalTelemetryEventType.GOAL_UPDATED)
 
     // When
     val actual = resolver.resolveUpdateEventTypes(previousGoal, updatedGoal)
@@ -151,7 +151,7 @@ class TelemetryEventTypeResolverTest {
       steps = updatedSteps,
       targetCompletionDate = LocalDate.parse("2024-06-30"),
     )
-    val expectedTelemetryEventTypes = listOf(TelemetryEventType.GOAL_UPDATED)
+    val expectedTelemetryEventTypes = listOf(GoalTelemetryEventType.GOAL_UPDATED)
 
     // When
     val actual = resolver.resolveUpdateEventTypes(previousGoal, updatedGoal)
@@ -171,7 +171,7 @@ class TelemetryEventTypeResolverTest {
   fun `should get goal update types given goals with different statuses`(
     previousGoalStatus: GoalStatus,
     updatedGoalStatus: GoalStatus,
-    expectedTelemetryEventType: TelemetryEventType,
+    expectedTelemetryEventType: GoalTelemetryEventType,
   ) {
     // Given
     val goalReference = aValidReference()
@@ -305,7 +305,7 @@ class TelemetryEventTypeResolverTest {
   fun `should get goal update types given a step with different statuses`(
     previousStepStatus: StepStatus,
     updatedStepStatus: StepStatus,
-    expectedTelemetryEventType: TelemetryEventType,
+    expectedTelemetryEventType: GoalTelemetryEventType,
   ) {
     // Given
     val goalReference = aValidReference()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
@@ -255,40 +255,34 @@ class TelemetryServiceTest {
     fun `should track induction created event`() {
       // Given
       val induction = aValidInduction()
-      val correlationId = UUID.randomUUID()
       val expectedEventProperties = mapOf(
-        "correlationId" to correlationId.toString(),
         "reference" to induction.reference.toString(),
         "prisonId" to induction.createdAtPrison,
         "userId" to induction.createdBy!!,
-        "timestamp" to induction.createdAt.toString(),
       )
 
       // When
-      telemetryService.trackInductionCreated(induction, correlationId)
+      telemetryService.trackInductionCreated(induction)
 
       // Then
-      verify(telemetryClient).trackEvent("induction-created", expectedEventProperties)
+      verify(telemetryClient).trackEvent("INDUCTION_CREATED", expectedEventProperties)
     }
 
     @Test
     fun `should track induction updated event`() {
       // Given
       val induction = aValidInduction()
-      val correlationId = UUID.randomUUID()
       val expectedEventProperties = mapOf(
-        "correlationId" to correlationId.toString(),
         "reference" to induction.reference.toString(),
         "prisonId" to induction.lastUpdatedAtPrison,
         "userId" to induction.lastUpdatedBy!!,
-        "timestamp" to induction.lastUpdatedAt.toString(),
       )
 
       // When
-      telemetryService.trackInductionUpdated(induction, correlationId)
+      telemetryService.trackInductionUpdated(induction)
 
       // Then
-      verify(telemetryClient).trackEvent("induction-updated", expectedEventProperties)
+      verify(telemetryClient).trackEvent("INDUCTION_UPDATED", expectedEventProperties)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
@@ -258,7 +258,7 @@ class TelemetryServiceTest {
       val correlationId = UUID.randomUUID()
       val expectedEventProperties = mapOf(
         "correlationId" to correlationId.toString(),
-        "prisonNumber" to induction.prisonNumber,
+        "reference" to induction.reference.toString(),
         "prisonId" to induction.createdAtPrison,
         "userId" to induction.createdBy!!,
         "timestamp" to induction.createdAt.toString(),
@@ -278,7 +278,7 @@ class TelemetryServiceTest {
       val correlationId = UUID.randomUUID()
       val expectedEventProperties = mapOf(
         "correlationId" to correlationId.toString(),
-        "prisonNumber" to induction.prisonNumber,
+        "reference" to induction.reference.toString(),
         "prisonId" to induction.lastUpdatedAtPrison,
         "userId" to induction.lastUpdatedBy!!,
         "timestamp" to induction.lastUpdatedAt.toString(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
@@ -21,20 +21,21 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.trackEvent
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_ARCHIVED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_COMPLETED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_CREATED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_STARTED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.GOAL_UPDATED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_ADDED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_COMPLETED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_NOT_STARTED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_REMOVED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_STARTED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.TelemetryEventType.STEP_UPDATED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_ARCHIVED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_COMPLETED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_CREATED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_STARTED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.GOAL_UPDATED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_ADDED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_COMPLETED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_NOT_STARTED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_REMOVED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_STARTED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.GoalTelemetryEventType.STEP_UPDATED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.GoalStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInduction
 import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
@@ -245,6 +246,49 @@ class TelemetryServiceTest {
       assertThat(propertiesForGoalUpdatedEvent["correlationId"])
         .isEqualTo(propertiesForFirstStepRemovalEvent["correlationId"])
         .isEqualTo(propertiesForSecondStepRemovalEvent["correlationId"])
+    }
+  }
+
+  @Nested
+  inner class TrackInductionEvents {
+    @Test
+    fun `should track induction created event`() {
+      // Given
+      val induction = aValidInduction()
+      val correlationId = UUID.randomUUID()
+      val expectedEventProperties = mapOf(
+        "correlationId" to correlationId.toString(),
+        "prisonNumber" to induction.prisonNumber,
+        "prisonId" to induction.createdAtPrison,
+        "userId" to induction.createdBy!!,
+        "timestamp" to induction.createdAt.toString(),
+      )
+
+      // When
+      telemetryService.trackInductionCreated(induction, correlationId)
+
+      // Then
+      verify(telemetryClient).trackEvent("induction-created", expectedEventProperties)
+    }
+
+    @Test
+    fun `should track induction updated event`() {
+      // Given
+      val induction = aValidInduction()
+      val correlationId = UUID.randomUUID()
+      val expectedEventProperties = mapOf(
+        "correlationId" to correlationId.toString(),
+        "prisonNumber" to induction.prisonNumber,
+        "prisonId" to induction.lastUpdatedAtPrison,
+        "userId" to induction.lastUpdatedBy!!,
+        "timestamp" to induction.lastUpdatedAt.toString(),
+      )
+
+      // When
+      telemetryService.trackInductionUpdated(induction, correlationId)
+
+      // Then
+      verify(telemetryClient).trackEvent("induction-updated", expectedEventProperties)
     }
   }
 }


### PR DESCRIPTION
This PR adds AppInsights events for creating and updating CIAG Inductions.

We are only interested in these "high-level" events for the foreseeable future and are not sending specific details about the Inductions themselves.