### PR TITLE
Revert RR-446 - Use AP helm chart instead of manual template config

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-api/Chart.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/Chart.yaml
@@ -10,6 +10,3 @@ dependencies:
   - name: generic-prometheus-alerts
     version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
-  - name: generic-data-analytics-extractor
-    version: 1.1.0
-    repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-education-and-work-plan-api/templates/export-database-to-analytical-platform-cronjob.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/templates/export-database-to-analytical-platform-cronjob.yaml
@@ -1,0 +1,63 @@
+# Export database to Analytical Platform data pipeline
+#
+# Sets up a CronJob pod that uses the `ministryofjustice/data-engineering-data-extractor` docker image to extract
+# all tables to CSV and upload to the Analytical Platform S3 bucket.
+#
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: export-database-to-analytical-platform-cronjob
+spec:
+  suspend: true
+  schedule: "0 1 * * *" # 1am every day
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: data-extractor-analytics
+              image: ministryofjustice/data-engineering-data-extractor:v1
+              imagePullPolicy: Always
+              args: ["extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
+              env:
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: rds_instance_address
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: database_name
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: database_username
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-postgresql-instance-output
+                      key: database_password
+                - name: S3_DESTINATION
+                  valueFrom:
+                    secretKeyRef:
+                      name: analytical-platform-reporting-s3-bucket
+                      key: destination_bucket
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: analytical-platform-reporting-s3-bucket
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: analytical-platform-reporting-s3-bucket
+                      key: secret_access_key
+                - name: AWS_DEFAULT_REGION
+                  value: eu-west-2
+                - name: SAVE_EVENTS_LOG
+                  value: "true"

--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -53,10 +53,3 @@ generic-service:
 
 generic-prometheus-alerts:
   targetApplication: hmpps-education-and-work-plan-api
-
-generic-data-analytics-extractor:
-  cronJobSchedule: "0 1 * * *" # 1am every day
-  databaseSecretName: rds-postgresql-instance-output
-  destinationS3SecretName: analytical-platform-reporting-s3-bucket
-  serviceAccountName: hmpps-education-and-work-plan-prod-to-ap-s3
-  enabled: false

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,6 +20,3 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev
-
-generic-data-analytics-extractor:
-  serviceAccountName: hmpps-education-and-work-plan-dev-to-ap-s3

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,6 +20,3 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev
-
-generic-data-analytics-extractor:
-  serviceAccountName: hmpps-education-and-work-plan-preprod-to-ap-s3


### PR DESCRIPTION
This PR reverts the previous commit  `RR-446 - Use AP helm chart instead of manual template config` (7bef82edec845e49e329d8635c580a6ec3a91055)