### PR TITLE
RR-476 - Update flyway migration to correct any existing timeline event records

### DIFF
--- a/src/main/resources/db/migration/V2023.12.05.0001__fix_actioned_by_on_timeline_events.sql
+++ b/src/main/resources/db/migration/V2023.12.05.0001__fix_actioned_by_on_timeline_events.sql
@@ -1,15 +1,15 @@
 -- Update the actioned_by field on timeline events where it has been set incorrectly previously.
 UPDATE timeline_event
-    SET actioned_by = (
-        SELECT g.updated_by
-        FROM timeline_event te
-            INNER JOIN goal g ON g.reference::text = te.source_reference
-        WHERE te.reference = timeline_event.reference
-    )
-    WHERE EXISTS (
-        SELECT *
-        FROM timeline_event te
-            INNER JOIN goal g ON g.reference::text = te.source_reference
-        WHERE (te.event_type = 'GOAL_UPDATED' OR te.event_type = 'INDUCTION_UPDATED')
-          AND te.actioned_by != g.updated_by
-    );
+SET actioned_by = (
+    SELECT g.updated_by
+    FROM timeline_event te
+      INNER JOIN goal g ON g.reference::text = te.source_reference
+    WHERE te.reference = timeline_event.reference
+)
+WHERE id = (
+    SELECT te.id
+    FROM timeline_event te
+      INNER JOIN goal g ON g.reference::text = te.source_reference
+    WHERE (te.event_type = 'GOAL_UPDATED' OR te.event_type = 'INDUCTION_UPDATED')
+      AND te.actioned_by != g.updated_by
+);

--- a/src/main/resources/db/migration/V2023.12.05.0001__fix_actioned_by_on_timeline_events.sql
+++ b/src/main/resources/db/migration/V2023.12.05.0001__fix_actioned_by_on_timeline_events.sql
@@ -6,7 +6,7 @@ SET actioned_by = (
       INNER JOIN goal g ON g.reference::text = te.source_reference
     WHERE te.reference = timeline_event.reference
 )
-WHERE id = (
+WHERE id IN (
     SELECT te.id
     FROM timeline_event te
       INNER JOIN goal g ON g.reference::text = te.source_reference


### PR DESCRIPTION
This is OK for this PR to update a flyway migration, as the migration in question failed previously, so it has never successfully run anywhere