### PR TITLE
RR-521 - Update Induction swagger spec

### DIFF
--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -2348,7 +2348,6 @@ components:
           $ref: '#/components/schemas/UpdateFutureWorkInterestsRequest'
       required:
         - reference
-        - workOnRelease
     UpdateWorkOnReleaseRequest:
       description: A request to update a Prisoner's views on obtaining work after release.
       allOf:


### PR DESCRIPTION
This PR adds the swagger spec for a new update Induction endpoint.

The following sceenshot from swagger-editor makes it look like the `UpdateInductionRequest` object contains the "create" objects by mistake, but that's because the "update" objects are based on the respective create ones, using the `allOf` notation. They are the same as the create objects, except for the `reference` field.

![image](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/assets/135589132/eb2b765b-f567-4867-a7f2-9e6a5c6e5704)
