### PR TITLE
RR-523 - InductionResponse builders. Move legacy CIAG builders

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagI
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateCiagInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalsRequest
@@ -48,7 +49,8 @@ abstract class IntegrationTestBase {
     const val CREATE_ACTION_PLAN_URI_TEMPLATE = "/action-plans/{prisonNumber}"
     const val GET_ACTION_PLAN_URI_TEMPLATE = "/action-plans/{prisonNumber}"
     const val GET_TIMELINE_URI_TEMPLATE = "/timelines/{prisonNumber}"
-    const val INDUCTION_URI_TEMPLATE = "/ciag/induction/{prisonNumber}"
+    const val CIAG_INDUCTION_URI_TEMPLATE = "/ciag/induction/{prisonNumber}"
+    const val INDUCTION_URI_TEMPLATE = "/inductions/{prisonNumber}"
 
     private val localStackContainer = LocalStackContainer.instance
 
@@ -135,14 +137,14 @@ abstract class IntegrationTestBase {
       .returnResult(TimelineResponse::class.java)
       .responseBody.blockFirst()!!
 
-  fun createInduction(
+  fun createCiagInduction(
     prisonNumber: String,
     createCiagInductionRequest: CreateCiagInductionRequest,
     username: String = "auser_gen",
     displayName: String = "Albert User",
   ) {
     webTestClient.post()
-      .uri(INDUCTION_URI_TEMPLATE, prisonNumber)
+      .uri(CIAG_INDUCTION_URI_TEMPLATE, prisonNumber)
       .withBody(createCiagInductionRequest)
       .bearerToken(
         aValidTokenWithEditAuthority(
@@ -157,9 +159,31 @@ abstract class IntegrationTestBase {
       .isCreated()
   }
 
-  fun getInduction(prisonNumber: String): CiagInductionResponse =
-    webTestClient.get()
+  fun createInduction(
+    prisonNumber: String,
+    createInductionRequest: CreateInductionRequest,
+    username: String = "auser_gen",
+    displayName: String = "Albert User",
+  ) {
+    webTestClient.post()
       .uri(INDUCTION_URI_TEMPLATE, prisonNumber)
+      .withBody(createInductionRequest)
+      .bearerToken(
+        aValidTokenWithEditAuthority(
+          username = username,
+          displayName = displayName,
+          privateKey = keyPair.private,
+        ),
+      )
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
+  }
+
+  fun getCiagInduction(prisonNumber: String): CiagInductionResponse =
+    webTestClient.get()
+      .uri(CIAG_INDUCTION_URI_TEMPLATE, prisonNumber)
       .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
       .exchange()
       .expectStatus()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actio
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidUpdateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidUpdateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateCiagInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 import java.time.LocalDate
@@ -140,7 +140,7 @@ class GetTimelineTest : IntegrationTestBase() {
   fun `should get timeline with multiple events in order`() {
     // Given
     val prisonNumber = anotherValidPrisonNumber()
-    createInduction(prisonNumber, aValidCreateCiagInductionRequest())
+    createCiagInduction(prisonNumber, aValidCreateCiagInductionRequest())
     val createActionPlanRequest = aValidCreateActionPlanRequest(
       reviewDate = LocalDate.now(),
       goals = listOf(aValidCreateGoalRequest(title = "Learn German")),

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/CreateCiagInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/CreateCiagInductionTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.ciag
 
-import aValidCreatePrisonWorkAndEducationRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
@@ -38,11 +37,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Reaso
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TrainingType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateEducationAndQualificationsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousWorkRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateSkillsAndInterestsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreatePreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreatePrisonWorkAndEducationRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateSkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonTrainingType as InPrisonTrainingTypeEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InPrisonWorkType as InPrisonWorkTypeEntity

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/GetCiagInductionSummariesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/GetCiagInductionSummariesTest.kt
@@ -14,10 +14,10 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Error
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork.NO
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork.YES
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCiagInductionSummaryResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidGetCiagInductionSummariesRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCiagInductionSummaryResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidGetCiagInductionSummariesRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 
 class GetCiagInductionSummariesTest : IntegrationTestBase() {
@@ -84,8 +84,8 @@ class GetCiagInductionSummariesTest : IntegrationTestBase() {
     // Given
     val prisonNumber1 = aValidPrisonNumber()
     val prisonNumber2 = anotherValidPrisonNumber()
-    createInduction(prisonNumber1, aValidCreateCiagInductionRequest(hopingToGetWork = NO))
-    createInduction(prisonNumber2, aValidCreateCiagInductionRequest(hopingToGetWork = YES))
+    createCiagInduction(prisonNumber1, aValidCreateCiagInductionRequest(hopingToGetWork = NO))
+    createCiagInduction(prisonNumber2, aValidCreateCiagInductionRequest(hopingToGetWork = YES))
 
     val expectedResponse = CiagInductionSummaryListResponse(
       ciagProfileList = listOf(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/GetCiagInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/GetCiagInductionTest.kt
@@ -13,12 +13,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagI
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidEducationAndQualificationsResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPrisonWorkAndEducationResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidSkillsAndInterestsResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidEducationAndQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidPreviousWorkResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidPrisonWorkAndEducationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidSkillsAndInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.isEquivalentTo
 
 class GetCiagInductionTest : IntegrationTestBase() {
@@ -62,7 +62,7 @@ class GetCiagInductionTest : IntegrationTestBase() {
   fun `should get induction for prisoner`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    createInduction(prisonNumber, aValidCreateCiagInductionRequest())
+    createCiagInduction(prisonNumber, aValidCreateCiagInductionRequest())
     val expectedWorkExperience = aValidPreviousWorkResponse()
     val expectedSkillsAndInterests = aValidSkillsAndInterestsResponse()
     val expectedQualificationsAndTraining = aValidEducationAndQualificationsResponse()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/UpdateCiagInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/UpdateCiagInductionTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.ciag
 
-import aValidUpdatePrisonWorkAndEducationRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
@@ -39,21 +38,22 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkI
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateEducationAndQualificationsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidEducationAndQualificationsResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPrisonWorkAndEducationResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidSkillsAndInterestsResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateCiagInductionRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateEducationAndQualificationsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousWorkRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateSkillsAndInterestsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateWorkInterestsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkExperienceResource
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterestsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.anotherValidAchievedQualification
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidEducationAndQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidPreviousWorkResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidPrisonWorkAndEducationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidSkillsAndInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdateEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdatePreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdatePrisonWorkAndEducationRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdateSkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdateWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidWorkExperienceResource
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidWorkInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.isEquivalentTo
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
@@ -142,14 +142,14 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
   fun `should update all fields within a Prisoner's induction`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    createInduction(
+    createCiagInduction(
       username = "auser_gen",
       displayName = "Albert User",
       prisonNumber = prisonNumber,
       createCiagInductionRequest = aValidCreateCiagInductionRequest(),
     )
 
-    val persistedInduction = getInduction(prisonNumber)
+    val persistedInduction = getCiagInduction(prisonNumber)
     val updateInductionRequest = aValidUpdateCiagInductionRequest(
       reference = null,
       hopingToGetWork = HopingToWork.YES,
@@ -275,7 +275,7 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
       .isNoContent
 
     // Then
-    val updatedInduction = getInduction(prisonNumber)
+    val updatedInduction = getCiagInduction(prisonNumber)
     assertThat(updatedInduction)
       .hasReference(persistedInduction.reference)
       .hasHopingToGetWork(HopingToWork.YES)
@@ -326,14 +326,14 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
   fun `should update induction but ignore child fields when they are not provided`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    createInduction(
+    createCiagInduction(
       username = "auser_gen",
       displayName = "Albert User",
       prisonNumber = prisonNumber,
       createCiagInductionRequest = aValidCreateCiagInductionRequest(),
     )
 
-    val persistedInduction = getInduction(prisonNumber)
+    val persistedInduction = getCiagInduction(prisonNumber)
     val updateInductionRequest = aValidUpdateCiagInductionRequest(
       reference = null,
       hopingToGetWork = HopingToWork.YES,
@@ -413,7 +413,7 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
       .isNoContent
 
     // Then
-    val updatedInduction = getInduction(prisonNumber)
+    val updatedInduction = getCiagInduction(prisonNumber)
     assertThat(updatedInduction)
       .hasReference(persistedInduction.reference)
       .hasHopingToGetWork(HopingToWork.YES)
@@ -447,8 +447,8 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
   fun `should update induction with null or empty values within child fields`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    createInduction(prisonNumber, aValidCreateCiagInductionRequest())
-    val persistedInduction = getInduction(prisonNumber)
+    createCiagInduction(prisonNumber, aValidCreateCiagInductionRequest())
+    val persistedInduction = getCiagInduction(prisonNumber)
     val updateInductionRequest = aValidUpdateInductionRequestBasedOn(
       originalInduction = persistedInduction,
       workExperience = aValidUpdatePreviousWorkRequest(
@@ -537,7 +537,7 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
       .isNoContent
 
     // Then
-    val updatedInduction = getInduction(prisonNumber)
+    val updatedInduction = getCiagInduction(prisonNumber)
     assertThat(updatedInduction)
       .hasReference(persistedInduction.reference)
       .hasHopingToGetWork(HopingToWork.NOT_SURE)
@@ -565,7 +565,7 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
   fun `should update induction with populated child values given it previously did not have any`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    createInduction(
+    createCiagInduction(
       prisonNumber,
       aValidCreateCiagInductionRequest(
         workExperience = null,
@@ -579,7 +579,7 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
         inPrisonInterests = null,
       ),
     )
-    val persistedInduction = getInduction(prisonNumber)
+    val persistedInduction = getCiagInduction(prisonNumber)
     val updateInductionRequest = aValidUpdateInductionRequestBasedOn(
       originalInduction = persistedInduction,
       workExperience = aValidUpdatePreviousWorkRequest(
@@ -676,7 +676,7 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
       .isNoContent
 
     // Then
-    val updatedInduction = getInduction(prisonNumber)
+    val updatedInduction = getCiagInduction(prisonNumber)
     assertThat(updatedInduction)
       .hasReference(persistedInduction.reference)
       .hasHopingToGetWork(HopingToWork.NOT_SURE)
@@ -698,11 +698,11 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
   fun `should update JPA managed fields after calling update induction with no changes`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    createInduction(
+    createCiagInduction(
       prisonNumber,
       aValidCreateCiagInductionRequest(),
     )
-    val persistedInduction = getInduction(prisonNumber)
+    val persistedInduction = getCiagInduction(prisonNumber)
     val updateInductionRequest = aValidUpdateInductionRequestBasedOn(
       originalInduction = persistedInduction,
     )
@@ -724,7 +724,7 @@ class UpdateCiagInductionTest : IntegrationTestBase() {
       .isNoContent
 
     // Then
-    val updatedInduction = getInduction(prisonNumber)
+    val updatedInduction = getCiagInduction(prisonNumber)
     assertThat(updatedInduction)
       .hasReference(persistedInduction.reference)
       .hasHopingToGetWork(HopingToWork.NOT_SURE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInPrisonInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInPrisonInterestsResourceMapperTest.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag
 
-import aValidCreatePrisonWorkAndEducationRequest
-import aValidUpdatePrisonWorkAndEducationRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -14,7 +12,9 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInPrisonInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInPrisonTrainingInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInPrisonWorkInterest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPrisonWorkAndEducationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreatePrisonWorkAndEducationRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidPrisonWorkAndEducationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdatePrisonWorkAndEducationRequest
 import java.time.OffsetDateTime
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonTrainingType as InPrisonTrainingTypeDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonWorkType as InPrisonWorkTypeDomain

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInductionResponseMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInductionResponseMapperTest.kt
@@ -19,12 +19,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aVa
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidWorkOnRelease
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AbilityToWorkFactor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonNotToWork
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCiagInductionResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCiagInductionSummaryResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidEducationAndQualificationsResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPrisonWorkAndEducationResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidSkillsAndInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCiagInductionResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCiagInductionSummaryResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidEducationAndQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidPreviousWorkResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidPrisonWorkAndEducationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidSkillsAndInterestsResponse
 import java.time.OffsetDateTime
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.HopingToWork as HopingToWorkDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork as HopingToWorkApi

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagSkillsAndInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagSkillsAndInterestsResourceMapperTest.kt
@@ -16,9 +16,9 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aVa
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPersonalSkillsAndInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterestType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkillType
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateSkillsAndInterestsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidSkillsAndInterestsResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateSkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateSkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidSkillsAndInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdateSkillsAndInterestsRequest
 import java.time.OffsetDateTime
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalInterest as PersonalInterestDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkill as PersonalSkillDomain

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkExperiencesResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkExperiencesResourceMapperTest.kt
@@ -13,11 +13,11 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePreviousWorkExperiencesDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousWorkRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousWorkRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkExperienceResource
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreatePreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidPreviousWorkResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdatePreviousWorkRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidWorkExperienceResource
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidWorkInterestsResponse
 import java.time.ZoneOffset
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkExperienceType as WorkExperienceTypeDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType as WorkInterestTypeDomain

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkInterestsResourceMapperTest.kt
@@ -6,8 +6,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Wor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkInterestType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkInterestDetail
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkInterestsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdateWorkInterestsRequest
 
 class CiagWorkInterestsResourceMapperTest {
   private val mapper = CiagWorkInterestsResourceMapper()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkOnReleaseResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagWorkOnReleaseResourceMapperTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.AffectAbilityToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.HopingToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.NotHopingToWorkReason
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateCiagInductionRequest
 
 class CiagWorkOnReleaseResourceMapperTest {
   private val mapper = CiagWorkOnReleaseResourceMapperImpl()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CreateCiagInductionRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CreateCiagInductionRequestMapperTest.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreatePreviousTrainingDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreatePreviousWorkExperiencesDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreateWorkOnReleaseDto
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateCiagInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateCiagInductionRequest
 
 @ExtendWith(MockitoExtension::class)
 class CreateCiagInductionRequestMapperTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/QualificationsAndTrainingResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/QualificationsAndTrainingResourceMapperTest.kt
@@ -11,9 +11,9 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aVa
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HighestEducationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateEducationAndQualificationsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidEducationAndQualificationsResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCreateEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidEducationAndQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidUpdateEducationAndQualificationsRequest
 import java.time.Instant
 import java.time.ZoneOffset
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.HighestEducationLevel as HighestEducationLevelDomain

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/FutureWorkInterestsResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/FutureWorkInterestsResponseBuilder.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.FutureWorkInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.FutureWorkInterestsResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidFutureWorkInterestsResponse(
+  reference: UUID = UUID.randomUUID(),
+  interests: List<FutureWorkInterest> = listOf(aValidFutureWorkInterest()),
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
+): FutureWorkInterestsResponse =
+  FutureWorkInterestsResponse(
+    reference = reference,
+    interests = interests,
+    createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
+    createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
+    updatedBy = updatedBy,
+    updatedByDisplayName = updatedByDisplayName,
+    updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/InPrisonInterestsResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/InPrisonInterestsResponseBuilder.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkInterest
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidInPrisonInterestsResponse(
+  reference: UUID = UUID.randomUUID(),
+  inPrisonWorkInterests: List<InPrisonWorkInterest> = listOf(aValidInPrisonWorkInterest()),
+  inPrisonTrainingInterests: List<InPrisonTrainingInterest> = listOf(aValidInPrisonTrainingInterest()),
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
+): InPrisonInterestsResponse =
+  InPrisonInterestsResponse(
+    reference = reference,
+    inPrisonWorkInterests = inPrisonWorkInterests,
+    inPrisonTrainingInterests = inPrisonTrainingInterests,
+    createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
+    createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
+    updatedBy = updatedBy,
+    updatedByDisplayName = updatedByDisplayName,
+    updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PersonalSkillsAndInterestsResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PersonalSkillsAndInterestsResponseBuilder.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkill
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkillsAndInterestsResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidPersonalSkillsAndInterestsResponse(
+  reference: UUID = UUID.randomUUID(),
+  skills: List<PersonalSkill> = listOf(aValidPersonalSkill()),
+  interests: List<PersonalInterest> = listOf(aValidPersonalInterest()),
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
+): PersonalSkillsAndInterestsResponse =
+  PersonalSkillsAndInterestsResponse(
+    reference = reference,
+    skills = skills,
+    interests = interests,
+    createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
+    createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
+    updatedBy = updatedBy,
+    updatedByDisplayName = updatedByDisplayName,
+    updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousQualificationsResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousQualificationsResponseBuilder.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HighestEducationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousQualificationsResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidPreviousQualificationsResponse(
+  reference: UUID = UUID.randomUUID(),
+  educationLevel: HighestEducationLevel = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
+  qualifications: List<AchievedQualification> = listOf(
+    aValidAchievedQualification(),
+    anotherValidAchievedQualification(),
+  ),
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
+): PreviousQualificationsResponse =
+  PreviousQualificationsResponse(
+    reference = reference,
+    educationLevel = educationLevel,
+    qualifications = qualifications,
+    createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
+    createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
+    updatedBy = updatedBy,
+    updatedByDisplayName = updatedByDisplayName,
+    updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousTrainingResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousTrainingResponseBuilder.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousTrainingResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TrainingType
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidPreviousTrainingResponse(
+  reference: UUID = UUID.randomUUID(),
+  trainingTypes: List<TrainingType> = listOf(TrainingType.OTHER),
+  trainingTypeOther: String? = "Certified Kotlin Developer",
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
+): PreviousTrainingResponse =
+  PreviousTrainingResponse(
+    reference = reference,
+    trainingTypes = trainingTypes,
+    trainingTypeOther = trainingTypeOther,
+    createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
+    createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
+    updatedBy = updatedBy,
+    updatedByDisplayName = updatedByDisplayName,
+    updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkExperiencesResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousWorkExperiencesResponseBuilder.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkExperience
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkExperiencesResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidPreviousWorkExperiencesResponse(
+  reference: UUID = UUID.randomUUID(),
+  hasWorkedBefore: Boolean = true,
+  experiences: List<PreviousWorkExperience> = listOf(aValidPreviousWorkExperience()),
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
+): PreviousWorkExperiencesResponse =
+  PreviousWorkExperiencesResponse(
+    reference = reference,
+    hasWorkedBefore = hasWorkedBefore,
+    experiences = experiences,
+    createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
+    createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
+    updatedBy = updatedBy,
+    updatedByDisplayName = updatedByDisplayName,
+    updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/CiagInductionResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/CiagInductionResponseAssert.kt
@@ -1,0 +1,171 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AbilityToWorkFactor
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonNotToWork
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun assertThat(actual: CiagInductionResponse?) = CiagInductionResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [CiagInductionResponse].
+ */
+class CiagInductionResponseAssert(actual: CiagInductionResponse?) :
+  AbstractObjectAssert<CiagInductionResponseAssert, CiagInductionResponse?>(
+    actual,
+    CiagInductionResponseAssert::class.java,
+  ) {
+
+  fun hasReference(expected: UUID): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun isForOffenderId(expected: String): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (offenderId != expected) {
+        failWithMessage("Expected offenderId to be $expected, but was $offenderId")
+      }
+    }
+    return this
+  }
+
+  fun hasHopingToGetWork(expected: HopingToWork): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (hopingToGetWork != expected) {
+        failWithMessage("Expected hopingToGetWork to be $expected, but was $hopingToGetWork")
+      }
+    }
+    return this
+  }
+
+  fun hasReasonToNotGetWork(expected: Set<ReasonNotToWork>): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reasonToNotGetWork != expected) {
+        failWithMessage("Expected reasonToNotGetWork to be $expected, but was $reasonToNotGetWork")
+      }
+    }
+    return this
+  }
+
+  fun hasReasonToNotGetWorkOther(expected: String): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reasonToNotGetWorkOther != expected) {
+        failWithMessage("Expected reasonToNotGetWorkOther to be $expected, but was $reasonToNotGetWorkOther")
+      }
+    }
+    return this
+  }
+
+  fun hasNoReasonToNotGetWorkOther(): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reasonToNotGetWorkOther != null) {
+        failWithMessage("Expected reasonToNotGetWorkOther to be null, but was $reasonToNotGetWorkOther")
+      }
+    }
+    return this
+  }
+
+  fun hasAbilityToWork(expected: Set<AbilityToWorkFactor>): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (abilityToWork != expected) {
+        failWithMessage("Expected abilityToWork to be $expected, but was $abilityToWork")
+      }
+    }
+    return this
+  }
+
+  fun hasAbilityToWorkOther(expected: String): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (abilityToWorkOther != expected) {
+        failWithMessage("Expected abilityToWorkOther to be $expected, but was $abilityToWorkOther")
+      }
+    }
+    return this
+  }
+
+  fun hasNoAbilityToWorkOther(): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (abilityToWorkOther != null) {
+        failWithMessage("Expected abilityToWorkOther to be null, but was $abilityToWorkOther")
+      }
+    }
+    return this
+  }
+
+  fun hasPrisonId(expected: String): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (prisonId != expected) {
+        failWithMessage("Expected prisonId to be $expected, but was $prisonId")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdDateTime != expected) {
+        failWithMessage("Expected createdDateTime to be $expected, but was $createdDateTime")
+      }
+    }
+    return this
+  }
+
+  fun wasLastModifiedAt(expected: OffsetDateTime): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (modifiedDateTime != expected) {
+        failWithMessage("Expected modifiedDateTime to be $expected, but was $modifiedDateTime")
+      }
+    }
+    return this
+  }
+
+  fun wasLastModifiedAfter(dateTime: OffsetDateTime): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!modifiedDateTime.isAfter(dateTime)) {
+        failWithMessage("Expected modifiedDateTime to be after $dateTime, but was $modifiedDateTime")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun wasModifiedBy(expected: String): CiagInductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (modifiedBy != expected) {
+        failWithMessage("Expected modifiedBy to be $expected, but was $modifiedBy")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/CiagInductionResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/CiagInductionResponseBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AbilityToWorkFactor

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/CiagInductionSummaryListResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/CiagInductionSummaryListResponseAssert.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import org.assertj.core.api.AbstractObjectAssert
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionSummaryListResponse

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/CiagInductionSummaryResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/CiagInductionSummaryResponseBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionSummaryResponse

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/CreateCiagInductionRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/CreateCiagInductionRequestBuilder.kt
@@ -1,6 +1,5 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
-import aValidCreatePrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AbilityToWorkFactor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateCiagInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateEducationAndQualificationsRequest

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/EducationAndQualificationsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/EducationAndQualificationsRequestBuilder.kt
@@ -1,10 +1,12 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateEducationAndQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HighestEducationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TrainingType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateEducationAndQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.anotherValidAchievedQualification
 import java.util.UUID
 
 fun aValidCreateEducationAndQualificationsRequest(

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/EducationAndQualificationsResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/EducationAndQualificationsResponseBuilder.kt
@@ -1,9 +1,11 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationAndQualificationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HighestEducationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.anotherValidAchievedQualification
 import java.time.OffsetDateTime
 import java.util.UUID
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/GetCiagInductionSummariesRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/GetCiagInductionSummariesRequestBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.anotherValidPrisonNumber

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/PreviousWorkRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/PreviousWorkRequestBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousWorkRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateWorkInterestsRequest

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/PreviousWorkResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/PreviousWorkResponseBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkExperience

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/PrisonWorkAndEducationRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/PrisonWorkAndEducationRequestBuilder.kt
@@ -1,3 +1,5 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
+
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/PrisonWorkAndEducationResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/PrisonWorkAndEducationResponseBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/SkillsAndInterestsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/SkillsAndInterestsRequestBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterestType

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/SkillsAndInterestsResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/SkillsAndInterestsResponseBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterestType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkillType

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/UpdateCiagInductionRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/UpdateCiagInductionRequestBuilder.kt
@@ -1,6 +1,5 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
-import aValidUpdatePrisonWorkAndEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AbilityToWorkFactor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonNotToWork

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/WorkInterestsBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/WorkInterestsBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateWorkInterestsRequest


### PR DESCRIPTION
This PR adds builders for an `InductionResponse` and also moves existing legacy CIAG Induction builders/custom assertions under a new `ciag` package.

It looks large, but is actually a small change which doesn't impact any existing functionality. It's just a precursor before adding a new GET Induction endpoint...