### PR TITLE
RR-446 - CronJob to export database to analytical platform data pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ sonar-project.properties
 
 #Helm
 **/Chart.lock
+
+#Misc
+.DS_Store

--- a/helm_deploy/hmpps-education-and-work-plan-api/templates/export-database-to-analytical-platform-data-pipeline-cronjob.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/templates/export-database-to-analytical-platform-data-pipeline-cronjob.yaml
@@ -1,0 +1,62 @@
+# Export database to Analytical Platform data pipeline
+#
+# Sets up a CronJob pod that uses the `ministryofjustice/data-engineering-data-extractor` docker image to extract
+# all tables to CSV and upload to the Analytical Platform S3 bucket.
+#
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: export-database-to-analytical-platform-data-pipeline-cronjob
+spec:
+  schedule: "0 9-17 * * 1-5" # On the hour between 09:00 and 17:00 Mon-Fri. For testing only; once smoke tested and working change to every day at 1am -> "0 1 * * *"
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: data-extractor-analytics
+              image: ministryofjustice/data-engineering-data-extractor:v1
+              imagePullPolicy: Always
+              args: ["extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
+              env:
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: rds_instance_address
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: database_name
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: database_username
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: database_password
+                - name: S3_DESTINATION
+                  valueFrom:
+                    secretKeyRef:
+                      name: analytical-platform-reporting-s3-bucket
+                      key: destination_bucket
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: analytical-platform-reporting-s3-bucket
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: analytical-platform-reporting-s3-bucket
+                      key: secret_access_key
+                - name: AWS_DEFAULT_REGION
+                  value: eu-west-2
+                - name: SAVE_EVENTS_LOG
+                  value: "true"


### PR DESCRIPTION
This PR sets up a CronJob k8s pod that uses the `ministryofjustice/data-engineering-data-extractor` docker image to extract all tables to CSV and upload to the Analytical Platform S3 bucket.

**Do not merge yet** - there is a [PR](https://github.com/ministryofjustice/register-my-data/pull/250) outstanding in the `register-my-data` repo that needs to be approved and merged first that creates the folder in the bucket and grants our user access to it.

Also, so far I've only done the `CPE` and `register-my-data` PRs for `dev`. Once we approve and merge this PR we need to be very careful that we do no promote to `preprod` or `prod` until we have the corresponding PRs in `CPE` and `register-my-data`