### PR TITLE
RR-476 - Update Goal audit fields when updating Steps

### DIFF
--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/KeyAwareDomain.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/KeyAwareDomain.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal
+
+/**
+ * Interface for domain model classes that enables them to provide a key to help identify them, or potentially to sort
+ * them within Collections.
+ */
+interface KeyAwareDomain {
+  fun key(): String
+}

--- a/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Step.kt
+++ b/domain/goal/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/Step.kt
@@ -13,7 +13,9 @@ data class Step(
   val title: String,
   val status: StepStatus = StepStatus.NOT_STARTED,
   val sequenceNumber: Int,
-)
+) : KeyAwareDomain {
+  override fun key(): String = reference.toString()
+}
 
 enum class StepStatus {
   NOT_STARTED,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -5,14 +5,12 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.test.context.transaction.TestTransaction
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.StepStatus
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.aValidActionPlanEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
@@ -153,16 +151,11 @@ class CreateActionPlanTest : IntegrationTestBase() {
   }
 
   @Test
-  @Transactional
   fun `should fail to create action plan given action plan already exists`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val actionPlan = aValidActionPlanEntity(prisonNumber = prisonNumber)
-    actionPlanRepository.save(actionPlan)
-    TestTransaction.flagForCommit()
-    TestTransaction.end()
-    TestTransaction.start()
-    assertThat(actionPlan).hasNumberOfGoals(1)
+    createActionPlan(prisonNumber)
+
     val createRequest = aValidCreateActionPlanRequest()
 
     // When

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.capture
@@ -170,7 +169,6 @@ class UpdateGoalTest : IntegrationTestBase() {
 
   @Test
   @Transactional
-  @Disabled("RR-476 - disabled whilst this fix is WIP")
   fun `should update goal`() {
     // Given
     val prisonNumber = aValidPrisonNumber()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.capture
@@ -169,6 +170,7 @@ class UpdateGoalTest : IntegrationTestBase() {
 
   @Test
   @Transactional
+  @Disabled("RR-476 - disabled whilst this fix is WIP")
   fun `should update goal`() {
     // Given
     val prisonNumber = aValidPrisonNumber()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/KeyAwareChildEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/KeyAwareChildEntity.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
 
 /**
  * Interface for "child" entity classes that can provide a key to help identify them, or potentially to sort them

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ParentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/ParentEntity.kt
@@ -1,11 +1,11 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
 
 /**
- * Abstract class for "parent" entities, which contain one or more collections of [KeyAwareChildEntity] entities.
+ * Interface for "parent" entities, which contain one or more collections of [KeyAwareChildEntity] entities.
  */
-abstract class ParentEntity {
+interface ParentEntity {
 
-  abstract fun childEntityUpdated()
+  fun childEntityUpdated()
 
   fun <CHILD : KeyAwareChildEntity> addChild(newChild: CHILD, existingChildren: MutableList<CHILD>) {
     addChildren(mutableListOf(newChild), existingChildren)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/GoalEntity.kt
@@ -23,6 +23,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ParentEntity
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -92,7 +93,18 @@ class GoalEntity(
   @Column
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
-) {
+) : ParentEntity {
+
+  fun steps(): MutableList<StepEntity> {
+    if (steps == null) {
+      steps = mutableListOf()
+    }
+    return steps!!
+  }
+
+  override fun childEntityUpdated() {
+    updatedAt = Instant.now()
+  }
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/GoalEntity.kt
@@ -9,7 +9,6 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
@@ -57,8 +56,7 @@ class GoalEntity(
   @Column
   var notes: String? = null,
 
-  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "goal_id", nullable = false)
+  @OneToMany(mappedBy = "parent", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   @field:NotNull
   var steps: MutableList<StepEntity>? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
@@ -27,6 +27,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.KeyAwareChildEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ParentEntity
 import java.time.Instant
 import java.util.UUID
 
@@ -80,7 +82,7 @@ class FutureWorkInterestsEntity(
   @Column
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
-) : ParentEntity() {
+) : ParentEntity {
 
   fun interests(): MutableList<WorkInterestEntity> {
     if (interests == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntity.kt
@@ -27,6 +27,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.KeyAwareChildEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ParentEntity
 import java.time.Instant
 import java.util.UUID
 
@@ -83,7 +85,7 @@ class InPrisonInterestsEntity(
   @Column
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
-) : ParentEntity() {
+) : ParentEntity {
 
   fun inPrisonWorkInterests(): MutableList<InPrisonWorkInterestEntity> {
     if (inPrisonWorkInterests == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntity.kt
@@ -27,6 +27,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.KeyAwareChildEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ParentEntity
 import java.time.Instant
 import java.util.UUID
 
@@ -85,7 +87,7 @@ class PersonalSkillsAndInterestsEntity(
   @Column
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
-) : ParentEntity() {
+) : ParentEntity {
 
   fun skills(): MutableList<PersonalSkillEntity> {
     if (skills == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntity.kt
@@ -27,6 +27,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.KeyAwareChildEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ParentEntity
 import java.time.Instant
 import java.util.UUID
 
@@ -88,7 +90,7 @@ class PreviousQualificationsEntity(
   @Column
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
-) : ParentEntity() {
+) : ParentEntity {
 
   fun qualifications(): MutableList<QualificationEntity> {
     if (qualifications == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
@@ -27,6 +27,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.CreatedByDisplayName
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.DisplayNameAuditingEntityListener.LastModifiedByDisplayName
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.KeyAwareChildEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ParentEntity
 import java.time.Instant
 import java.util.UUID
 
@@ -85,7 +87,7 @@ class PreviousWorkExperiencesEntity(
   @Column
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
-) : ParentEntity() {
+) : ParentEntity {
 
   fun experiences(): MutableList<WorkExperienceEntity> {
     if (experiences == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityListManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityListManager.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.actionplan
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.KeyAwareChildEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ParentEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.KeyAwareDomain
+
+/**
+ * Provides a centralised place to update, add or remove existing JPA entities (and thereby apply changes to the
+ * database). Manages changes between lists of domain model objects (provided via the external API) and the equivalent
+ * lists of existing JPA entities.
+ */
+@Component
+class GoalEntityListManager<ENTITY : KeyAwareChildEntity, DOMAIN : KeyAwareDomain> {
+
+  fun updateExisting(
+    existingEntities: MutableList<ENTITY>,
+    updatedDomain: List<DOMAIN>,
+    mapper: KeyAwareEntityMapper<ENTITY, DOMAIN>,
+  ) {
+    val updatedDomainKeys = updatedDomain.map { it.key() }
+    existingEntities
+      .filter { entity -> updatedDomainKeys.contains(entity.key()) }
+      .onEach { entity ->
+        mapper.updateEntityFromDomain(
+          entity,
+          updatedDomain.first { dto -> dto.key() == entity.key() },
+        )
+      }
+  }
+
+  fun addNew(
+    parentEntity: ParentEntity,
+    existingEntities: MutableList<ENTITY>,
+    updatedDomain: List<DOMAIN>,
+    mapper: KeyAwareEntityMapper<ENTITY, DOMAIN>,
+  ) {
+    val currentIdentifiers = existingEntities.map { it.key() }
+
+    val newEntities = updatedDomain
+      .filter { dto -> !currentIdentifiers.contains(dto.key()) }
+      .map { newDto -> mapper.fromDomainToEntity(newDto) }
+
+    if (newEntities.isNotEmpty()) {
+      parentEntity.addChildren(newEntities, existingEntities)
+    }
+  }
+
+  fun deleteRemoved(
+    existingEntities: MutableList<ENTITY>,
+    updatedDomain: List<DOMAIN>,
+  ) {
+    val updatedIdentifiers = updatedDomain.map { it.key() }
+
+    val removedEntities = existingEntities.filter { entity -> !updatedIdentifiers.contains(entity.key()) }
+    if (removedEntities.isNotEmpty()) {
+      existingEntities.removeAll(removedEntities)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityMapper.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.map
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeReferenceField
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.GenerateNewReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Goal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateGoalDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateStepDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.UpdateGoalDto
@@ -25,9 +26,11 @@ import java.util.UUID
   ],
 )
 abstract class GoalEntityMapper {
-
   @Autowired
   private lateinit var stepEntityMapper: StepEntityMapper
+
+  @Autowired
+  private lateinit var entityListManager: GoalEntityListManager<StepEntity, Step>
 
   /**
    * Maps the supplied [CreateGoalDto] into a new un-persisted [GoalEntity].

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityMapper.kt
@@ -17,8 +17,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateGoalDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateStepDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.UpdateGoalDto
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.UpdateStepDto
-import java.util.UUID
 
 @Mapper(
   uses = [
@@ -71,64 +69,18 @@ abstract class GoalEntityMapper {
   @Mapping(target = "steps", expression = "java( updateSteps(goalEntity, updatedGoalDto) )")
   abstract fun updateEntityFromDto(@MappingTarget goalEntity: GoalEntity, updatedGoalDto: UpdateGoalDto)
 
-  protected fun updateSteps(goalEntity: GoalEntity, updatedGoalDto: UpdateGoalDto): List<StepEntity> {
-    val stepEntities = goalEntity.steps!!
-    val updatedSteps = updatedGoalDto.steps.setReferenceOnNewSteps()
+  protected fun updateSteps(entity: GoalEntity, dto: UpdateGoalDto): List<StepEntity> {
+    val existingSteps = entity.steps!!
+    val updatedSteps = dto.steps.map { stepEntityMapper.fromDtoToDomain(it) }
 
-    updateExistingSteps(stepEntities, updatedSteps)
-    addNewSteps(stepEntities, updatedSteps)
-    removeSteps(stepEntities, updatedSteps)
+    entityListManager.updateExisting(existingSteps, updatedSteps, stepEntityMapper)
+    entityListManager.addNew(entity, existingSteps, updatedSteps, stepEntityMapper)
+    entityListManager.deleteRemoved(existingSteps, updatedSteps)
 
-    stepEntities.sortBy { it.sequenceNumber }
+    existingSteps.sortBy { it.sequenceNumber }
 
-    return stepEntities
+    return existingSteps
   }
-
-  /**
-   * Update the [StepEntity] whose reference number matches the corresponding [UpdateGoalDto]
-   */
-  private fun updateExistingSteps(stepEntities: MutableList<StepEntity>, updates: List<UpdateStepDto>) {
-    val updatedStepReferences = updates.map { it.reference }
-    stepEntities
-      .filter { stepEntity -> updatedStepReferences.contains(stepEntity.reference) }
-      .onEach { stepEntity ->
-        stepEntityMapper.updateEntityFromDto(
-          stepEntity,
-          updates.first { updatedStepDto -> updatedStepDto.reference == stepEntity.reference },
-        )
-      }
-  }
-
-  /**
-   * Add new [StepEntity]s from the list of updated [UpdateStepDto]s where the reference number is not present in the list of [StepEntity]s
-   */
-  private fun addNewSteps(stepEntities: MutableList<StepEntity>, updates: List<UpdateStepDto>) {
-    val currentStepEntityReferences = stepEntities.map { it.reference }
-    stepEntities.addAll(
-      updates
-        .filter { updatedStepDto -> !currentStepEntityReferences.contains(updatedStepDto.reference) }
-        .map { newStepDto -> stepEntityMapper.fromDtoToEntity(newStepDto) },
-    )
-  }
-
-  /**
-   * Remove any [StepEntity]s whose reference number is not in the list of updated [UpdateStepDto]s
-   */
-  private fun removeSteps(stepEntities: MutableList<StepEntity>, updates: List<UpdateStepDto>) {
-    val updatedStepReferences = updates.map { it.reference }
-    stepEntities.removeIf { stepEntity ->
-      !updatedStepReferences.contains(stepEntity.reference)
-    }
-  }
-
-  private fun List<UpdateStepDto>.setReferenceOnNewSteps(): List<UpdateStepDto> =
-    this.map {
-      if (it.reference == null) {
-        it.copy(reference = UUID.randomUUID())
-      } else {
-        it
-      }
-    }
 
   private fun addNewStepsToEntity(steps: List<CreateStepDto>, entity: GoalEntity) {
     steps.forEach {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/KeyAwareEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/KeyAwareEntityMapper.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.actionplan
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.KeyAwareChildEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.KeyAwareDomain
+
+/**
+ * Interface for mapping between entity and domain objects that adhere to the 'KeyAware' interfaces.
+ */
+interface KeyAwareEntityMapper<ENTITY : KeyAwareChildEntity, DOMAIN : KeyAwareDomain> {
+  fun updateEntityFromDomain(entity: ENTITY, domain: DOMAIN)
+
+  fun fromDomainToEntity(domain: DOMAIN): ENTITY
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/StepEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/StepEntityMapper.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.actionplan
 
 import org.mapstruct.Mapper
+import org.mapstruct.Mapping
 import org.mapstruct.MappingTarget
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.StepEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeJpaManagedFields
@@ -10,9 +11,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.map
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateStepDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.UpdateStepDto
+import java.util.UUID
 
-@Mapper
-interface StepEntityMapper {
+@Mapper(
+  imports = [UUID::class],
+)
+interface StepEntityMapper : KeyAwareEntityMapper<StepEntity, Step> {
 
   /**
    * Maps the supplied [CreateStepDto] into a new un-persisted [StepEntity].
@@ -42,4 +46,16 @@ interface StepEntityMapper {
   @ExcludeReferenceField
   @ExcludeParentEntity
   fun updateEntityFromDto(@MappingTarget stepEntity: StepEntity, updatedStep: UpdateStepDto)
+
+  @Mapping(target = "reference", expression = "java( updateStepDto.getReference() != null ? updateStepDto.getReference() : UUID.randomUUID() )")
+  fun fromDtoToDomain(updateStepDto: UpdateStepDto): Step
+
+  @ExcludeJpaManagedFields
+  @ExcludeParentEntity
+  override fun fromDomainToEntity(domain: Step): StepEntity
+
+  @ExcludeJpaManagedFields
+  @ExcludeReferenceField
+  @ExcludeParentEntity
+  override fun updateEntityFromDomain(@MappingTarget entity: StepEntity, domain: Step)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/StepEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/StepEntityMapper.kt
@@ -4,6 +4,7 @@ import org.mapstruct.Mapper
 import org.mapstruct.MappingTarget
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.StepEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeJpaManagedFields
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeParentEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.ExcludeReferenceField
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.GenerateNewReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
@@ -20,6 +21,7 @@ interface StepEntityMapper {
    */
   @ExcludeJpaManagedFields
   @GenerateNewReference
+  @ExcludeParentEntity
   fun fromDtoToEntity(createStepDto: CreateStepDto): StepEntity
 
   /**
@@ -28,6 +30,7 @@ interface StepEntityMapper {
    * This method is suitable for creating a new [StepEntity] to be subsequently persisted to the database.
    */
   @ExcludeJpaManagedFields
+  @ExcludeParentEntity
   fun fromDtoToEntity(updateStepDto: UpdateStepDto): StepEntity
 
   /**
@@ -37,5 +40,6 @@ interface StepEntityMapper {
 
   @ExcludeJpaManagedFields
   @ExcludeReferenceField
+  @ExcludeParentEntity
   fun updateEntityFromDto(@MappingTarget stepEntity: StepEntity, updatedStep: UpdateStepDto)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityListManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityListManager.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.KeyAwareChildEntity
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.ParentEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.KeyAwareChildEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.ParentEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.KeyAwareDomain
 
 /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/KeyAwareEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/KeyAwareEntityMapper.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
 
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.KeyAwareChildEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.KeyAwareChildEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.KeyAwareDomain
 
 /**

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityMapperTest.kt
@@ -9,9 +9,11 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.StepEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.aValidGoalEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.aValidStepEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.aValidStep
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.CreateStepDto
@@ -31,6 +33,9 @@ class GoalEntityMapperTest {
 
   @Mock
   private lateinit var stepMapper: StepEntityMapper
+
+  @Mock
+  private lateinit var entityListManager: GoalEntityListManager<StepEntity, Step>
 
   @Test
   fun `should map from CreateGoalDto to entity`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityMapperUpdateEntityFromDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityMapperUpdateEntityFromDtoTest.kt
@@ -3,11 +3,13 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.GoalStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.StepEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.StepStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.aValidGoalEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.aValidStepEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.deepCopy
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.Step
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidUpdateGoalDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.dto.aValidUpdateStepDto
 import java.time.LocalDate
@@ -15,17 +17,24 @@ import java.time.LocalDate
 /**
  * Unit test class for [GoalEntityMapper] specifically for the [GoalEntityMapper.updateEntityFromDto] method.
  *
- * The tests in this class test the [GoalEntityMapper] but with a concrete [StepEntityMapper] rather than a mock.
+ * The tests in this class test the [GoalEntityMapper] but with concrete [GoalEntityListManager] and [StepEntityMapper]
+ * instances rather than mocks.
  * This is because the method under test ([GoalEntityMapper.updateEntityFromDto]) mutates the steps collection using
- * the [StepEntityMapper].
+ * the [GoalEntityListManager] and [StepEntityMapper].
  * It is set with reflection as there is no setter or constructor injection on the mapstruct generated class.
  */
 class GoalEntityMapperUpdateEntityFromDtoTest {
 
   private val mapper: GoalEntityMapper = GoalEntityMapperImpl().also {
-    GoalEntityMapper::class.java.getDeclaredField("stepEntityMapper").apply {
-      isAccessible = true
-      set(it, StepEntityMapperImpl())
+    with(GoalEntityMapper::class.java) {
+      getDeclaredField("stepEntityMapper").apply {
+        isAccessible = true
+        set(it, StepEntityMapperImpl())
+      }
+      getDeclaredField("entityListManager").apply {
+        isAccessible = true
+        set(it, GoalEntityListManager<StepEntity, Step>())
+      }
     }
   }
 
@@ -213,7 +222,7 @@ class GoalEntityMapperUpdateEntityFromDtoTest {
   }
 
   @Test
-  fun `should update entity from UpdateGoalDto given DTO given steps re-ordered and new step added in the middle`() {
+  fun `should update entity from UpdateGoalDto given DTO has steps re-ordered and new step added in the middle`() {
     // Given
     val goalReference = aValidReference()
     val step1Reference = aValidReference()

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/EntityAssertions.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/EntityAssertions.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity
 
 // JPA managed fields, plus the reference field, which are all managed/generated within the API
 internal val INTERNALLY_MANAGED_FIELDS =

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/GoalEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/GoalEntityAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.INTERNALLY_MANAGED_FIELDS
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -13,11 +14,6 @@ fun assertThat(actual: GoalEntity?) = GoalEntityAssert(actual)
  */
 class GoalEntityAssert(actual: GoalEntity?) :
   AbstractObjectAssert<GoalEntityAssert, GoalEntity?>(actual, GoalEntityAssert::class.java) {
-
-  companion object {
-    private val JPA_MANAGED_FIELDS =
-      arrayOf("id", "createdAt", "createdBy", "createdByDisplayName", "updatedAt", "updatedBy", "updatedByDisplayName")
-  }
 
   fun hasJpaManagedFieldsPopulated(): GoalEntityAssert {
     isNotNull
@@ -49,7 +45,7 @@ class GoalEntityAssert(actual: GoalEntity?) :
   fun isEqualToIgnoringJpaManagedFields(expected: GoalEntity): GoalEntityAssert {
     assertThat(actual)
       .usingRecursiveComparison()
-      .ignoringFields(*JPA_MANAGED_FIELDS)
+      .ignoringFieldsMatchingRegexes(*INTERNALLY_MANAGED_FIELDS)
       .isEqualTo(expected)
     return this
   }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/StepEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/StepEntityAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.INTERNALLY_MANAGED_FIELDS
 import java.time.Instant
 import java.util.UUID
 
@@ -11,10 +12,6 @@ fun assertThat(actual: StepEntity?) = StepEntityAssert(actual)
  */
 class StepEntityAssert(actual: StepEntity?) :
   AbstractObjectAssert<StepEntityAssert, StepEntity?>(actual, StepEntityAssert::class.java) {
-
-  companion object {
-    private val JPA_MANAGED_FIELDS = arrayOf("id", "createdAt", "createdBy", "updatedAt", "updatedBy")
-  }
 
   fun hasJpaManagedFieldsPopulated(): StepEntityAssert {
     isNotNull
@@ -44,7 +41,7 @@ class StepEntityAssert(actual: StepEntity?) :
   fun isEqualToIgnoringJpaManagedFields(expected: StepEntity): StepEntityAssert {
     assertThat(actual)
       .usingRecursiveComparison()
-      .ignoringFields(*JPA_MANAGED_FIELDS)
+      .ignoringFieldsMatchingRegexes(*INTERNALLY_MANAGED_FIELDS)
       .isEqualTo(expected)
     return this
   }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntityAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.INTERNALLY_MANAGED_FIELDS
 import java.time.Instant
 import java.util.UUID
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InPrisonInterestsEntityAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.INTERNALLY_MANAGED_FIELDS
 import java.time.Instant
 import java.util.UUID
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntityAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.INTERNALLY_MANAGED_FIELDS
 import java.time.Instant
 import java.util.UUID
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PersonalSkillsAndInterestsEntityAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.INTERNALLY_MANAGED_FIELDS
 import java.time.Instant
 import java.util.UUID
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntityAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.INTERNALLY_MANAGED_FIELDS
 import java.time.Instant
 import java.util.UUID
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousTrainingEntityAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.INTERNALLY_MANAGED_FIELDS
 import java.time.Instant
 import java.util.UUID
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntityAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.INTERNALLY_MANAGED_FIELDS
 import java.time.Instant
 import java.util.UUID
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/WorkOnReleaseEntityAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.INTERNALLY_MANAGED_FIELDS
 import java.time.Instant
 import java.util.UUID
 


### PR DESCRIPTION
This PR fixes a bug when an `UpdateGoalRequest` was processed that contained new or edited Steps, but not removed Steps, and no changes to the parent Goal. IE. a request to update a Goal where the request was to either add new Steps only, or update existing Steps only.

In these cases the parent Goal was not updated at all, so the JPA managed audit fields were not updated. This had the side effect of the Timeline event for the updated Goal having the wrong "updated by/at" fields (as these are taken from the Goal, and these had not been updated)