### PR TITLE
RR-521 Ensure null child objects are ignored when updating an Induction

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapper.kt
@@ -94,17 +94,39 @@ abstract class QualificationsAndTrainingResourceMapper {
 
   fun toOffsetDateTime(instant: Instant?): OffsetDateTime? = instant?.atOffset(ZoneOffset.UTC)
 
+  fun toUpdatePreviousQualificationsDto(
+    request: UpdateEducationAndQualificationsRequest?,
+    prisonId: String,
+  ): UpdatePreviousQualificationsDto? {
+    return if (request == null) {
+      null
+    } else {
+      convertToUpdatePreviousQualificationsDto(request, prisonId)
+    }
+  }
+
   @Mapping(target = "reference", source = "request.id")
   @Mapping(target = "educationLevel", source = "request.educationLevel", defaultValue = "NOT_SURE")
-  abstract fun toUpdatePreviousQualificationsDto(
-    request: UpdateEducationAndQualificationsRequest,
+  abstract fun convertToUpdatePreviousQualificationsDto(
+    request: UpdateEducationAndQualificationsRequest?,
     prisonId: String,
   ): UpdatePreviousQualificationsDto?
+
+  fun toUpdatePreviousTrainingDto(
+    request: UpdateEducationAndQualificationsRequest?,
+    prisonId: String,
+  ): UpdatePreviousTrainingDto? {
+    return if (request == null) {
+      null
+    } else {
+      convertToUpdatePreviousTrainingDto(request, prisonId)
+    }
+  }
 
   @Mapping(target = "reference", source = "request.id")
   @Mapping(target = "trainingTypes", source = "request.additionalTraining")
   @Mapping(target = "trainingTypeOther", source = "request.additionalTrainingOther")
-  abstract fun toUpdatePreviousTrainingDto(
+  abstract fun convertToUpdatePreviousTrainingDto(
     request: UpdateEducationAndQualificationsRequest?,
     prisonId: String,
   ): UpdatePreviousTrainingDto?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/UpdateCiagInductionRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/UpdateCiagInductionRequestMapper.kt
@@ -21,7 +21,7 @@ class UpdateCiagInductionRequestMapper(
       prisonNumber = prisonNumber,
       workOnRelease = workOnReleaseMapper.toUpdateWorkOnReleaseDto(request),
       previousQualifications = qualificationsAndTrainingMapper.toUpdatePreviousQualificationsDto(
-        request = request.qualificationsAndTraining!!,
+        request = request.qualificationsAndTraining,
         prisonId = prisonId,
       ),
       previousTraining = qualificationsAndTrainingMapper.toUpdatePreviousTrainingDto(

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.7.1'
+  version: '1.7.2'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -202,11 +202,11 @@ paths:
       deprecated: true
       summary: Updates an Induction for a Prisoner.
       description: |
-        Provides the ability to update a Prisoner's Induction. Completely overwrites the existing Prisoner's Induction with the
-        information provided in the update request. If a field is not included in the update request, it will be removed from the 
-        database, effectively making the update request the authoritative source of information. This endpoint has been migrated
-        from the `hmpps-ciag-careers-induction-api` and the data structure has been kept the same in order to prevent breaking
-        the CIAG UI when it points to this endpoint.
+        Provides the ability to update a Prisoner's Induction. If a field (or "child" object) is provided in the request, it will
+        completely overwrite the existing value. Conversely, if a field is not included in the request, then the existing value
+        will remain untouched (including its updatedAt/updatedBy values). This endpoint has been migrated from the
+        `hmpps-ciag-careers-induction-api` and the data structure has been kept the same in order to prevent breaking the CIAG
+        UI when it points to this endpoint.
       tags:
         - Legacy Inductions
       responses:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsAndTrainingResourceMapperTest.kt
@@ -275,4 +275,17 @@ class QualificationsAndTrainingResourceMapperTest {
     assertThat(actual.trainingTypes).isEqualTo(expectedTrainingTypes)
     assertThat(actual.trainingTypeOther).isEqualTo("Any training")
   }
+
+  @Test
+  fun `should not map to UpdatePreviousTrainingDto given null request`() {
+    // Given
+    val prisonId = "BXI"
+    val request = null
+
+    // When
+    val actual = mapper.toUpdatePreviousTrainingDto(request, prisonId)
+
+    // Then
+    assertThat(actual).isNull()
+  }
 }


### PR DESCRIPTION
This PR ensures that an Induction can be updated if any of the "child" objects (e.g. `educationAndTraining`) is not provided in an update request.

I have also taken this opportunity to rationalise `UpdateInductionTest` and combine multiple scenarios into fewer tests where possible.