### PR TITLE
RR-511 - Accept requests with null workExperience and empty collections

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -40,8 +40,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.asser
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateEducationAndQualificationsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousWorkRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidEducationAndQualificationsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPrisonWorkAndEducationResponse
@@ -476,7 +474,7 @@ class UpdateInductionTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should update induction with no previous work experience and modified work interests`() {
+  fun `should update induction with no previous work experience or work interests`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     createInduction(prisonNumber, aValidCreateCiagInductionRequest())
@@ -491,14 +489,9 @@ class UpdateInductionTest : IntegrationTestBase() {
         workExperience = null,
         workInterests = aValidUpdateWorkInterestsRequest(
           id = persistedInduction.workExperience!!.workInterests!!.id,
-          workInterests = setOf(WorkType.SPORTS),
+          workInterests = null,
           workInterestsOther = null,
-          particularJobInterests = setOf(
-            WorkInterestDetail(
-              workInterest = WorkType.SPORTS,
-              role = "Football coach",
-            ),
-          ),
+          particularJobInterests = null,
         ),
       ),
     )
@@ -511,14 +504,9 @@ class UpdateInductionTest : IntegrationTestBase() {
       workExperience = null,
       workInterests = aValidWorkInterestsResponse(
         id = persistedInduction.workExperience!!.workInterests!!.id,
-        workInterests = setOf(WorkType.SPORTS),
+        workInterests = emptySet(),
         workInterestsOther = null,
-        particularJobInterests = setOf(
-          WorkInterestDetail(
-            workInterest = WorkType.SPORTS,
-            role = "Football coach",
-          ),
-        ),
+        particularJobInterests = emptySet(),
       ),
       modifiedBy = "auser_gen",
     )
@@ -552,19 +540,13 @@ class UpdateInductionTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should update induction with previous work experience given it previously did not have any`() {
+  fun `should update induction with previous work experience and future interests given it previously did not have any`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     createInduction(
       prisonNumber,
       aValidCreateCiagInductionRequest(
-        workExperience = aValidCreatePreviousWorkRequest(
-          hasWorkedBefore = false,
-          typeOfWorkExperience = null,
-          typeOfWorkExperienceOther = null,
-          workExperience = null,
-          workInterests = aValidCreateWorkInterestsRequest(),
-        ),
+        workExperience = null,
       ),
     )
     val persistedInduction = getInduction(prisonNumber)
@@ -608,9 +590,9 @@ class UpdateInductionTest : IntegrationTestBase() {
       .wasCreatedAt(persistedInduction.createdDateTime)
       .wasLastModifiedAt(persistedInduction.modifiedDateTime) // should be unchanged
     assertThat(updatedInduction.workExperience).isEquivalentTo(expectedWorkExperience)
-    assertThat(updatedInduction.workExperience!!.modifiedDateTime).isAfter(persistedInduction.workExperience!!.modifiedDateTime)
+    assertThat(updatedInduction.workExperience!!.modifiedDateTime).isAfter(persistedInduction.modifiedDateTime)
+    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isAfter(persistedInduction.modifiedDateTime)
     // other last modified dates should remain unchanged
-    assertThat(updatedInduction.workExperience!!.workInterests!!.modifiedDateTime).isEqualTo(persistedInduction.workExperience!!.workInterests!!.modifiedDateTime)
     assertThat(updatedInduction.qualificationsAndTraining!!.modifiedDateTime).isEqualTo(persistedInduction.qualificationsAndTraining!!.modifiedDateTime)
     assertThat(updatedInduction.skillsAndInterests!!.modifiedDateTime).isEqualTo(persistedInduction.skillsAndInterests!!.modifiedDateTime)
     assertThat(updatedInduction.inPrisonInterests!!.modifiedDateTime).isEqualTo(persistedInduction.inPrisonInterests!!.modifiedDateTime)
@@ -839,16 +821,16 @@ class UpdateInductionTest : IntegrationTestBase() {
     reasonToNotGetWork: Set<ReasonNotToWork>? = originalInduction.reasonToNotGetWork,
     reasonToNotGetWorkOther: String? = originalInduction.reasonToNotGetWorkOther,
     workExperience: UpdatePreviousWorkRequest? = aValidUpdatePreviousWorkRequest(
-      id = originalInduction.workExperience!!.id!!,
+      id = originalInduction.workExperience?.id,
     ),
     skillsAndInterests: UpdateSkillsAndInterestsRequest? = aValidUpdateSkillsAndInterestsRequest(
-      id = originalInduction.workExperience!!.id!!,
+      id = originalInduction.skillsAndInterests?.id,
     ),
     qualificationsAndTraining: UpdateEducationAndQualificationsRequest? = aValidUpdateEducationAndQualificationsRequest(
-      id = originalInduction.workExperience!!.id!!,
+      id = originalInduction.qualificationsAndTraining?.id,
     ),
     inPrisonInterests: UpdatePrisonWorkAndEducationRequest? = aValidUpdatePrisonWorkAndEducationRequest(
-      id = originalInduction.workExperience!!.id!!,
+      id = originalInduction.inPrisonInterests?.id,
     ),
   ): UpdateCiagInductionRequest =
     aValidUpdateCiagInductionRequest(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousWorkExperiencesResourceMapper.kt
@@ -25,8 +25,20 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkE
 
 @Mapper(nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
 abstract class PreviousWorkExperiencesResourceMapper {
+
+  fun toCreatePreviousWorkExperiencesDto(
+    request: CreatePreviousWorkRequest?,
+    prisonId: String,
+  ): CreatePreviousWorkExperiencesDto? {
+    return if (request == null) {
+      null
+    } else {
+      convertToCreatePreviousWorkExperiencesDto(request, prisonId)
+    }
+  }
+
   @Mapping(target = "experiences", source = "request.workExperience")
-  abstract fun toCreatePreviousWorkExperiencesDto(
+  protected abstract fun convertToCreatePreviousWorkExperiencesDto(
     request: CreatePreviousWorkRequest?,
     prisonId: String,
   ): CreatePreviousWorkExperiencesDto?
@@ -91,9 +103,20 @@ abstract class PreviousWorkExperiencesResourceMapper {
 
   fun toOffsetDateTime(instant: Instant?): OffsetDateTime? = instant?.atOffset(ZoneOffset.UTC)
 
+  fun toUpdatePreviousWorkExperiencesDto(
+    request: UpdatePreviousWorkRequest?,
+    prisonId: String,
+  ): UpdatePreviousWorkExperiencesDto? {
+    return if (request == null) {
+      null
+    } else {
+      convertToUpdatePreviousWorkExperiencesDto(request, prisonId)
+    }
+  }
+
   @Mapping(target = "reference", source = "request.id")
   @Mapping(target = "experiences", source = "request.workExperience")
-  abstract fun toUpdatePreviousWorkExperiencesDto(
+  protected abstract fun convertToUpdatePreviousWorkExperiencesDto(
     request: UpdatePreviousWorkRequest?,
     prisonId: String,
   ): UpdatePreviousWorkExperiencesDto?

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.6.0'
+  version: '1.6.1'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -596,7 +596,6 @@ components:
         hasWorkedBefore:
           type: boolean
         typeOfWorkExperience:
-          minItems: 1
           uniqueItems: true
           type: array
           description: A list of the Prisoner's type of previous work experience.
@@ -606,7 +605,6 @@ components:
           type: string
           description: A specific work experience type for the Prisoner. Mandatory when 'typeOfWorkExperience' includes 'OTHER'.
         workExperience:
-          minItems: 1
           uniqueItems: true
           type: array
           description: A list of the Prisoner's previous work experience details.
@@ -638,7 +636,6 @@ components:
           description: A unique reference for this Prisoner's skills and interests (not the database primary key).
           example: c88a6c48-97e2-4c04-93b5-98619966447b
         skills:
-          minItems: 1
           uniqueItems: true
           type: array
           description: One or more skills that the Prisoner feels they have.
@@ -648,7 +645,6 @@ components:
           type: string
           description: A specific type of a skill that the Prisoner feels they have. Mandatory when 'skills' includes 'OTHER'.
         personalInterests:
-          minItems: 1
           uniqueItems: true
           type: array
           description: One or more interests that the Prisoner feels they have.
@@ -719,7 +715,6 @@ components:
           description: A unique reference for this Prisoner's in-prison work and education interests (not the database primary key).
           example: c88a6c48-97e2-4c04-93b5-98619966447b
         inPrisonWork:
-          minItems: 1
           uniqueItems: true
           type: array
           description: A list of in-prison work that the Prisoner is interested in.
@@ -729,7 +724,6 @@ components:
           type: string
           description: A specific type of in-prison work that does not fit the given 'inPrisonWork' types. Mandatory when 'inPrisonWork' includes 'OTHER'.
         inPrisonEducation:
-          minItems: 1
           uniqueItems: true
           type: array
           description: Any potential in-prison education/training that the Prisoner is interested in.
@@ -1011,7 +1005,6 @@ components:
         hasWorkedBefore:
           type: boolean
         typeOfWorkExperience:
-          minItems: 1
           uniqueItems: true
           type: array
           description: A list of the Prisoner's type of previous work experience.
@@ -1021,7 +1014,6 @@ components:
           type: string
           description: A specific work experience type for the Prisoner. Mandatory when 'typeOfWorkExperience' includes 'OTHER'.
         workExperience:
-          minItems: 1
           uniqueItems: true
           type: array
           description: A list of the Prisoner's previous work experience details.
@@ -1037,7 +1029,6 @@ components:
       type: object
       properties:
         workInterests:
-          minItems: 1
           uniqueItems: true
           type: array
           description: A list of Prisoner's future work interests.
@@ -1052,15 +1043,12 @@ components:
           description: A detailed list of work interests that a Prisoner has.
           items:
             $ref: '#/components/schemas/WorkInterestDetail'
-      required:
-        - workInterests
 
     CreateSkillsAndInterestsRequest:
       description: A request to persist a Prisoner's personal skills and interests. Migrated from hmpps-ciag-careers-induction-api.
       type: object
       properties:
         skills:
-          minItems: 1
           uniqueItems: true
           type: array
           description: One or more skills that the Prisoner feels they have.
@@ -1070,7 +1058,6 @@ components:
           type: string
           description: A specific type of a skill that the Prisoner feels they have. Mandatory when 'skills' includes 'OTHER'.
         personalInterests:
-          minItems: 1
           uniqueItems: true
           type: array
           description: One or more interests that the Prisoner feels they have.
@@ -1108,7 +1095,6 @@ components:
       type: object
       properties:
         inPrisonWork:
-          minItems: 1
           uniqueItems: true
           type: array
           description: A list of in-prison work that the Prisoner is interested in.
@@ -1118,7 +1104,6 @@ components:
           type: string
           description: A specific type of in-prison work that does not fit the given 'inPrisonWork' types. Mandatory when 'inPrisonWork' includes 'OTHER'.
         inPrisonEducation:
-          minItems: 1
           uniqueItems: true
           type: array
           description: Any potential in-prison education/training that the Prisoner is interested in.
@@ -1185,7 +1170,6 @@ components:
         hasWorkedBefore:
           type: boolean
         typeOfWorkExperience:
-          minItems: 1
           uniqueItems: true
           type: array
           description: A list of the Prisoner's type of previous work experience.
@@ -1195,7 +1179,6 @@ components:
           type: string
           description: A specific work experience type for the Prisoner. Mandatory when 'typeOfWorkExperience' includes 'OTHER'.
         workExperience:
-          minItems: 1
           uniqueItems: true
           type: array
           description: A list of the Prisoner's previous work experience details.

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/WorkInterestsBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/WorkInterestsBuilder.kt
@@ -26,7 +26,7 @@ fun aValidCreateWorkInterestsRequest(
 
 fun aValidUpdateWorkInterestsRequest(
   id: UUID = UUID.randomUUID(),
-  workInterests: Set<WorkType> = setOf(WorkType.OTHER),
+  workInterests: Set<WorkType>? = setOf(WorkType.OTHER),
   workInterestsOther: String? = "Any job I can get",
   particularJobInterests: Set<WorkInterestDetail>? = setOf(
     WorkInterestDetail(


### PR DESCRIPTION
This PR relaxes the validation and cardinality within the API so that we can accept create/update requests with completely null workExperience, along with empty collections elsewhere within the CIAG API.