### PR TITLE
RR-522 - Precursor before adding new Induction endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CiagInductionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CiagInductionController.kt
@@ -12,9 +12,9 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.CiagInductionResponseMapper
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.CreateCiagInductionRequestMapper
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.UpdateCiagInductionRequestMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag.CiagInductionResponseMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag.CreateCiagInductionRequestMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag.UpdateCiagInductionRequestMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionSummaryListResponse
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Updat
 
 @RestController
 @RequestMapping(value = ["/ciag/induction"], produces = [MediaType.APPLICATION_JSON_VALUE])
-class InductionController(
+class CiagInductionController(
   private val inductionService: InductionService,
   private val createInductionRequestMapper: CreateCiagInductionRequestMapper,
   private val updateInductionRequestMapper: UpdateCiagInductionRequestMapper,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInPrisonInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInPrisonInterestsResourceMapper.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPri
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType as InPrisonWorkTypeApi
 
 @Component
-class InPrisonInterestsResourceMapper(
+class CiagInPrisonInterestsResourceMapper(
   val instantMapper: InstantMapper,
 ) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInductionResponseMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInductionResponseMapper.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
@@ -11,11 +11,11 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Hopin
 
 @Component
 class CiagInductionResponseMapper(
-  private val workOnReleaseMapper: WorkOnReleaseResourceMapper,
+  private val workOnReleaseMapper: CiagWorkOnReleaseResourceMapper,
   private val qualificationsAndTrainingMapper: QualificationsAndTrainingResourceMapper,
-  private val workExperiencesMapper: PreviousWorkExperiencesResourceMapper,
-  private val inPrisonInterestsMapper: InPrisonInterestsResourceMapper,
-  private val skillsAndInterestsMapper: PersonalSkillsAndInterestsResourceMapper,
+  private val workExperiencesMapper: CiagWorkExperiencesResourceMapper,
+  private val inPrisonInterestsMapper: CiagInPrisonInterestsResourceMapper,
+  private val skillsAndInterestsMapper: CiagSkillsAndInterestsResourceMapper,
   private val instantMapper: InstantMapper,
 ) {
   fun fromDomainToModel(inductionDomain: Induction): CiagInductionResponse {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagSkillsAndInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagSkillsAndInterestsResourceMapper.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Perso
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkillType as PersonalSkillApi
 
 @Component
-class PersonalSkillsAndInterestsResourceMapper(
+class CiagSkillsAndInterestsResourceMapper(
   private val instantMapper: InstantMapper,
 ) {
   fun toCreatePersonalSkillsAndInterestsDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkExperiencesResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkExperiencesResourceMapper.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Wor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkExperience as WorkExperienceApi
 
 @Mapper(nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
-abstract class PreviousWorkExperiencesResourceMapper {
+abstract class CiagWorkExperiencesResourceMapper {
 
   fun toCreatePreviousWorkExperiencesDto(
     request: CreatePreviousWorkRequest?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkInterestsResourceMapper.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterest
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkI
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 
 @Component
-class FutureWorkInterestsResourceMapper {
+class CiagWorkInterestsResourceMapper {
   fun toCreateFutureWorkInterestsDto(request: CreateWorkInterestsRequest?, prisonId: String): CreateFutureWorkInterestsDto? =
     request?.let {
       CreateFutureWorkInterestsDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkOnReleaseResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkOnReleaseResourceMapper.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Reaso
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateCiagInductionRequest
 
 @Mapper(nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
-interface WorkOnReleaseResourceMapper {
+interface CiagWorkOnReleaseResourceMapper {
 
   @Mapping(target = "hopingToWork", source = "hopingToGetWork")
   @Mapping(target = "notHopingToWorkReasons", source = "reasonToNotGetWork")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CreateCiagInductionRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CreateCiagInductionRequestMapper.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateInductionDto
@@ -6,12 +6,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 
 @Component
 class CreateCiagInductionRequestMapper(
-  private val workOnReleaseMapper: WorkOnReleaseResourceMapper,
+  private val workOnReleaseMapper: CiagWorkOnReleaseResourceMapper,
   private val qualificationsAndTrainingMapper: QualificationsAndTrainingResourceMapper,
-  private val workExperiencesMapper: PreviousWorkExperiencesResourceMapper,
-  private val inPrisonInterestsMapper: InPrisonInterestsResourceMapper,
-  private val skillsAndInterestsMapper: PersonalSkillsAndInterestsResourceMapper,
-  private val workInterestsMapper: FutureWorkInterestsResourceMapper,
+  private val workExperiencesMapper: CiagWorkExperiencesResourceMapper,
+  private val inPrisonInterestsMapper: CiagInPrisonInterestsResourceMapper,
+  private val skillsAndInterestsMapper: CiagSkillsAndInterestsResourceMapper,
+  private val workInterestsMapper: CiagWorkInterestsResourceMapper,
 ) {
 
   fun toCreateInductionDto(prisonNumber: String, request: CreateCiagInductionRequest): CreateInductionDto {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/QualificationsAndTrainingResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/QualificationsAndTrainingResourceMapper.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/UpdateCiagInductionRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/UpdateCiagInductionRequestMapper.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateInductionDto
@@ -6,12 +6,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Updat
 
 @Component
 class UpdateCiagInductionRequestMapper(
-  private val workOnReleaseMapper: WorkOnReleaseResourceMapper,
+  private val workOnReleaseMapper: CiagWorkOnReleaseResourceMapper,
   private val qualificationsAndTrainingMapper: QualificationsAndTrainingResourceMapper,
-  private val workExperiencesMapper: PreviousWorkExperiencesResourceMapper,
-  private val inPrisonInterestsMapper: InPrisonInterestsResourceMapper,
-  private val skillsAndInterestsMapper: PersonalSkillsAndInterestsResourceMapper,
-  private val workInterestsMapper: FutureWorkInterestsResourceMapper,
+  private val workExperiencesMapper: CiagWorkExperiencesResourceMapper,
+  private val inPrisonInterestsMapper: CiagInPrisonInterestsResourceMapper,
+  private val skillsAndInterestsMapper: CiagSkillsAndInterestsResourceMapper,
+  private val workInterestsMapper: CiagWorkInterestsResourceMapper,
 ) {
 
   fun toUpdateInductionDto(prisonNumber: String, request: UpdateCiagInductionRequest): UpdateInductionDto {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInPrisonInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInPrisonInterestsResourceMapperTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import aValidCreatePrisonWorkAndEducationRequest
 import aValidUpdatePrisonWorkAndEducationRequest
@@ -22,10 +22,10 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPri
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType as InPrisonWorkTypeApi
 
 @ExtendWith(MockitoExtension::class)
-class InPrisonInterestsResourceMapperTest {
+class CiagInPrisonInterestsResourceMapperTest {
 
   @InjectMocks
-  private lateinit var mapper: InPrisonInterestsResourceMapper
+  private lateinit var mapper: CiagInPrisonInterestsResourceMapper
 
   @Mock
   private lateinit var instantMapper: InstantMapper

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInductionResponseMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInductionResponseMapperTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -36,19 +36,19 @@ class CiagInductionResponseMapperTest {
   private lateinit var mapper: CiagInductionResponseMapper
 
   @Mock
-  private lateinit var workOnReleaseMapper: WorkOnReleaseResourceMapper
+  private lateinit var workOnReleaseMapper: CiagWorkOnReleaseResourceMapper
 
   @Mock
   private lateinit var qualificationsAndTrainingMapper: QualificationsAndTrainingResourceMapper
 
   @Mock
-  private lateinit var workExperiencesMapper: PreviousWorkExperiencesResourceMapper
+  private lateinit var workExperiencesMapper: CiagWorkExperiencesResourceMapper
 
   @Mock
-  private lateinit var inPrisonInterestsMapper: InPrisonInterestsResourceMapper
+  private lateinit var inPrisonInterestsMapper: CiagInPrisonInterestsResourceMapper
 
   @Mock
-  private lateinit var skillsAndInterestsMapper: PersonalSkillsAndInterestsResourceMapper
+  private lateinit var skillsAndInterestsMapper: CiagSkillsAndInterestsResourceMapper
 
   @Mock
   private lateinit var instantMapper: InstantMapper

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagSkillsAndInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagSkillsAndInterestsResourceMapperTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -24,10 +24,10 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Per
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkill as PersonalSkillDomain
 
 @ExtendWith(MockitoExtension::class)
-class PersonalSkillsAndInterestsResourceMapperTest {
+class CiagSkillsAndInterestsResourceMapperTest {
 
   @InjectMocks
-  private lateinit var mapper: PersonalSkillsAndInterestsResourceMapper
+  private lateinit var mapper: CiagSkillsAndInterestsResourceMapper
 
   @Mock
   private lateinit var instantMapper: InstantMapper

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkExperiencesResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkExperiencesResourceMapperTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -22,8 +22,8 @@ import java.time.ZoneOffset
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkExperienceType as WorkExperienceTypeDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType as WorkInterestTypeDomain
 
-class PreviousWorkExperiencesResourceMapperTest {
-  private val mapper = PreviousWorkExperiencesResourceMapperImpl()
+class CiagWorkExperiencesResourceMapperTest {
+  private val mapper = CiagWorkExperiencesResourceMapperImpl()
 
   @Test
   fun `should map to CreatePreviousWorkExperiencesDto`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkInterestsResourceMapperTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -9,8 +9,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateWorkInterestsRequest
 
-class FutureWorkInterestsResourceMapperTest {
-  private val mapper = FutureWorkInterestsResourceMapper()
+class CiagWorkInterestsResourceMapperTest {
+  private val mapper = CiagWorkInterestsResourceMapper()
 
   @Test
   fun `should map to CreateFutureWorkInterestsDto`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkOnReleaseResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkOnReleaseResourceMapperTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -7,8 +7,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Hop
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.NotHopingToWorkReason
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
 
-class WorkOnReleaseResourceMapperTest {
-  private val mapper = WorkOnReleaseResourceMapperImpl()
+class CiagWorkOnReleaseResourceMapperTest {
+  private val mapper = CiagWorkOnReleaseResourceMapperImpl()
 
   @Test
   fun `should map to PreviousTrainingDto`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CreateCiagInductionRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CreateCiagInductionRequestMapperTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -25,22 +25,22 @@ class CreateCiagInductionRequestMapperTest {
   private lateinit var mapper: CreateCiagInductionRequestMapper
 
   @Mock
-  private lateinit var workOnReleaseMapper: WorkOnReleaseResourceMapper
+  private lateinit var workOnReleaseMapper: CiagWorkOnReleaseResourceMapper
 
   @Mock
   private lateinit var qualificationsAndTrainingMapper: QualificationsAndTrainingResourceMapper
 
   @Mock
-  private lateinit var workExperiencesMapper: PreviousWorkExperiencesResourceMapper
+  private lateinit var workExperiencesMapper: CiagWorkExperiencesResourceMapper
 
   @Mock
-  private lateinit var inPrisonInterestsMapper: InPrisonInterestsResourceMapper
+  private lateinit var inPrisonInterestsMapper: CiagInPrisonInterestsResourceMapper
 
   @Mock
-  private lateinit var skillsAndInterestsMapper: PersonalSkillsAndInterestsResourceMapper
+  private lateinit var skillsAndInterestsMapper: CiagSkillsAndInterestsResourceMapper
 
   @Mock
-  private lateinit var workInterestsMapper: FutureWorkInterestsResourceMapper
+  private lateinit var workInterestsMapper: CiagWorkInterestsResourceMapper
 
   @Test
   fun `should map to createInductionDto`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/QualificationsAndTrainingResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/QualificationsAndTrainingResourceMapperTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
This PR is purely a precursor before adding a new `InductionController` and the necessary mappers for our new `/inductions` endpoints. It doesn't change any existing behaviour - it just renames/moves existing classes.