### PR TITLE
RR-516 Disable migration in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -2,8 +2,7 @@
 # Per environment values which override defaults in hmpps-education-and-work-plan-api/values.yaml
 
 generic-service:
-  # TODO - RR-502 - set this back to 2
-  replicaCount: 1
+  replicaCount: 2
 
   ingress:
     host: learningandworkprogress-api-dev.hmpps.service.justice.gov.uk
@@ -18,7 +17,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     # TODO - RR-502 - Remove `CIAG_INDUCTION_API_URL` and `CIAG_INDUCTION_DATA_MIGRATION_ENABLED`
     CIAG_INDUCTION_API_URL: "https://ciag-induction-api-dev.hmpps.service.justice.gov.uk"
-    CIAG_INDUCTION_DATA_MIGRATION_ENABLED: "true"
+    CIAG_INDUCTION_DATA_MIGRATION_ENABLED: "false"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
I suggest we run this after doing one more dry run of the data migration ASAP. Then we can run the migration on all 3 envs in one evening, once we've got the go ahead.