### PR TITLE
RR-548 - Ensure timestamp and author fields are updated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
@@ -33,6 +33,7 @@ class JpaInductionPersistenceAdapter(
     val inductionEntity = inductionRepository.findByPrisonNumber(updateInductionDto.prisonNumber)
     return if (inductionEntity != null) {
       inductionMapper.updateEntityFromDto(inductionEntity, updateInductionDto)
+      inductionEntity.updateLastUpdatedAt() // force the main Induction's JPA managed fields to update
       val persistedEntity = inductionRepository.saveAndFlush(inductionEntity)
       inductionMapper.fromEntityToDomain(persistedEntity)
     } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntity.kt
@@ -106,6 +106,10 @@ class InductionEntity(
   @LastModifiedByDisplayName
   var updatedByDisplayName: String? = null,
 ) {
+  fun updateLastUpdatedAt() {
+    updatedAt = Instant.now()
+  }
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/CiagInductionResponseMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/CiagInductionResponseMapper.kt
@@ -42,12 +42,8 @@ class CiagInductionResponseMapper(
         inPrisonInterests = inPrisonInterestsMapper.toPrisonWorkAndEducationResponse(inPrisonInterests),
         createdBy = createdBy!!,
         createdDateTime = instantMapper.toOffsetDateTime(createdAt)!!,
-        // The main Induction domain object is immutable (the data that can be changed belongs in associated "child"
-        // objects). However, the CIAG API stores details regarding a prisoner's work aspirations at the root level,
-        // which means that any changes to these values needs to be reflected in the "modified" fields of the root
-        // Induction in the response.
-        modifiedBy = workOnRelease.lastUpdatedBy!!,
-        modifiedDateTime = instantMapper.toOffsetDateTime(workOnRelease.lastUpdatedAt)!!,
+        modifiedBy = lastUpdatedBy!!,
+        modifiedDateTime = instantMapper.toOffsetDateTime(lastUpdatedAt)!!,
       )
     }
   }


### PR DESCRIPTION
We've discovered an issue where the timestamp and author fields are wrong when an `INDUCTION_UPDATED` timeline event occurs. This was due to the way the main Induction's `updatedAt`/`updatedBy`/`updatedByDisplayName` fields were not being correctly updated in most circumstances when the "Update Induction" endpoint is called. This PR ensures that these fields are now updated whenever the update endpoint is called.