### PR TITLE
RR-511 - Mapping of workInterests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapper.kt
@@ -37,7 +37,7 @@ class FutureWorkInterestsResourceMapper {
     return workInterests?.map {
       val workType = toWorkInterestType(it)
       val workTypeOther = if (isOtherWorkType(it)) workInterestsOther else null
-      val role = particularWorkInterests?.first { particularInterest -> particularInterest.workInterest == it }?.role
+      val role = particularWorkInterests?.firstOrNull { particularInterest -> particularInterest.workInterest == it }?.role
       WorkInterest(
         workType = workType,
         workTypeOther = workTypeOther,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapper.kt
@@ -15,7 +15,7 @@ class FutureWorkInterestsResourceMapper {
   fun toCreateFutureWorkInterestsDto(request: CreateWorkInterestsRequest?, prisonId: String): CreateFutureWorkInterestsDto? =
     request?.let {
       CreateFutureWorkInterestsDto(
-        interests = toWorkInterests(it.particularJobInterests, it.workInterestsOther),
+        interests = toWorkInterests(it.workInterests, it.particularJobInterests, it.workInterestsOther),
         prisonId = prisonId,
       )
     }
@@ -24,22 +24,24 @@ class FutureWorkInterestsResourceMapper {
     request?.let {
       UpdateFutureWorkInterestsDto(
         reference = it.id,
-        interests = toWorkInterests(it.particularJobInterests, it.workInterestsOther),
+        interests = toWorkInterests(it.workInterests, it.particularJobInterests, it.workInterestsOther),
         prisonId = prisonId,
       )
     }
 
   private fun toWorkInterests(
-    workInterests: Set<WorkInterestDetail>?,
+    workInterests: Set<WorkType>?,
+    particularWorkInterests: Set<WorkInterestDetail>?,
     workInterestsOther: String?,
   ): List<WorkInterest> {
     return workInterests?.map {
-      val workType = toWorkInterestType(it.workInterest)
+      val workType = toWorkInterestType(it)
       val workTypeOther = if (isOtherWorkType(it)) workInterestsOther else null
+      val role = particularWorkInterests?.first { particularInterest -> particularInterest.workInterest == it }?.role
       WorkInterest(
         workType = workType,
         workTypeOther = workTypeOther,
-        role = it.role,
+        role = role,
       )
     } ?: emptyList()
   }
@@ -47,6 +49,6 @@ class FutureWorkInterestsResourceMapper {
   private fun toWorkInterestType(workType: WorkType): WorkInterestType =
     WorkInterestType.valueOf(workType.name)
 
-  private fun isOtherWorkType(workInterestDetail: WorkInterestDetail) =
-    workInterestDetail.workInterest == WorkType.OTHER
+  private fun isOtherWorkType(workType: WorkType) =
+    workType == WorkType.OTHER
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
@@ -2,7 +2,10 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateWorkInterestsRequest
 
@@ -13,24 +16,71 @@ class FutureWorkInterestsResourceMapperTest {
   fun `should map to CreateFutureWorkInterestsDto`() {
     // Given
     val prisonId = "BXI"
-    val request = aValidCreateWorkInterestsRequest()
+    val request = aValidCreateWorkInterestsRequest(
+      workInterests = setOf(WorkType.OTHER, WorkType.TECHNICAL),
+      workInterestsOther = "Entertainment",
+      particularJobInterests = setOf(
+        WorkInterestDetail(
+          workInterest = WorkType.OTHER,
+          role = "Juggler",
+        ),
+        WorkInterestDetail(
+          workInterest = WorkType.TECHNICAL,
+          role = "Kotlin Developer",
+        ),
+      )
+    )
+    val expectedInterests = listOf(
+      WorkInterest(
+        workType = WorkInterestType.OTHER,
+        workTypeOther = "Entertainment",
+        role = "Juggler",
+      ),
+      WorkInterest(
+        workType = WorkInterestType.TECHNICAL,
+        workTypeOther = null,
+        role = "Kotlin Developer",
+      ),
+    )
 
     // When
     val actual = mapper.toCreateFutureWorkInterestsDto(request, prisonId)
 
     // Then
     assertThat(actual!!.prisonId).isEqualTo(prisonId)
-    assertThat(actual.interests).hasSize(1)
-    assertThat(actual.interests[0].workType).isEqualTo(WorkInterestType.OTHER)
-    assertThat(actual.interests[0].workTypeOther).isEqualTo("Any job I can get")
-    assertThat(actual.interests[0].role).isEqualTo("Any role")
+    assertThat(actual.interests).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedInterests)
   }
 
   @Test
   fun `should map to UpdateFutureWorkInterestsDto`() {
     // Given
     val prisonId = "BXI"
-    val request = aValidUpdateWorkInterestsRequest()
+    val request = aValidUpdateWorkInterestsRequest(
+      workInterests = setOf(WorkType.OTHER, WorkType.TECHNICAL),
+      workInterestsOther = "Entertainment",
+      particularJobInterests = setOf(
+        WorkInterestDetail(
+          workInterest = WorkType.OTHER,
+          role = "Juggler",
+        ),
+        WorkInterestDetail(
+          workInterest = WorkType.TECHNICAL,
+          role = "Kotlin Developer",
+        ),
+      )
+    )
+    val expectedInterests = listOf(
+      WorkInterest(
+        workType = WorkInterestType.OTHER,
+        workTypeOther = "Entertainment",
+        role = "Juggler",
+      ),
+      WorkInterest(
+        workType = WorkInterestType.TECHNICAL,
+        workTypeOther = null,
+        role = "Kotlin Developer",
+      ),
+    )
 
     // When
     val actual = mapper.toUpdateFutureWorkInterestsDto(request, prisonId)
@@ -38,17 +88,61 @@ class FutureWorkInterestsResourceMapperTest {
     // Then
     assertThat(actual!!.prisonId).isEqualTo(prisonId)
     assertThat(actual.reference).isEqualTo(request.id)
-    assertThat(actual.interests).hasSize(1)
-    assertThat(actual.interests[0].workType).isEqualTo(WorkInterestType.OTHER)
-    assertThat(actual.interests[0].workTypeOther).isEqualTo("Any job I can get")
-    assertThat(actual.interests[0].role).isEqualTo("Any role")
+    assertThat(actual.interests).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedInterests)
+  }
+
+  @Test
+  fun `should map to UpdateFutureWorkInterestsDto with missing particular job interest`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdateWorkInterestsRequest(
+      workInterests = setOf(WorkType.OTHER, WorkType.TECHNICAL),
+      workInterestsOther = "Entertainment",
+      particularJobInterests = setOf(
+        WorkInterestDetail(
+          workInterest = WorkType.OTHER,
+          role = "Juggler",
+        ),
+      )
+    )
+    val expectedInterests = listOf(
+      WorkInterest(
+        workType = WorkInterestType.OTHER,
+        workTypeOther = "Entertainment",
+        role = "Juggler",
+      ),
+      WorkInterest(
+        workType = WorkInterestType.TECHNICAL,
+        workTypeOther = null,
+        role = null,
+      ),
+    )
+
+    // When
+    val actual = mapper.toUpdateFutureWorkInterestsDto(request, prisonId)
+
+    // Then
+    assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.reference).isEqualTo(request.id)
+    assertThat(actual.interests).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedInterests)
   }
 
   @Test
   fun `should map to UpdateFutureWorkInterestsDto when particular job interests is null`() {
     // Given
     val prisonId = "BXI"
-    val request = aValidUpdateWorkInterestsRequest(particularJobInterests = null)
+    val request = aValidUpdateWorkInterestsRequest(
+      workInterests = setOf(WorkType.TECHNICAL),
+      workInterestsOther = "",
+      particularJobInterests = emptySet(),
+    )
+    val expectedInterests = listOf(
+      WorkInterest(
+        workType = WorkInterestType.TECHNICAL,
+        workTypeOther = null,
+        role = null,
+      ),
+    )
 
     // When
     val actual = mapper.toUpdateFutureWorkInterestsDto(request, prisonId)
@@ -56,9 +150,6 @@ class FutureWorkInterestsResourceMapperTest {
     // Then
     assertThat(actual!!.prisonId).isEqualTo(prisonId)
     assertThat(actual.reference).isEqualTo(request.id)
-    assertThat(actual.interests).hasSize(1)
-    assertThat(actual.interests[0].workType).isEqualTo(WorkInterestType.OTHER)
-    assertThat(actual.interests[0].workTypeOther).isEqualTo("Any job I can get")
-    assertThat(actual.interests[0].role).isNull()
+    assertThat(actual.interests).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedInterests)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
@@ -43,4 +43,22 @@ class FutureWorkInterestsResourceMapperTest {
     assertThat(actual.interests[0].workTypeOther).isEqualTo("Any job I can get")
     assertThat(actual.interests[0].role).isEqualTo("Any role")
   }
+
+  @Test
+  fun `should map to UpdateFutureWorkInterestsDto when particular job interests is null`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdateWorkInterestsRequest(particularJobInterests = null)
+
+    // When
+    val actual = mapper.toUpdateFutureWorkInterestsDto(request, prisonId)
+
+    // Then
+    assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.reference).isEqualTo(request.id)
+    assertThat(actual.interests).hasSize(1)
+    assertThat(actual.interests[0].workType).isEqualTo(WorkInterestType.OTHER)
+    assertThat(actual.interests[0].workTypeOther).isEqualTo("Any job I can get")
+    assertThat(actual.interests[0].role).isNull()
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/FutureWorkInterestsResourceMapperTest.kt
@@ -28,7 +28,7 @@ class FutureWorkInterestsResourceMapperTest {
           workInterest = WorkType.TECHNICAL,
           role = "Kotlin Developer",
         ),
-      )
+      ),
     )
     val expectedInterests = listOf(
       WorkInterest(
@@ -67,7 +67,7 @@ class FutureWorkInterestsResourceMapperTest {
           workInterest = WorkType.TECHNICAL,
           role = "Kotlin Developer",
         ),
-      )
+      ),
     )
     val expectedInterests = listOf(
       WorkInterest(
@@ -103,7 +103,7 @@ class FutureWorkInterestsResourceMapperTest {
           workInterest = WorkType.OTHER,
           role = "Juggler",
         ),
-      )
+      ),
     )
     val expectedInterests = listOf(
       WorkInterest(


### PR DESCRIPTION
This PR changes the way we map work interests. Previously it was assumed that the UI should and would always send the array of `particularJobInterests`, since it always does when creating an Induction (even when no role is provided). However this is not the case when performing an update. For some reason, the UI does not ask for a role at all.