### PR TITLE
RR-533 - Fix mapping of qualifications when highest level of education is not provided

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
@@ -19,19 +19,34 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.HighestEducationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInPrisonInterestsEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInPrisonTrainingInterestEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInPrisonWorkInterestEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidInductionEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPreviousQualificationsEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPreviousTrainingEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidQualificationEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AbilityToWorkFactor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonNotToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TrainingType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateEducationAndQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonTrainingType as InPrisonTrainingTypeEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonWorkType as InPrisonWorkTypeEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.TrainingType as TrainingTypeEntity
 
 class CreateInductionTest : IntegrationTestBase() {
 
@@ -172,6 +187,103 @@ class CreateInductionTest : IntegrationTestBase() {
 
   @Test
   @Transactional
+  fun `should create a short route induction`() {
+    // Given
+    val prisonNumber = "B5678CD"
+    val createRequest = aValidCreateCiagInductionRequest(
+      hopingToGetWork = HopingToWork.NO,
+      abilityToWork = setOf(AbilityToWorkFactor.OTHER),
+      abilityToWorkOther = "Lack of interest",
+      reasonToNotGetWork = setOf(ReasonNotToWork.OTHER),
+      reasonToNotGetWorkOther = "Crime pays",
+      workExperience = null,
+      skillsAndInterests = null,
+      qualificationsAndTraining = aValidCreateEducationAndQualificationsRequest(
+        educationLevel = null, // not set in short route
+        qualifications = setOf(aValidAchievedQualification()),
+        additionalTraining = setOf(TrainingType.NONE),
+        additionalTrainingOther = null,
+      ),
+      inPrisonInterests = aValidCreatePrisonWorkAndEducationRequest(
+        inPrisonWork = setOf(InPrisonWorkType.OTHER),
+        inPrisonWorkOther = "Any in-prison work",
+        inPrisonEducation = setOf(InPrisonTrainingType.OTHER),
+        inPrisonEducationOther = "Any in-prison training",
+      ),
+    )
+    val dpsUsername = "auser_gen"
+    val displayName = "Albert User"
+    val prisonId = createRequest.prisonId
+    val expectedPreviousQualifications = aValidPreviousQualificationsEntity(
+      educationLevel = HighestEducationLevel.NOT_SURE,
+      qualifications = mutableListOf(aValidQualificationEntity()),
+    )
+    val expectedPreviousTraining = aValidPreviousTrainingEntity(
+      trainingTypes = mutableListOf(TrainingTypeEntity.NONE),
+      trainingTypeOther = null,
+    )
+    val expectedInPrisonInterests = aValidInPrisonInterestsEntity(
+      inPrisonWorkInterests = mutableListOf(
+        aValidInPrisonWorkInterestEntity(
+          workType = InPrisonWorkTypeEntity.OTHER,
+          workTypeOther = "Any in-prison work",
+        ),
+      ),
+      inPrisonTrainingInterests = mutableListOf(
+        aValidInPrisonTrainingInterestEntity(
+          trainingType = InPrisonTrainingTypeEntity.OTHER,
+          trainingTypeOther = "Any in-prison training",
+        ),
+      ),
+    )
+
+    // When
+    webTestClient.post()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(createRequest)
+      .bearerToken(
+        aValidTokenWithEditAuthority(
+          username = dpsUsername,
+          displayName = displayName,
+          privateKey = keyPair.private,
+        ),
+      )
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
+
+    // Then
+    val induction = inductionRepository.findByPrisonNumber(prisonNumber)
+    assertThat(induction)
+      .isForPrisonNumber(prisonNumber)
+      .hasAReference()
+      .hasJpaManagedFieldsPopulated()
+      .wasCreatedBy(dpsUsername)
+      .wasUpdatedBy(dpsUsername)
+      .wasCreatedAtPrison(prisonId)
+      .wasUpdatedAtPrison(prisonId)
+    assertThat(induction!!.previousQualifications).isEqualToIgnoringInternallyManagedFields(expectedPreviousQualifications)
+    assertThat(induction.previousTraining).isEqualToIgnoringInternallyManagedFields(expectedPreviousTraining)
+    assertThat(induction.inPrisonInterests).isEqualToIgnoringInternallyManagedFields(expectedInPrisonInterests)
+
+    await.untilAsserted {
+      val eventPropertiesCaptor = ArgumentCaptor.forClass(Map::class.java as Class<Map<String, String>>)
+      verify(telemetryClient, times(1)).trackEvent(
+        eq("INDUCTION_CREATED"),
+        capture(eventPropertiesCaptor),
+        eq(null),
+      )
+      val createInductionEventProperties = eventPropertiesCaptor.firstValue
+      assertThat(createInductionEventProperties)
+        .containsEntry("prisonId", prisonId)
+        .containsEntry("userId", dpsUsername)
+        .containsKey("reference")
+    }
+  }
+
+  @Test
+  @Transactional
   fun `should create a new induction with empty collections`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
@@ -283,6 +395,7 @@ class CreateInductionTest : IntegrationTestBase() {
         personalInterestsOther = null,
       ),
       qualificationsAndTraining = aValidCreateEducationAndQualificationsRequest(
+        educationLevel = null,
         qualifications = null,
         additionalTraining = setOf(TrainingType.NONE), // cannot set to null
         additionalTrainingOther = null,
@@ -324,6 +437,7 @@ class CreateInductionTest : IntegrationTestBase() {
       .wasUpdatedBy(dpsUsername)
       .wasCreatedAtPrison(prisonId)
       .wasUpdatedAtPrison(prisonId)
+    assertThat(induction!!.previousQualifications!!.educationLevel).isEqualTo(HighestEducationLevel.NOT_SURE)
 
     await.untilAsserted {
       val eventPropertiesCaptor = ArgumentCaptor.forClass(Map::class.java as Class<Map<String, String>>)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -394,7 +394,7 @@ class UpdateInductionTest : IntegrationTestBase() {
 
     val expectedQualificationsAndTraining = aValidEducationAndQualificationsResponse(
       id = persistedInduction.qualificationsAndTraining!!.id!!,
-      educationLevel = null,
+      educationLevel = HighestEducationLevel.NOT_SURE,
       qualifications = emptySet(),
       additionalTraining = setOf(TrainingType.CSCS_CARD),
       additionalTrainingOther = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapper.kt
@@ -30,12 +30,12 @@ abstract class QualificationsAndTrainingResourceMapper {
     request: CreateEducationAndQualificationsRequest?,
     prisonId: String,
   ): CreatePreviousQualificationsDto? {
-    if (request?.educationLevel == null) {
+    if (request == null) {
       return null
     }
 
     return CreatePreviousQualificationsDto(
-      educationLevel = toHighestEducationLevelDomain(request.educationLevel)!!,
+      educationLevel = toHighestEducationLevelDomain(request.educationLevel) ?: HighestEducationLevelDomain.NOT_SURE,
       qualifications = request.qualifications?.map { toQualification(it) } ?: emptyList(),
       prisonId = prisonId,
     )
@@ -95,6 +95,7 @@ abstract class QualificationsAndTrainingResourceMapper {
   fun toOffsetDateTime(instant: Instant?): OffsetDateTime? = instant?.atOffset(ZoneOffset.UTC)
 
   @Mapping(target = "reference", source = "request.id")
+  @Mapping(target = "educationLevel", source = "request.educationLevel", defaultValue = "NOT_SURE")
   abstract fun toUpdatePreviousQualificationsDto(
     request: UpdateEducationAndQualificationsRequest,
     prisonId: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapperTest.kt
@@ -51,6 +51,24 @@ class QualificationsAndTrainingResourceMapperTest {
   }
 
   @Test
+  fun `should map to CreatePreviousQualificationsDto when prisoner has no qualifications`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidCreateEducationAndQualificationsRequest(
+      educationLevel = null,
+      qualifications = null,
+    )
+
+    // When
+    val actual = mapper.toCreatePreviousQualificationsDto(request, prisonId)
+
+    // Then
+    assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.educationLevel).isEqualTo(HighestEducationLevelDomain.NOT_SURE)
+    assertThat(actual.qualifications).isEmpty()
+  }
+
+  @Test
   fun `should map to CreatePreviousTrainingDto`() {
     // Given
     val prisonId = "BXI"
@@ -207,6 +225,36 @@ class QualificationsAndTrainingResourceMapperTest {
     assertThat(actual!!.prisonId).isEqualTo(prisonId)
     assertThat(actual.reference).isEqualTo(request.id)
     assertThat(actual.educationLevel).isEqualTo(HighestEducationLevelDomain.SECONDARY_SCHOOL_TOOK_EXAMS)
+    assertThat(actual.qualifications).isEqualTo(expectedQualifications)
+  }
+
+  @Test
+  fun `should map to UpdatePreviousQualificationsDto given missing education level`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdateEducationAndQualificationsRequest(
+      educationLevel = null,
+    )
+    val expectedQualifications = listOf(
+      Qualification(
+        subject = "English",
+        level = QualificationLevel.LEVEL_3,
+        grade = "A",
+      ),
+      Qualification(
+        subject = "Maths",
+        level = QualificationLevel.LEVEL_3,
+        grade = "B",
+      ),
+    )
+
+    // When
+    val actual = mapper.toUpdatePreviousQualificationsDto(request, prisonId)
+
+    // Then
+    assertThat(actual!!.prisonId).isEqualTo(prisonId)
+    assertThat(actual.reference).isEqualTo(request.id)
+    assertThat(actual.educationLevel).isEqualTo(HighestEducationLevelDomain.NOT_SURE)
     assertThat(actual.qualifications).isEqualTo(expectedQualifications)
   }
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntityBuilder.kt
@@ -7,7 +7,7 @@ fun aValidPreviousTrainingEntity(
   id: UUID? = null,
   reference: UUID = UUID.randomUUID(),
   trainingTypes: MutableList<TrainingType> = mutableListOf(TrainingType.OTHER),
-  trainingTypeOther: String = "Kotlin course",
+  trainingTypeOther: String? = "Kotlin course",
   createdAt: Instant? = null,
   createdAtPrison: String = "BXI",
   createdBy: String? = null,


### PR DESCRIPTION
This fixes a bug we've discovered where qualifications are not saved during the short route.