### PR TITLE
RR-446 - renamed cronjob so is within 52 character limit

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-api/templates/export-database-to-analytical-platform-cronjob.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/templates/export-database-to-analytical-platform-cronjob.yaml
@@ -6,7 +6,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: export-database-to-analytical-platform-data-pipeline-cronjob
+  name: export-database-to-analytical-platform-cronjob
 spec:
   schedule: "0 9-17 * * 1-5" # On the hour between 09:00 and 17:00 Mon-Fri. For testing only; once smoke tested and working change to every day at 1am -> "0 1 * * *"
   concurrencyPolicy: Replace


### PR DESCRIPTION
Deploy of previous PR failed to deploy to `dev` because helm/kubernetes appears to have a limit of 52 characters for job names! Who knew? ! 🤣 

<img width="1502" alt="Screenshot 2023-12-04 at 13 06 37" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/assets/94835226/c33c316b-aad7-4d70-8413-14a92159ef4a">
