### PR TITLE
RR-511 - Allow empty collections in create requests

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -362,7 +362,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       qualificationsAndTraining = aValidUpdateEducationAndQualificationsRequest(
         id = persistedInduction.qualificationsAndTraining!!.id!!,
         educationLevel = null,
-        qualifications = null,
+        qualifications = emptySet(),
         additionalTraining = setOf(TrainingType.CSCS_CARD),
         additionalTrainingOther = null,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/FutureWorkInterestsEntityMapper.kt
@@ -6,6 +6,7 @@ import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.mapstruct.MappingTarget
 import org.mapstruct.Named
+import org.mapstruct.NullValueMappingStrategy
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.FutureWorkInterestsEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.WorkInterestEntity
@@ -23,6 +24,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
   uses = [
     WorkInterestEntityMapper::class,
   ],
+  nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
 )
 abstract class FutureWorkInterestsEntityMapper {
   @Autowired

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InPrisonInterestsEntityMapper.kt
@@ -6,6 +6,7 @@ import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.mapstruct.MappingTarget
 import org.mapstruct.Named
+import org.mapstruct.NullValueMappingStrategy
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonInterestsEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonTrainingInterestEntity
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
     InPrisonWorkInterestEntityMapper::class,
     InPrisonTrainingInterestEntityMapper::class,
   ],
+  nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
 )
 abstract class InPrisonInterestsEntityMapper {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PersonalSkillsAndInterestsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PersonalSkillsAndInterestsEntityMapper.kt
@@ -6,6 +6,7 @@ import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.mapstruct.MappingTarget
 import org.mapstruct.Named
+import org.mapstruct.NullValueMappingStrategy
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PersonalInterestEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PersonalSkillEntity
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
     PersonalSkillEntityMapper::class,
     PersonalInterestEntityMapper::class,
   ],
+  nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
 )
 abstract class PersonalSkillsAndInterestsEntityMapper {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapper.kt
@@ -6,6 +6,7 @@ import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.mapstruct.MappingTarget
 import org.mapstruct.Named
+import org.mapstruct.NullValueMappingStrategy
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PreviousQualificationsEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.QualificationEntity
@@ -23,6 +24,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
   uses = [
     QualificationEntityMapper::class,
   ],
+  nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
 )
 abstract class PreviousQualificationsEntityMapper {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapper.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.mapstruct.MappingTarget
+import org.mapstruct.NullValueMappingStrategy
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PreviousTrainingEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeJpaManagedFieldsIncludingDisplayNameFields
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeReferenceField
@@ -17,6 +18,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Tra
   uses = [
     TrainingTypeMapper::class,
   ],
+  nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
 )
 interface PreviousTrainingEntityMapper {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/WorkOnReleaseEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/WorkOnReleaseEntityMapper.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.mapstruct.MappingTarget
+import org.mapstruct.NullValueMappingStrategy
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.WorkOnReleaseEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeJpaManagedFieldsIncludingDisplayNameFields
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeReferenceField
@@ -11,7 +12,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Wor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateWorkOnReleaseDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateWorkOnReleaseDto
 
-@Mapper
+@Mapper(nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
 interface WorkOnReleaseEntityMapper {
 
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/WorkInterestsBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/WorkInterestsBuilder.kt
@@ -9,7 +9,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 fun aValidCreateWorkInterestsRequest(
-  workInterests: Set<WorkType> = setOf(WorkType.OTHER),
+  workInterests: Set<WorkType>? = setOf(WorkType.OTHER),
   workInterestsOther: String? = "Any job I can get",
   particularJobInterests: Set<WorkInterestDetail>? = setOf(
     WorkInterestDetail(


### PR DESCRIPTION
Technically the API was accepting an empty/null collection of qualifications when creating an induction, but this was then being mapped to a null collection in the domain object afterwards.

I had tests for sending null/empty lists of qualifications in update requests, but not create ones (though I had a test for sending no qualifications data, including no `educationLevel`).