### PR TITLE
RR-476 - Correctly set actionedBy fields when saving GOAL_UPDATED timeline event

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -27,8 +27,10 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Actio
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.MissingQueueException
@@ -153,4 +155,27 @@ abstract class IntegrationTestBase {
       .isOk
       .returnResult(CiagInductionResponse::class.java)
       .responseBody.blockFirst()!!
+
+  fun createGoal(
+    prisonNumber: String,
+    createGoalRequest: CreateGoalRequest,
+    username: String = "auser_gen",
+    displayName: String = "Albert User",
+  ) {
+    val createGoalsRequest = aValidCreateGoalsRequest(goals = listOf(createGoalRequest))
+    webTestClient.post()
+      .uri("/action-plans/{prisonNumber}/goals", prisonNumber)
+      .withBody(createGoalsRequest)
+      .bearerToken(
+        aValidTokenWithEditAuthority(
+          username = username,
+          displayName = displayName,
+          privateKey = keyPair.private,
+        ),
+      )
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
+  }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -135,11 +135,22 @@ abstract class IntegrationTestBase {
       .returnResult(TimelineResponse::class.java)
       .responseBody.blockFirst()!!
 
-  fun createInduction(prisonNumber: String, createCiagInductionRequest: CreateCiagInductionRequest) {
+  fun createInduction(
+    prisonNumber: String,
+    createCiagInductionRequest: CreateCiagInductionRequest,
+    username: String = "auser_gen",
+    displayName: String = "Albert User",
+  ) {
     webTestClient.post()
       .uri(INDUCTION_URI_TEMPLATE, prisonNumber)
       .withBody(createCiagInductionRequest)
-      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .bearerToken(
+        aValidTokenWithEditAuthority(
+          username = username,
+          displayName = displayName,
+          privateKey = keyPair.private,
+        ),
+      )
       .contentType(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.GoalEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.actionplan.GoalEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ActionPlanRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.GoalRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateGoalDto
@@ -17,6 +18,7 @@ private val log = KotlinLogging.logger {}
 
 @Component
 class JpaGoalPersistenceAdapter(
+  private val goalRepository: GoalRepository,
   private val actionPlanRepository: ActionPlanRepository,
   private val goalMapper: GoalEntityMapper,
 ) : GoalPersistenceAdapter {
@@ -53,7 +55,8 @@ class JpaGoalPersistenceAdapter(
     val goalEntity = getGoalEntityByPrisonNumberAndGoalReference(prisonNumber, updatedGoalDto.reference)
     return if (goalEntity != null) {
       goalMapper.updateEntityFromDto(goalEntity, updatedGoalDto)
-      goalMapper.fromEntityToDomain(goalEntity)
+      val persistedEntity = goalRepository.saveAndFlush(goalEntity)
+      goalMapper.fromEntityToDomain(persistedEntity)
     } else {
       null
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
@@ -33,7 +33,8 @@ class JpaInductionPersistenceAdapter(
     val inductionEntity = inductionRepository.findByPrisonNumber(updateInductionDto.prisonNumber)
     return if (inductionEntity != null) {
       inductionMapper.updateEntityFromDto(inductionEntity, updateInductionDto)
-      inductionMapper.fromEntityToDomain(inductionEntity)
+      val persistedEntity = inductionRepository.saveAndFlush(inductionEntity)
+      inductionMapper.fromEntityToDomain(persistedEntity)
     } else {
       null
     }

--- a/src/main/resources/db/migration/V2023.12.05.0001__fix_actioned_by_on_timeline_events.sql
+++ b/src/main/resources/db/migration/V2023.12.05.0001__fix_actioned_by_on_timeline_events.sql
@@ -1,0 +1,15 @@
+-- Update the actioned_by field on timeline events where it has been set incorrectly previously.
+UPDATE timeline_event
+    SET actioned_by = (
+        SELECT g.updated_by
+        FROM timeline_event te
+            INNER JOIN goal g ON g.reference::text = te.source_reference
+        WHERE te.reference = timeline_event.reference
+    )
+    WHERE EXISTS (
+        SELECT *
+        FROM timeline_event te
+            INNER JOIN goal g ON g.reference::text = te.source_reference
+        WHERE (te.event_type = 'GOAL_UPDATED' OR te.event_type = 'INDUCTION_UPDATED')
+          AND te.actioned_by != g.updated_by
+    );

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
@@ -185,7 +185,7 @@ class JpaGoalPersistenceAdapterTest {
       val actionPlanEntity = aValidActionPlanEntity(prisonNumber = prisonNumber, goals = listOf(goalEntity))
       given(actionPlanRepository.findByPrisonNumber(any())).willReturn(actionPlanEntity)
 
-      val persistedGoalEntity = aValidGoalEntity(reference = reference, title = "Original goal title", createdBy = "USER1", updatedBy = "USER2")
+      val persistedGoalEntity = aValidGoalEntity(reference = reference, title = "Updated goal title", createdBy = "USER1", updatedBy = "USER2")
       given(goalRepository.saveAndFlush(any<GoalEntity>())).willReturn(persistedGoalEntity)
 
       val expectedDomainGoal = aValidGoal(reference = reference, title = "Updated goal title", createdBy = "USER1", lastUpdatedBy = "USER2")


### PR DESCRIPTION
This PR fixes a problem with GOAL_UPDATED timeline events where the actionedBy fields were not being correctly set to the user that performed the goal update.

The problem was because the the goal was not saved & flushed within the Goal JPA Adapter , which meant the Goal that was returned from the method was the updated goal in respect of the fields mapped from the DTO, but crucially did not have the JPA managed fields updated on it.

---
I'm in 2 minds about whether to write a flyway migration to correct any current timeline event records that have the wrong actioned_by fields. Currently, using this query on `prod`, there are no affected records, which is good:
```
select te.* from timeline_event te 
inner join goal g on g.reference::text = te.source_reference
where te.event_type = 'GOAL_UPDATED'
and te.actioned_by != g.updated_by;
```
But I wonder if we should have the flyway migration as part of this PR anyway, just for completeness?
Other envs such as `dev` will have incorrect records (which is how we found this bug to start with), but I wonder if we care too much about `dev`? 
I've just checked with the above query in `dev`, and there are 15 affected records