### PR TITLE
RR-512 - Save multiple GOAL_CREATED events with the same correlation ID

### DIFF
--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalEventService.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalEventService.kt
@@ -8,9 +8,9 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
 interface GoalEventService {
 
   /**
-   * Implementations providing custom code for when a [Goal] is created.
+   * Implementations providing custom code for when one or more [Goal]s are created.
    */
-  fun goalCreated(prisonNumber: String, createdGoal: Goal)
+  fun goalsCreated(prisonNumber: String, createdGoals: List<Goal>)
 
   /**
    * Implementations providing custom code for when a [Goal] is updated.

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalService.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalService.kt
@@ -48,7 +48,9 @@ class GoalService(
         .let { it.goals }
     } else {
       goalPersistenceAdapter.createGoals(prisonNumber, createGoalDtos)
-        .onEach { goalEventService.goalCreated(prisonNumber, it) }
+        .also {
+          goalEventService.goalsCreated(prisonNumber, it)
+        }
     }
   }
 

--- a/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
+++ b/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/service/GoalServiceTest.kt
@@ -47,7 +47,9 @@ class GoalServiceTest {
       val prisonNumber = aValidPrisonNumber()
       val goal = aValidGoal()
       given(actionPlanPersistenceAdapter.getActionPlan(any())).willReturn(aValidActionPlan())
-      given(goalPersistenceAdapter.createGoals(any(), any())).willReturn(listOf(goal))
+
+      val createdGoals = listOf(goal)
+      given(goalPersistenceAdapter.createGoals(any(), any())).willReturn(createdGoals)
       val createGoalDto = aValidCreateGoalDto()
 
       // When
@@ -57,7 +59,7 @@ class GoalServiceTest {
       assertThat(actual).isEqualTo(goal)
       verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
       verify(goalPersistenceAdapter).createGoals(prisonNumber, listOf(createGoalDto))
-      verify(goalEventService).goalCreated(prisonNumber, actual)
+      verify(goalEventService).goalsCreated(prisonNumber, createdGoals)
       verifyNoInteractions(actionPlanEventService)
     }
 
@@ -95,7 +97,9 @@ class GoalServiceTest {
       val goal1 = aValidGoal(title = "Goal 1")
       val goal2 = aValidGoal(title = "Goal 2")
       given(actionPlanPersistenceAdapter.getActionPlan(any())).willReturn(aValidActionPlan())
-      given(goalPersistenceAdapter.createGoals(any(), any())).willReturn(listOf(goal1, goal2))
+
+      val createdGoals = listOf(goal1, goal2)
+      given(goalPersistenceAdapter.createGoals(any(), any())).willReturn(createdGoals)
 
       val createGoalDto1 = aValidCreateGoalDto(title = "Goal 1")
       val createGoalDto2 = aValidCreateGoalDto(title = "Goal 2")
@@ -108,8 +112,7 @@ class GoalServiceTest {
       assertThat(actual).containsExactlyInAnyOrder(goal1, goal2)
       verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
       verify(goalPersistenceAdapter).createGoals(prisonNumber, createGoalDtos)
-      verify(goalEventService).goalCreated(prisonNumber, goal1)
-      verify(goalEventService).goalCreated(prisonNumber, goal2)
+      verify(goalEventService).goalsCreated(prisonNumber, createdGoals)
       verifyNoInteractions(actionPlanEventService)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncGoalEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncGoalEventServiceTest.kt
@@ -1,19 +1,26 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
+import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.firstValue
 import org.mockito.kotlin.given
+import org.mockito.kotlin.secondValue
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimelineEvent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelineService
+import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
 class AsyncGoalEventServiceTest {
@@ -30,22 +37,58 @@ class AsyncGoalEventServiceTest {
   @Mock
   private lateinit var timelineService: TimelineService
 
+  @Captor
+  private lateinit var correlationIdCaptor: ArgumentCaptor<UUID>
+
   @Test
-  fun `should send event details given goal created`() {
+  fun `should send event details given single goal created`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     val createdGoal = aValidGoal()
     val createGoalTimelineEvent = aValidTimelineEvent()
     given(timelineEventFactory.goalCreatedTimelineEvent(any(), any())).willReturn(createGoalTimelineEvent)
 
+    val createdGoals = listOf(createdGoal)
+
     // When
-    goalEventService.goalCreated(prisonNumber = prisonNumber, createdGoal = createdGoal)
+    goalEventService.goalsCreated(prisonNumber = prisonNumber, createdGoals = createdGoals)
 
     // Then
     await.untilAsserted {
       verify(timelineEventFactory).goalCreatedTimelineEvent(eq(createdGoal), any())
       verify(telemetryService).trackGoalCreatedEvent(eq(createdGoal), any())
       verify(timelineService).recordTimelineEvent(prisonNumber, createGoalTimelineEvent)
+    }
+  }
+
+  @Test
+  fun `should send event details given multiple goals created`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+
+    val createdGoal1 = aValidGoal()
+    val createGoal1TimelineEvent = aValidTimelineEvent()
+    val createdGoal2 = aValidGoal()
+    val createGoal2TimelineEvent = aValidTimelineEvent()
+    given(timelineEventFactory.goalCreatedTimelineEvent(any(), any())).willReturn(createGoal1TimelineEvent, createGoal2TimelineEvent)
+
+    val createdGoals = listOf(createdGoal1, createdGoal2)
+
+    // When
+    goalEventService.goalsCreated(prisonNumber = prisonNumber, createdGoals = createdGoals)
+
+    // Then
+    await.untilAsserted {
+      verify(timelineEventFactory).goalCreatedTimelineEvent(eq(createdGoal1), capture(correlationIdCaptor))
+      verify(timelineEventFactory).goalCreatedTimelineEvent(eq(createdGoal2), capture(correlationIdCaptor))
+      val correlationIdForTimelineEvent1 = correlationIdCaptor.firstValue
+      val correlationIdForTimelineEvent2 = correlationIdCaptor.secondValue
+      assertThat(correlationIdForTimelineEvent1).isEqualTo(correlationIdForTimelineEvent2)
+
+      verify(telemetryService).trackGoalCreatedEvent(eq(createdGoal1), any())
+      verify(telemetryService).trackGoalCreatedEvent(eq(createdGoal2), any())
+      verify(timelineService).recordTimelineEvent(prisonNumber, createGoal1TimelineEvent)
+      verify(timelineService).recordTimelineEvent(prisonNumber, createGoal2TimelineEvent)
     }
   }
 


### PR DESCRIPTION
This PR fixes a problem where when saving multiple `GOAL_CREATED` events in the same request , they need to be saved with the same correlation ID
Previously they were being saved with a new correlation ID for each `Goal`. This has been changed so that irrespective of how many `Goal`s were created as part of the originating request, they all use the same correlation ID.
