### PR TITLE
RR-446 - Temporarily disable cronjob

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-api/templates/export-database-to-analytical-platform-cronjob.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/templates/export-database-to-analytical-platform-cronjob.yaml
@@ -8,7 +8,8 @@ kind: CronJob
 metadata:
   name: export-database-to-analytical-platform-cronjob
 spec:
-  schedule: "0 9-17 * * 1-5" # On the hour between 09:00 and 17:00 Mon-Fri. For testing only; once smoke tested and working change to every day at 1am -> "0 1 * * *"
+  suspend: true
+  schedule: "0 1 * * *" # 1am every day
   concurrencyPolicy: Replace
   jobTemplate:
     spec:


### PR DESCRIPTION
Temporarily disable the "export data to analytics platform" cronjob (with `suspend: true`) because it is likely that we will need to promote `main` to `preprod` and `prod` soon, but the analytical platform setup work is not yet complete in `preprod` and `prod` which means we can't allow the cronjob to run in those environments yet.