### PR TITLE
RR-524 - Update induction

### DIFF
--- a/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateInductionDto.kt
+++ b/domain/induction/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/dto/UpdateInductionDto.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 data class UpdateInductionDto(
   val reference: UUID?,
   val prisonNumber: String,
-  val workOnRelease: UpdateWorkOnReleaseDto,
+  val workOnRelease: UpdateWorkOnReleaseDto?,
   val previousQualifications: UpdatePreviousQualificationsDto?,
   val previousTraining: UpdatePreviousTrainingDto?,
   val previousWorkExperiences: UpdatePreviousWorkExperiencesDto?,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateCiagInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalsRequest
@@ -189,6 +190,16 @@ abstract class IntegrationTestBase {
       .expectStatus()
       .isOk
       .returnResult(CiagInductionResponse::class.java)
+      .responseBody.blockFirst()!!
+
+  fun getInduction(prisonNumber: String): InductionResponse =
+    webTestClient.get()
+      .uri(INDUCTION_URI_TEMPLATE, prisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(InductionResponse::class.java)
       .responseBody.blockFirst()!!
 
   fun createGoal(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -1,0 +1,449 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.firstValue
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.MediaType.APPLICATION_JSON
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HighestEducationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequestForPrisonerLookingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequestForPrisonerNotLookingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidFutureWorkInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidInPrisonInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPersonalSkillsAndInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousTrainingResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkExperiencesResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateFutureWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateInPrisonInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateInductionRequestForPrisonerLookingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateInductionRequestForPrisonerNotLookingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePersonalSkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousWorkExperiencesRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateWorkOnReleaseRequestForPrisonerLookingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateWorkOnReleaseRequestForPrisonerNotLookingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkOnReleaseResponseForPrisonerLookingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkOnReleaseResponseForPrisonerNotLookingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.isEquivalentTo
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
+
+class UpdateInductionTest : IntegrationTestBase() {
+
+  companion object {
+    private const val URI_TEMPLATE = "/inductions/{prisonNumber}"
+  }
+
+  @Test
+  fun `should return unauthorized given no bearer token`() {
+    webTestClient.put()
+      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `should return forbidden given bearer token with view only role`() {
+    webTestClient.put()
+      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .withBody(aValidUpdateInductionRequest())
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should fail to update induction given no induction data provided`() {
+    val prisonNumber = aValidPrisonNumber()
+
+    // When
+    val response = webTestClient.put()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .bodyValue(
+        """
+          { }
+        """.trimIndent(),
+      )
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.BAD_REQUEST.value())
+      .hasUserMessageContaining("JSON parse error")
+      .hasUserMessageContaining("value failed for JSON property reference due to missing (therefore NULL) value for creator parameter reference")
+  }
+
+  @Test
+  fun `should fail to update induction given induction does not exist`() {
+    // Given
+    val prisonNumber = "A1234BC"
+    val updateInductionRequest = aValidUpdateInductionRequest()
+
+    // When
+    val response = webTestClient.put()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(updateInductionRequest)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isNotFound
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(NOT_FOUND.value())
+      .hasUserMessage("Induction not found for prisoner [$prisonNumber]")
+  }
+
+  @Test
+  fun `should update induction for prisoner who is no longer looking to work`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val createUsername = "auser_gen"
+    val createDisplayName = "Albert User"
+    val updateUsername = "buser_gen"
+    val updateDisplayName = "Bernie User"
+    createInduction(
+      username = createUsername,
+      displayName = createDisplayName,
+      prisonNumber = prisonNumber,
+      createInductionRequest = aValidCreateInductionRequestForPrisonerLookingToWork(),
+    )
+    val persistedInduction = getInduction(prisonNumber)
+    val updateInductionRequest = aValidUpdateInductionRequestForPrisonerNotLookingToWork(
+      reference = persistedInduction.reference,
+      prisonId = "MDI",
+      workOnRelease = aValidUpdateWorkOnReleaseRequestForPrisonerNotLookingToWork(
+        reference = persistedInduction.workOnRelease.reference,
+      ),
+      inPrisonInterests = aValidUpdateInPrisonInterestsRequest(),
+      previousQualifications = null, // null means these values won't be changed
+      previousTraining = null,
+      previousWorkExperiences = null,
+      personalSkillsAndInterests = null,
+      futureWorkInterests = null,
+    )
+
+    // the response fields match the original create request ones, except for the auto generated fields
+    val expectedUnchangedWorkExperience = aValidPreviousWorkExperiencesResponse(
+      reference = persistedInduction.previousWorkExperiences!!.reference,
+      createdBy = createUsername,
+      createdByDisplayName = createDisplayName,
+      createdAt = persistedInduction.previousWorkExperiences!!.createdAt,
+      updatedBy = createUsername,
+      updatedByDisplayName = createDisplayName,
+      updatedAt = persistedInduction.previousWorkExperiences!!.updatedAt,
+    )
+    val expectedUnchangedSkillsAndInterests = aValidPersonalSkillsAndInterestsResponse(
+      reference = persistedInduction.personalSkillsAndInterests!!.reference,
+      createdBy = createUsername,
+      createdByDisplayName = createDisplayName,
+      createdAt = persistedInduction.personalSkillsAndInterests!!.createdAt,
+      updatedBy = createUsername,
+      updatedByDisplayName = createDisplayName,
+      updatedAt = persistedInduction.personalSkillsAndInterests!!.updatedAt,
+    )
+    val expectedUnchangedQualifications = aValidPreviousQualificationsResponse(
+      reference = persistedInduction.previousQualifications!!.reference,
+      createdBy = createUsername,
+      createdByDisplayName = createDisplayName,
+      createdAt = persistedInduction.previousQualifications!!.createdAt,
+      updatedBy = createUsername,
+      updatedByDisplayName = createDisplayName,
+      updatedAt = persistedInduction.previousQualifications!!.updatedAt,
+    )
+    val expectedUnchangedTraining = aValidPreviousTrainingResponse(
+      reference = persistedInduction.previousTraining!!.reference,
+      createdBy = createUsername,
+      createdByDisplayName = createDisplayName,
+      createdAt = persistedInduction.previousTraining!!.createdAt,
+      updatedBy = createUsername,
+      updatedByDisplayName = createDisplayName,
+      updatedAt = persistedInduction.previousTraining!!.updatedAt,
+    )
+    val expectedUnchangedWorkInterests = aValidFutureWorkInterestsResponse(
+      reference = persistedInduction.futureWorkInterests!!.reference,
+      createdBy = createUsername,
+      createdByDisplayName = createDisplayName,
+      createdAt = persistedInduction.futureWorkInterests!!.createdAt,
+      updatedBy = createUsername,
+      updatedByDisplayName = createDisplayName,
+      updatedAt = persistedInduction.futureWorkInterests!!.updatedAt,
+    )
+    // only workOnRelease and inPrisonInterests should be different
+    val expectedWorkOnRelease = aValidWorkOnReleaseResponseForPrisonerNotLookingToWork(
+      createdBy = createUsername,
+      createdByDisplayName = createDisplayName,
+      createdAtPrison = "BXI",
+      updatedBy = updateUsername,
+      updatedByDisplayName = updateDisplayName,
+      updatedAtPrison = "MDI", // different prison to the create request
+    )
+    val expectedInPrisonInterests = aValidInPrisonInterestsResponse(
+      createdBy = updateUsername, // in-prison interests didn't exist previously, so will be created by the update request
+      createdByDisplayName = updateDisplayName,
+      createdAtPrison = "MDI",
+      updatedBy = updateUsername,
+      updatedByDisplayName = updateDisplayName,
+      updatedAtPrison = "MDI",
+    )
+    shortDelayForTimestampChecking()
+
+    // When
+    webTestClient.put()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(updateInductionRequest)
+      .bearerToken(
+        aValidTokenWithEditAuthority(
+          username = updateUsername,
+          displayName = updateDisplayName,
+          privateKey = keyPair.private,
+        ),
+      )
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    // Then
+    val updatedInduction = getInduction(prisonNumber)
+    assertThat(updatedInduction)
+      .hasReference(persistedInduction.reference)
+      .wasCreatedAt(persistedInduction.createdAt)
+      .wasUpdatedAfter(persistedInduction.updatedAt)
+      .wasCreatedBy(createUsername)
+      .wasCreatedByDisplayName(createDisplayName)
+      .wasUpdatedBy(updateUsername)
+      .wasUpdatedByDisplayName(updateDisplayName)
+      .wasCreatedAtPrison("BXI")
+      .wasUpdatedAtPrison("MDI")
+    assertThat(updatedInduction.previousWorkExperiences).isEqualTo(expectedUnchangedWorkExperience)
+    assertThat(updatedInduction.personalSkillsAndInterests).isEqualTo(expectedUnchangedSkillsAndInterests)
+    assertThat(updatedInduction.previousQualifications).isEqualTo(expectedUnchangedQualifications)
+    assertThat(updatedInduction.previousTraining).isEqualTo(expectedUnchangedTraining)
+    assertThat(updatedInduction.futureWorkInterests).isEqualTo(expectedUnchangedWorkInterests)
+    // for the updated objects, we do not have the auto generated values, so use isEquivalentTo()
+    assertThat(updatedInduction.workOnRelease).isEquivalentTo(expectedWorkOnRelease)
+    assertThat(updatedInduction.inPrisonInterests).isEquivalentTo(expectedInPrisonInterests)
+    assertThat(updatedInduction.workOnRelease.updatedAt).isAfter(persistedInduction.createdAt)
+    assertThat(updatedInduction.inPrisonInterests!!.updatedAt).isAfter(persistedInduction.createdAt)
+
+    val timeline = getTimeline(prisonNumber)
+    assertThat(timeline)
+      .event(2) { // the 2nd Timeline event will be the INDUCTION_UPDATED event
+        it.hasEventType(TimelineEventType.INDUCTION_UPDATED)
+          .wasActionedBy(updateUsername)
+          .hasActionedByDisplayName(updateDisplayName)
+      }
+
+    await.untilAsserted {
+      val eventPropertiesCaptor = ArgumentCaptor.forClass(Map::class.java as Class<Map<String, String>>)
+      verify(telemetryClient, times(1)).trackEvent(
+        eq("INDUCTION_UPDATED"),
+        capture(eventPropertiesCaptor),
+        eq(null),
+      )
+      val updateInductionEventProperties = eventPropertiesCaptor.firstValue
+      assertThat(updateInductionEventProperties)
+        .containsEntry("prisonId", "MDI")
+        .containsEntry("userId", updateUsername)
+        .containsKey("reference")
+    }
+  }
+
+  @Test
+  fun `should update induction for prisoner who is now looking to work`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val createUsername = "auser_gen"
+    val createDisplayName = "Albert User"
+    val updateUsername = "buser_gen"
+    val updateDisplayName = "Bernie User"
+    createInduction(
+      username = createUsername,
+      displayName = createDisplayName,
+      prisonNumber = prisonNumber,
+      createInductionRequest = aValidCreateInductionRequestForPrisonerNotLookingToWork(),
+    )
+
+    val persistedInduction = getInduction(prisonNumber)
+    val updateInductionRequest = aValidUpdateInductionRequestForPrisonerLookingToWork(
+      reference = persistedInduction.reference,
+      prisonId = "MDI",
+      workOnRelease = aValidUpdateWorkOnReleaseRequestForPrisonerLookingToWork(
+        reference = persistedInduction.workOnRelease.reference,
+      ),
+      previousQualifications = aValidUpdatePreviousQualificationsRequest(
+        reference = persistedInduction.previousQualifications!!.reference,
+        // educationLevel is required for the "long" route
+        educationLevel = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
+      ),
+      previousWorkExperiences = aValidUpdatePreviousWorkExperiencesRequest(),
+      personalSkillsAndInterests = aValidUpdatePersonalSkillsAndInterestsRequest(),
+      futureWorkInterests = aValidUpdateFutureWorkInterestsRequest(),
+      // these fields were provided in the create request and won't be changed
+      inPrisonInterests = null,
+      previousTraining = null,
+    )
+
+    // the response builder fields match the original create induction builder ones, except for the auto generated fields
+    val expectedUnchangedTraining = aValidPreviousTrainingResponse(
+      reference = persistedInduction.previousTraining!!.reference,
+      createdBy = createUsername,
+      createdByDisplayName = createDisplayName,
+      createdAt = persistedInduction.previousTraining!!.createdAt,
+      updatedBy = createUsername,
+      updatedByDisplayName = createDisplayName,
+      updatedAt = persistedInduction.previousTraining!!.updatedAt,
+    )
+    val expectedUnchangedInPrisonInterests = aValidInPrisonInterestsResponse(
+      reference = persistedInduction.inPrisonInterests!!.reference,
+      createdBy = createUsername,
+      createdByDisplayName = createDisplayName,
+      createdAt = persistedInduction.inPrisonInterests!!.createdAt,
+      updatedBy = createUsername,
+      updatedByDisplayName = createDisplayName,
+      updatedAt = persistedInduction.inPrisonInterests!!.updatedAt,
+    )
+    // these fields should have been modified
+    val expectedWorkOnRelease = aValidWorkOnReleaseResponseForPrisonerLookingToWork(
+      createdBy = createUsername,
+      createdByDisplayName = createDisplayName,
+      createdAtPrison = "BXI",
+      updatedBy = updateUsername,
+      updatedByDisplayName = updateDisplayName,
+      updatedAtPrison = "MDI", // different prison to the create request
+    )
+    val expectedPreviousQualifications = aValidPreviousQualificationsResponse(
+      educationLevel = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
+      createdBy = createUsername, // didn't exist previously, so will be created by the update request
+      createdByDisplayName = createDisplayName,
+      createdAtPrison = "BXI",
+      updatedBy = updateUsername,
+      updatedByDisplayName = updateDisplayName,
+      updatedAtPrison = "MDI",
+    )
+    // these fields should be created
+    val expectedPreviousWorkExperiences = aValidPreviousWorkExperiencesResponse(
+      createdBy = updateUsername,
+      createdByDisplayName = updateDisplayName,
+      createdAtPrison = "MDI",
+      updatedBy = updateUsername,
+      updatedByDisplayName = updateDisplayName,
+      updatedAtPrison = "MDI",
+    )
+    val expectedPersonalSkillsAndInterests = aValidPersonalSkillsAndInterestsResponse(
+      createdBy = updateUsername,
+      createdByDisplayName = updateDisplayName,
+      createdAtPrison = "MDI",
+      updatedBy = updateUsername,
+      updatedByDisplayName = updateDisplayName,
+      updatedAtPrison = "MDI",
+    )
+    val expectedFutureWorkInterests = aValidFutureWorkInterestsResponse(
+      createdBy = updateUsername,
+      createdByDisplayName = updateDisplayName,
+      createdAtPrison = "MDI",
+      updatedBy = updateUsername,
+      updatedByDisplayName = updateDisplayName,
+      updatedAtPrison = "MDI",
+    )
+    shortDelayForTimestampChecking()
+
+    // When
+    webTestClient.put()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(updateInductionRequest)
+      .bearerToken(
+        aValidTokenWithEditAuthority(
+          username = updateUsername,
+          displayName = updateDisplayName,
+          privateKey = keyPair.private,
+        ),
+      )
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    // Then
+    val updatedInduction = getInduction(prisonNumber)
+    assertThat(updatedInduction)
+      .hasReference(persistedInduction.reference)
+      .wasCreatedAt(persistedInduction.createdAt)
+      .wasUpdatedAfter(persistedInduction.updatedAt)
+      .wasCreatedBy(createUsername)
+      .wasCreatedByDisplayName(createDisplayName)
+      .wasUpdatedBy(updateUsername)
+      .wasUpdatedByDisplayName(updateDisplayName)
+      .wasCreatedAtPrison("BXI")
+      .wasUpdatedAtPrison("MDI")
+    assertThat(updatedInduction.previousTraining).isEqualTo(expectedUnchangedTraining)
+    assertThat(updatedInduction.inPrisonInterests).isEqualTo(expectedUnchangedInPrisonInterests)
+    // for the updated objects, we do not have the auto generated values, so use isEquivalentTo()
+    assertThat(updatedInduction.workOnRelease).isEquivalentTo(expectedWorkOnRelease)
+    assertThat(updatedInduction.previousQualifications).isEquivalentTo(expectedPreviousQualifications)
+    assertThat(updatedInduction.previousWorkExperiences).isEquivalentTo(expectedPreviousWorkExperiences)
+    assertThat(updatedInduction.personalSkillsAndInterests).isEquivalentTo(expectedPersonalSkillsAndInterests)
+    assertThat(updatedInduction.futureWorkInterests).isEquivalentTo(expectedFutureWorkInterests)
+    assertThat(updatedInduction.workOnRelease.updatedAt).isAfter(persistedInduction.createdAt)
+    assertThat(updatedInduction.previousQualifications!!.updatedAt).isAfter(persistedInduction.createdAt)
+    assertThat(updatedInduction.previousWorkExperiences!!.updatedAt).isAfter(persistedInduction.createdAt)
+    assertThat(updatedInduction.personalSkillsAndInterests!!.updatedAt).isAfter(persistedInduction.createdAt)
+    assertThat(updatedInduction.futureWorkInterests!!.updatedAt).isAfter(persistedInduction.createdAt)
+
+    val timeline = getTimeline(prisonNumber)
+    assertThat(timeline)
+      .event(2) { // the 2nd Timeline event will be the INDUCTION_UPDATED event
+        it.hasEventType(TimelineEventType.INDUCTION_UPDATED)
+          .wasActionedBy(updateUsername)
+          .hasActionedByDisplayName(updateDisplayName)
+      }
+
+    await.untilAsserted {
+      val eventPropertiesCaptor = ArgumentCaptor.forClass(Map::class.java as Class<Map<String, String>>)
+      verify(telemetryClient, times(1)).trackEvent(
+        eq("INDUCTION_UPDATED"),
+        capture(eventPropertiesCaptor),
+        eq(null),
+      )
+      val updateInductionEventProperties = eventPropertiesCaptor.firstValue
+      assertThat(updateInductionEventProperties)
+        .containsEntry("prisonId", "MDI")
+        .containsEntry("userId", updateUsername)
+        .containsKey("reference")
+    }
+  }
+
+  private fun shortDelayForTimestampChecking() {
+    Thread.sleep(200)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/WorkOnReleaseEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/WorkOnReleaseEntityMapper.kt
@@ -31,5 +31,5 @@ interface WorkOnReleaseEntityMapper {
   @ExcludeReferenceField
   @Mapping(target = "createdAtPrison", ignore = true)
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  fun updateExistingEntityFromDto(@MappingTarget entity: WorkOnReleaseEntity, dto: UpdateWorkOnReleaseDto)
+  fun updateExistingEntityFromDto(@MappingTarget entity: WorkOnReleaseEntity, dto: UpdateWorkOnReleaseDto?)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/InductionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/InductionController.kt
@@ -7,6 +7,7 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -15,6 +16,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateInductionRequest
 
 @RestController
 @RequestMapping(value = ["/inductions"], produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -42,4 +44,16 @@ class InductionController(
     with(inductionService.getInductionForPrisoner(prisonNumber)) {
       inductionMapper.toInductionResponse(this)
     }
+
+  @PutMapping("/{prisonNumber}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PreAuthorize(HAS_EDIT_AUTHORITY)
+  fun updateInduction(
+    @Valid
+    @RequestBody
+    request: UpdateInductionRequest,
+    @PathVariable prisonNumber: String,
+  ) {
+    inductionService.updateInduction(inductionMapper.toUpdateInductionDto(prisonNumber, request))
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapper.kt
@@ -6,8 +6,10 @@ import org.mapstruct.NullValueMappingStrategy
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.InPrisonInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateInPrisonInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateInPrisonInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateInPrisonInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateInPrisonInterestsRequest
 
 @Mapper(
   uses = [
@@ -23,4 +25,6 @@ interface InPrisonInterestsResourceMapper {
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
   @Mapping(target = "updatedAtPrison", source = "lastUpdatedAtPrison")
   fun toInPrisonInterestsResponse(inPrisonInterests: InPrisonInterests?): InPrisonInterestsResponse?
+
+  fun toUpdateInPrisonInterestsDto(request: UpdateInPrisonInterestsRequest, prisonId: String): UpdateInPrisonInterestsDto
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InductionResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InductionResourceMapper.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Induction
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateInductionDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateInductionDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateInductionRequest
 import java.time.ZoneOffset
 
 @Component
@@ -66,5 +68,35 @@ class InductionResourceMapper(
         updatedAtPrison = lastUpdatedAtPrison,
       )
     }
+  }
+
+  fun toUpdateInductionDto(prisonNumber: String, request: UpdateInductionRequest): UpdateInductionDto {
+    val prisonId = request.prisonId
+    return UpdateInductionDto(
+      reference = request.reference,
+      prisonNumber = prisonNumber,
+      workOnRelease = request.workOnRelease?.let {
+        workOnReleaseMapper.toUpdateWorkOnReleaseDto(request = it, prisonId = prisonId)
+      },
+      previousQualifications = request.previousQualifications?.let {
+        qualificationsMapper.toUpdatePreviousQualificationsDto(request = it, prisonId = prisonId)
+      },
+      previousTraining = request.previousTraining?.let {
+        previousTrainingMapper.toUpdatePreviousTrainingDto(request = it, prisonId = prisonId)
+      },
+      previousWorkExperiences = request.previousWorkExperiences?.let {
+        workExperiencesMapper.toUpdatePreviousWorkExperiencesDto(request = it, prisonId = prisonId)
+      },
+      inPrisonInterests = request.inPrisonInterests?.let {
+        inPrisonInterestsMapper.toUpdateInPrisonInterestsDto(request = it, prisonId = prisonId)
+      },
+      personalSkillsAndInterests = request.personalSkillsAndInterests?.let {
+        skillsAndInterestsMapper.toUpdatePersonalSkillsAndInterestsDto(request = it, prisonId = prisonId)
+      },
+      futureWorkInterests = request.futureWorkInterests?.let {
+        workInterestsMapper.toUpdateFutureWorkInterestsDto(request = it, prisonId = prisonId)
+      },
+      prisonId = prisonId,
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousTrainingResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousTrainingResourceMapper.kt
@@ -6,8 +6,10 @@ import org.mapstruct.NullValueMappingStrategy
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PreviousTraining
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePreviousTrainingDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdatePreviousTrainingDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousTrainingRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousTrainingResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousTrainingRequest
 
 @Mapper(
   uses = [
@@ -23,4 +25,6 @@ interface PreviousTrainingResourceMapper {
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
   @Mapping(target = "updatedAtPrison", source = "lastUpdatedAtPrison")
   fun toPreviousTrainingResponse(previousTraining: PreviousTraining): PreviousTrainingResponse?
+
+  fun toUpdatePreviousTrainingDto(request: UpdatePreviousTrainingRequest, prisonId: String): UpdatePreviousTrainingDto
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapper.kt
@@ -6,8 +6,10 @@ import org.mapstruct.NullValueMappingStrategy
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PreviousQualifications
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePreviousQualificationsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousQualificationsRequest
 
 @Mapper(
   uses = [
@@ -24,4 +26,6 @@ interface QualificationsResourceMapper {
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
   @Mapping(target = "updatedAtPrison", source = "lastUpdatedAtPrison")
   fun toPreviousQualificationsResponse(previousQualifications: PreviousQualifications?): PreviousQualificationsResponse?
+
+  fun toUpdatePreviousQualificationsDto(request: UpdatePreviousQualificationsRequest, prisonId: String): UpdatePreviousQualificationsDto
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/SkillsAndInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/SkillsAndInterestsResourceMapper.kt
@@ -6,8 +6,10 @@ import org.mapstruct.NullValueMappingStrategy
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PersonalSkillsAndInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePersonalSkillsAndInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdatePersonalSkillsAndInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePersonalSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkillsAndInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePersonalSkillsAndInterestsRequest
 
 @Mapper(
   uses = [
@@ -23,4 +25,6 @@ interface SkillsAndInterestsResourceMapper {
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
   @Mapping(target = "updatedAtPrison", source = "lastUpdatedAtPrison")
   fun toPersonalSkillsAndInterestsResponse(personalSkillsAndInterests: PersonalSkillsAndInterests?): PersonalSkillsAndInterestsResponse?
+
+  fun toUpdatePersonalSkillsAndInterestsDto(request: UpdatePersonalSkillsAndInterestsRequest, prisonId: String): UpdatePersonalSkillsAndInterestsDto
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkExperiencesResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkExperiencesResourceMapper.kt
@@ -6,8 +6,10 @@ import org.mapstruct.NullValueMappingStrategy
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.PreviousWorkExperiences
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreatePreviousWorkExperiencesDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdatePreviousWorkExperiencesDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousWorkExperiencesRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkExperiencesResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousWorkExperiencesRequest
 
 @Mapper(
   uses = [
@@ -23,4 +25,5 @@ interface WorkExperiencesResourceMapper {
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
   @Mapping(target = "updatedAtPrison", source = "lastUpdatedAtPrison")
   fun toPreviousWorkExperiencesResponse(workExperiences: PreviousWorkExperiences?): PreviousWorkExperiencesResponse?
+  fun toUpdatePreviousWorkExperiencesDto(request: UpdatePreviousWorkExperiencesRequest, prisonId: String): UpdatePreviousWorkExperiencesDto
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkInterestsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkInterestsResourceMapper.kt
@@ -6,8 +6,10 @@ import org.mapstruct.NullValueMappingStrategy
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.FutureWorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateFutureWorkInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateFutureWorkInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateFutureWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.FutureWorkInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateFutureWorkInterestsRequest
 
 @Mapper(
   uses = [
@@ -23,4 +25,6 @@ interface WorkInterestsResourceMapper {
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
   @Mapping(target = "updatedAtPrison", source = "lastUpdatedAtPrison")
   fun toFutureWorkInterestsResponse(futureWorkInterests: FutureWorkInterests?): FutureWorkInterestsResponse?
+
+  fun toUpdateFutureWorkInterestsDto(request: UpdateFutureWorkInterestsRequest, prisonId: String): UpdateFutureWorkInterestsDto
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkOnReleaseResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkOnReleaseResourceMapper.kt
@@ -6,7 +6,9 @@ import org.mapstruct.NullValueMappingStrategy
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.WorkOnRelease
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.CreateWorkOnReleaseDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.UpdateWorkOnReleaseDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateWorkOnReleaseRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateWorkOnReleaseRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkOnReleaseResponse
 
 @Mapper(
@@ -23,4 +25,6 @@ interface WorkOnReleaseResourceMapper {
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
   @Mapping(target = "updatedAtPrison", source = "lastUpdatedAtPrison")
   fun toWorkOnReleaseResponse(workOnRelease: WorkOnRelease): WorkOnReleaseResponse
+
+  fun toUpdateWorkOnReleaseDto(request: UpdateWorkOnReleaseRequest, prisonId: String): UpdateWorkOnReleaseDto
 }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.7.5'
+  version: '1.7.6'
   description: Education and Work Plan API
   contact:
     name: Matt Wills
@@ -2367,6 +2367,10 @@ components:
           format: uuid
           description: The Induction's unique reference.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
+        prisonId:
+          type: string
+          description: The identifier of the prison that the prisoner is currently resident at.
+          example: BXI
         workOnRelease:
           $ref: '#/components/schemas/UpdateWorkOnReleaseRequest'
         previousQualifications:
@@ -2383,6 +2387,7 @@ components:
           $ref: '#/components/schemas/UpdateFutureWorkInterestsRequest'
       required:
         - reference
+        - prisonId
     UpdateWorkOnReleaseRequest:
       description: A request to update a Prisoner's views on obtaining work after release.
       allOf:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InPrisonInterestsResourceMapperTest.kt
@@ -11,8 +11,10 @@ import org.mockito.kotlin.given
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidInPrisonInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreateInPrisonInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateInPrisonInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInPrisonInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidInPrisonInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateInPrisonInterestsRequest
 import java.time.OffsetDateTime
 
 @ExtendWith(MockitoExtension::class)
@@ -54,6 +56,20 @@ class InPrisonInterestsResourceMapperTest {
 
     // When
     val actual = mapper.toInPrisonInterestsResponse(domain)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map to UpdateInPrisonInterestsDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdateInPrisonInterestsRequest()
+    val expected = aValidUpdateInPrisonInterestsDto(reference = request.reference!!)
+
+    // When
+    val actual = mapper.toUpdateInPrisonInterestsDto(request, prisonId)
 
     // Then
     assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InductionResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InductionResourceMapperTest.kt
@@ -18,8 +18,17 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreatePreviousTrainingDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreatePreviousWorkExperiencesDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreateWorkOnReleaseDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateFutureWorkInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateInPrisonInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateInductionDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePersonalSkillsAndInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePreviousQualificationsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePreviousTrainingDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePreviousWorkExperiencesDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateWorkOnReleaseDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aFullyPopulatedCreateInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aFullyPopulatedInductionResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aFullyPopulatedUpdateInductionRequest
 import java.time.ZoneOffset
 
 @ExtendWith(MockitoExtension::class)
@@ -115,5 +124,46 @@ class InductionResourceMapperTest {
 
     // Then
     assertThat(actual).isEqualTo(expectedInduction)
+  }
+
+  @Test
+  fun `should map to UpdateInductionDto`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val prisonId = "BXI"
+    val updateRequest = aFullyPopulatedUpdateInductionRequest(prisonId = prisonId)
+    val workOnRelease = aValidUpdateWorkOnReleaseDto()
+    val workExperiences = aValidUpdatePreviousWorkExperiencesDto()
+    val skillsAndInterests = aValidUpdatePersonalSkillsAndInterestsDto()
+    val qualifications = aValidUpdatePreviousQualificationsDto()
+    val training = aValidUpdatePreviousTrainingDto()
+    val inPrisonInterests = aValidUpdateInPrisonInterestsDto()
+    val workInterests = aValidUpdateFutureWorkInterestsDto()
+
+    given(workOnReleaseMapper.toUpdateWorkOnReleaseDto(any(), any())).willReturn(workOnRelease)
+    given(qualificationsMapper.toUpdatePreviousQualificationsDto(any(), any())).willReturn(qualifications)
+    given(previousTrainingMapper.toUpdatePreviousTrainingDto(any(), any())).willReturn(training)
+    given(workExperiencesMapper.toUpdatePreviousWorkExperiencesDto(any(), any())).willReturn(workExperiences)
+    given(inPrisonInterestsMapper.toUpdateInPrisonInterestsDto(any(), any())).willReturn(inPrisonInterests)
+    given(skillsAndInterestsMapper.toUpdatePersonalSkillsAndInterestsDto(any(), any())).willReturn(skillsAndInterests)
+    given(workInterestsMapper.toUpdateFutureWorkInterestsDto(any(), any())).willReturn(workInterests)
+    val expectedUpdateInductionDto = aValidUpdateInductionDto(
+      updateRequest.reference,
+      prisonNumber = prisonNumber,
+      workOnRelease = workOnRelease,
+      previousQualifications = qualifications,
+      previousTraining = training,
+      previousWorkExperiences = workExperiences,
+      inPrisonInterests = inPrisonInterests,
+      personalSkillsAndInterests = skillsAndInterests,
+      futureWorkInterests = workInterests,
+      prisonId = prisonId,
+    )
+
+    // When
+    val actual = mapper.toUpdateInductionDto(prisonNumber, updateRequest)
+
+    // Then
+    assertThat(actual).isEqualTo(expectedUpdateInductionDto)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousTrainingResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/PreviousTrainingResourceMapperTest.kt
@@ -11,8 +11,10 @@ import org.mockito.kotlin.given
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPreviousTraining
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreatePreviousTrainingDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePreviousTrainingDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousTrainingRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousTrainingResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousTrainingRequest
 import java.time.OffsetDateTime
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.TrainingType as TrainingTypeDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TrainingType as TrainingTypeApi
@@ -64,6 +66,24 @@ class PreviousTrainingResourceMapperTest {
 
     // When
     val actual = mapper.toPreviousTrainingResponse(domain)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map to UpdatePreviousTrainingDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdatePreviousTrainingRequest()
+    val expected = aValidUpdatePreviousTrainingDto(
+      reference = request.reference!!,
+      trainingTypes = listOf(TrainingTypeDomain.OTHER),
+      trainingTypeOther = "Certified Kotlin Developer",
+    )
+
+    // When
+    val actual = mapper.toUpdatePreviousTrainingDto(request, prisonId)
 
     // Then
     assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapperTest.kt
@@ -13,10 +13,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Qua
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPreviousQualifications
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreatePreviousQualificationsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.anotherValidAchievedQualification
 import java.time.OffsetDateTime
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.HighestEducationLevel as HighestEducationLevelDomain
@@ -102,6 +104,35 @@ class QualificationsResourceMapperTest {
 
     // When
     val actual = mapper.toPreviousQualificationsResponse(domain)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map to UpdatePreviousQualificationsDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdatePreviousQualificationsRequest()
+    val expected = aValidUpdatePreviousQualificationsDto(
+      reference = request.reference!!,
+      educationLevel = HighestEducationLevelDomain.SECONDARY_SCHOOL_TOOK_EXAMS,
+      qualifications = listOf(
+        aValidQualification(
+          subject = "English",
+          level = QualificationLevel.LEVEL_3,
+          grade = "A",
+        ),
+        aValidQualification(
+          subject = "Maths",
+          level = QualificationLevel.LEVEL_3,
+          grade = "B",
+        ),
+      ),
+    )
+
+    // When
+    val actual = mapper.toUpdatePreviousQualificationsDto(request, prisonId)
 
     // Then
     assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/SkillsAndInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/SkillsAndInterestsResourceMapperTest.kt
@@ -15,8 +15,10 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aVa
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPersonalSkill
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPersonalSkillsAndInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreatePersonalSkillsAndInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePersonalSkillsAndInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePersonalSkillsAndInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPersonalSkillsAndInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePersonalSkillsAndInterestsRequest
 import java.time.OffsetDateTime
 
 @ExtendWith(MockitoExtension::class)
@@ -71,6 +73,34 @@ class SkillsAndInterestsResourceMapperTest {
 
     // When
     val actual = mapper.toPersonalSkillsAndInterestsResponse(domain)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map to UpdatePersonalSkillsAndInterestsDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdatePersonalSkillsAndInterestsRequest()
+    val expected = aValidUpdatePersonalSkillsAndInterestsDto(
+      reference = request.reference!!,
+      skills = listOf(
+        aValidPersonalSkill(
+          skillType = SkillType.OTHER,
+          skillTypeOther = "Hidden skills",
+        ),
+      ),
+      interests = listOf(
+        aValidPersonalInterest(
+          interestType = InterestType.OTHER,
+          interestTypeOther = "Varied interests",
+        ),
+      ),
+    )
+
+    // When
+    val actual = mapper.toUpdatePersonalSkillsAndInterestsDto(request, prisonId)
 
     // Then
     assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkExperiencesResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkExperiencesResourceMapperTest.kt
@@ -13,10 +13,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Wor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidPreviousWorkExperiences
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidWorkExperience
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreatePreviousWorkExperiencesDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdatePreviousWorkExperiencesDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousWorkExperiencesRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkExperience
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousWorkExperiencesResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousWorkExperiencesRequest
 import java.time.OffsetDateTime
 
 @ExtendWith(MockitoExtension::class)
@@ -75,6 +77,30 @@ class WorkExperiencesResourceMapperTest {
 
     // When
     val actual = mapper.toPreviousWorkExperiencesResponse(domain)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map to UpdatePreviousWorkExperiencesDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdatePreviousWorkExperiencesRequest()
+    val expected = aValidUpdatePreviousWorkExperiencesDto(
+      reference = request.reference!!,
+      experiences = listOf(
+        aValidWorkExperience(
+          experienceType = WorkExperienceType.OTHER,
+          experienceTypeOther = "Scientist",
+          role = "Lab Technician",
+          details = "Cleaning test tubes",
+        ),
+      ),
+    )
+
+    // When
+    val actual = mapper.toUpdatePreviousWorkExperiencesDto(request, prisonId)
 
     // Then
     assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkInterestsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkInterestsResourceMapperTest.kt
@@ -13,10 +13,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.Wor
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidFutureWorkInterests
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidWorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreateFutureWorkInterestsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateFutureWorkInterestsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateFutureWorkInterestsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidFutureWorkInterest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidFutureWorkInterestsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateFutureWorkInterestsRequest
 import java.time.OffsetDateTime
 
 @ExtendWith(MockitoExtension::class)
@@ -73,6 +75,29 @@ class WorkInterestsResourceMapperTest {
 
     // When
     val actual = mapper.toFutureWorkInterestsResponse(domain)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map to UpdateFutureWorkInterestsDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdateFutureWorkInterestsRequest()
+    val expected = aValidUpdateFutureWorkInterestsDto(
+      reference = request.reference!!,
+      interests = listOf(
+        aValidWorkInterest(
+          workType = WorkInterestType.OTHER,
+          workTypeOther = "Any job I can get",
+          role = "Any role",
+        ),
+      ),
+    )
+
+    // When
+    val actual = mapper.toUpdateFutureWorkInterestsDto(request, prisonId)
 
     // Then
     assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkOnReleaseResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/WorkOnReleaseResourceMapperTest.kt
@@ -11,7 +11,9 @@ import org.mockito.kotlin.given
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.aValidWorkOnRelease
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidCreateWorkOnReleaseDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.dto.aValidUpdateWorkOnReleaseDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateWorkOnReleaseRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdateWorkOnReleaseRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidWorkOnReleaseResponseForPrisonerNotLookingToWork
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -80,6 +82,27 @@ class WorkOnReleaseResourceMapperTest {
 
     // When
     val actual = mapper.toWorkOnReleaseResponse(domain)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map to UpdateWorkOnReleaseDto`() {
+    // Given
+    val prisonId = "BXI"
+    val request = aValidUpdateWorkOnReleaseRequest()
+    val expected = aValidUpdateWorkOnReleaseDto(
+      reference = request.reference,
+      hopingToWork = HopingToWorkDomain.NO,
+      notHopingToWorkReasons = listOf(NotHopingToWorkReasonDomain.OTHER),
+      notHopingToWorkOtherReason = "Long term prison sentence",
+      affectAbilityToWork = listOf(AffectAbilityToWorkDomain.OTHER),
+      affectAbilityToWorkOther = "Employers aren't interested",
+    )
+
+    // When
+    val actual = mapper.toUpdateWorkOnReleaseDto(request, prisonId)
 
     // Then
     assertThat(actual).isEqualTo(expected)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateFutureWorkInterestsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateFutureWorkInterestsRequestBuilder.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.FutureWorkInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateFutureWorkInterestsRequest
+import java.util.UUID
+
+fun aValidUpdateFutureWorkInterestsRequest(
+  reference: UUID? = UUID.randomUUID(),
+  interests: List<FutureWorkInterest> = listOf(aValidFutureWorkInterest()),
+): UpdateFutureWorkInterestsRequest =
+  UpdateFutureWorkInterestsRequest(reference = reference, interests = interests)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateInPrisonInterestsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateInPrisonInterestsRequestBuilder.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateInPrisonInterestsRequest
+import java.util.UUID
+
+fun aValidUpdateInPrisonInterestsRequest(
+  reference: UUID? = UUID.randomUUID(),
+  inPrisonWorkInterests: List<InPrisonWorkInterest> = listOf(aValidInPrisonWorkInterest()),
+  inPrisonTrainingInterests: List<InPrisonTrainingInterest> = listOf(aValidInPrisonTrainingInterest()),
+): UpdateInPrisonInterestsRequest =
+  UpdateInPrisonInterestsRequest(
+    reference = reference,
+    inPrisonWorkInterests = inPrisonWorkInterests,
+    inPrisonTrainingInterests = inPrisonTrainingInterests,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateInductionRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateInductionRequestBuilder.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateFutureWorkInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateInPrisonInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateInductionRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePersonalSkillsAndInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousQualificationsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousTrainingRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousWorkExperiencesRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateWorkOnReleaseRequest
+import java.util.UUID
+
+fun aValidUpdateInductionRequest(): UpdateInductionRequest = aValidUpdateInductionRequestForPrisonerNotLookingToWork()
+
+fun aValidUpdateInductionRequestForPrisonerNotLookingToWork(
+  reference: UUID = UUID.randomUUID(),
+  prisonId: String = "BXI",
+  workOnRelease: UpdateWorkOnReleaseRequest = aValidUpdateWorkOnReleaseRequestForPrisonerNotLookingToWork(),
+  previousQualifications: UpdatePreviousQualificationsRequest? = aValidUpdatePreviousQualificationsRequest(
+    educationLevel = null,
+  ),
+  previousTraining: UpdatePreviousTrainingRequest? = aValidUpdatePreviousTrainingRequest(),
+  previousWorkExperiences: UpdatePreviousWorkExperiencesRequest? = null,
+  inPrisonInterests: UpdateInPrisonInterestsRequest? = aValidUpdateInPrisonInterestsRequest(),
+  personalSkillsAndInterests: UpdatePersonalSkillsAndInterestsRequest? = null,
+  futureWorkInterests: UpdateFutureWorkInterestsRequest? = null,
+): UpdateInductionRequest = UpdateInductionRequest(
+  reference = reference,
+  prisonId = prisonId,
+  workOnRelease = workOnRelease,
+  previousQualifications = previousQualifications,
+  previousTraining = previousTraining,
+  previousWorkExperiences = previousWorkExperiences,
+  inPrisonInterests = inPrisonInterests,
+  personalSkillsAndInterests = personalSkillsAndInterests,
+  futureWorkInterests = futureWorkInterests,
+)
+
+fun aValidUpdateInductionRequestForPrisonerLookingToWork(
+  reference: UUID = UUID.randomUUID(),
+  prisonId: String = "BXI",
+  workOnRelease: UpdateWorkOnReleaseRequest = aValidUpdateWorkOnReleaseRequestForPrisonerLookingToWork(),
+  previousQualifications: UpdatePreviousQualificationsRequest? = aValidUpdatePreviousQualificationsRequest(),
+  previousTraining: UpdatePreviousTrainingRequest? = aValidUpdatePreviousTrainingRequest(),
+  previousWorkExperiences: UpdatePreviousWorkExperiencesRequest? = aValidUpdatePreviousWorkExperiencesRequest(),
+  inPrisonInterests: UpdateInPrisonInterestsRequest? = null,
+  personalSkillsAndInterests: UpdatePersonalSkillsAndInterestsRequest? = aValidUpdatePersonalSkillsAndInterestsRequest(),
+  futureWorkInterests: UpdateFutureWorkInterestsRequest? = aValidUpdateFutureWorkInterestsRequest(),
+): UpdateInductionRequest = UpdateInductionRequest(
+  reference = reference,
+  prisonId = prisonId,
+  workOnRelease = workOnRelease,
+  previousQualifications = previousQualifications,
+  previousTraining = previousTraining,
+  previousWorkExperiences = previousWorkExperiences,
+  inPrisonInterests = inPrisonInterests,
+  personalSkillsAndInterests = personalSkillsAndInterests,
+  futureWorkInterests = futureWorkInterests,
+)
+
+fun aFullyPopulatedUpdateInductionRequest(
+  reference: UUID = UUID.randomUUID(),
+  prisonId: String = "BXI",
+  workOnRelease: UpdateWorkOnReleaseRequest = aValidUpdateWorkOnReleaseRequest(),
+  previousQualifications: UpdatePreviousQualificationsRequest? = aValidUpdatePreviousQualificationsRequest(),
+  previousTraining: UpdatePreviousTrainingRequest? = aValidUpdatePreviousTrainingRequest(),
+  previousWorkExperiences: UpdatePreviousWorkExperiencesRequest? = aValidUpdatePreviousWorkExperiencesRequest(),
+  inPrisonInterests: UpdateInPrisonInterestsRequest? = aValidUpdateInPrisonInterestsRequest(),
+  personalSkillsAndInterests: UpdatePersonalSkillsAndInterestsRequest? = aValidUpdatePersonalSkillsAndInterestsRequest(),
+  futureWorkInterests: UpdateFutureWorkInterestsRequest? = aValidUpdateFutureWorkInterestsRequest(),
+): UpdateInductionRequest = UpdateInductionRequest(
+  reference = reference,
+  prisonId = prisonId,
+  workOnRelease = workOnRelease,
+  previousQualifications = previousQualifications,
+  previousTraining = previousTraining,
+  previousWorkExperiences = previousWorkExperiences,
+  inPrisonInterests = inPrisonInterests,
+  personalSkillsAndInterests = personalSkillsAndInterests,
+  futureWorkInterests = futureWorkInterests,
+)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdatePersonalSkillsAndInterestsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdatePersonalSkillsAndInterestsRequestBuilder.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkill
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePersonalSkillsAndInterestsRequest
+import java.util.UUID
+
+fun aValidUpdatePersonalSkillsAndInterestsRequest(
+  reference: UUID? = UUID.randomUUID(),
+  skills: List<PersonalSkill> = listOf(aValidPersonalSkill()),
+  interests: List<PersonalInterest> = listOf(aValidPersonalInterest()),
+): UpdatePersonalSkillsAndInterestsRequest =
+  UpdatePersonalSkillsAndInterestsRequest(
+    reference = reference,
+    skills = skills,
+    interests = interests,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdatePreviousQualificationsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdatePreviousQualificationsRequestBuilder.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HighestEducationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousQualificationsRequest
+import java.util.UUID
+
+fun aValidUpdatePreviousQualificationsRequest(
+  reference: UUID? = UUID.randomUUID(),
+  educationLevel: HighestEducationLevel? = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
+  qualifications: List<AchievedQualification>? = listOf(
+    aValidAchievedQualification(),
+    anotherValidAchievedQualification(),
+  ),
+): UpdatePreviousQualificationsRequest =
+  UpdatePreviousQualificationsRequest(
+    reference = reference,
+    educationLevel = educationLevel,
+    qualifications = qualifications,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdatePreviousTrainingRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdatePreviousTrainingRequestBuilder.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousTrainingRequest
+import java.util.UUID
+
+fun aValidUpdatePreviousTrainingRequest(
+  reference: UUID? = UUID.randomUUID(),
+  trainingTypes: List<TrainingType> = listOf(TrainingType.OTHER),
+  trainingTypeOther: String? = "Certified Kotlin Developer",
+): UpdatePreviousTrainingRequest =
+  UpdatePreviousTrainingRequest(
+    reference = reference,
+    trainingTypes = trainingTypes,
+    trainingTypeOther = trainingTypeOther,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdatePreviousWorkExperiencesRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdatePreviousWorkExperiencesRequestBuilder.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousWorkExperience
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousWorkExperiencesRequest
+import java.util.UUID
+
+fun aValidUpdatePreviousWorkExperiencesRequest(
+  reference: UUID? = UUID.randomUUID(),
+  hasWorkedBefore: Boolean = true,
+  experiences: List<PreviousWorkExperience>? = listOf(aValidPreviousWorkExperience()),
+): UpdatePreviousWorkExperiencesRequest =
+  UpdatePreviousWorkExperiencesRequest(
+    reference = reference,
+    hasWorkedBefore = hasWorkedBefore,
+    experiences = experiences,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateWorkOnReleaseRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/UpdateWorkOnReleaseRequestBuilder.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AffectAbilityToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.NotHopingToWorkReason
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateWorkOnReleaseRequest
+import java.util.UUID
+
+fun aValidUpdateWorkOnReleaseRequest(): UpdateWorkOnReleaseRequest =
+  aValidUpdateWorkOnReleaseRequestForPrisonerNotLookingToWork()
+
+fun aValidUpdateWorkOnReleaseRequestForPrisonerNotLookingToWork(
+  reference: UUID = UUID.randomUUID(),
+  hopingToWork: HopingToWork = HopingToWork.NO,
+  notHopingToWorkReasons: List<NotHopingToWorkReason>? = listOf(NotHopingToWorkReason.OTHER),
+  notHopingToWorkOtherReason: String? = "Long term prison sentence",
+  affectAbilityToWork: List<AffectAbilityToWork>? = listOf(AffectAbilityToWork.OTHER),
+  affectAbilityToWorkOther: String? = "Employers aren't interested",
+): UpdateWorkOnReleaseRequest =
+  UpdateWorkOnReleaseRequest(
+    reference = reference,
+    hopingToWork = hopingToWork,
+    notHopingToWorkReasons = notHopingToWorkReasons,
+    notHopingToWorkOtherReason = notHopingToWorkOtherReason,
+    affectAbilityToWork = affectAbilityToWork,
+    affectAbilityToWorkOther = affectAbilityToWorkOther,
+  )
+
+fun aValidUpdateWorkOnReleaseRequestForPrisonerLookingToWork(
+  reference: UUID = UUID.randomUUID(),
+  hopingToWork: HopingToWork = HopingToWork.YES,
+  notHopingToWorkReasons: List<NotHopingToWorkReason>? = null,
+  notHopingToWorkOtherReason: String? = null,
+  affectAbilityToWork: List<AffectAbilityToWork>? = listOf(AffectAbilityToWork.NONE),
+  affectAbilityToWorkOther: String? = null,
+): UpdateWorkOnReleaseRequest =
+  UpdateWorkOnReleaseRequest(
+    reference = reference,
+    hopingToWork = hopingToWork,
+    notHopingToWorkReasons = notHopingToWorkReasons,
+    notHopingToWorkOtherReason = notHopingToWorkOtherReason,
+    affectAbilityToWork = affectAbilityToWork,
+    affectAbilityToWorkOther = affectAbilityToWorkOther,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/UpdateInPrisonInterestsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/ciag/UpdateInPrisonInterestsRequestBuilder.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateInPrisonInterestsRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonTrainingType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkInterest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonWorkType
+
+fun aValidCreateInPrisonInterestsRequest(
+  inPrisonWorkInterests: List<InPrisonWorkInterest> = listOf(aValidInPrisonWorkInterest()),
+  inPrisonTrainingInterests: List<InPrisonTrainingInterest> = listOf(aValidInPrisonTrainingInterest()),
+): CreateInPrisonInterestsRequest =
+  CreateInPrisonInterestsRequest(
+    inPrisonWorkInterests = inPrisonWorkInterests,
+    inPrisonTrainingInterests = inPrisonTrainingInterests,
+  )
+
+fun aValidInPrisonWorkInterest(
+  workType: InPrisonWorkType = InPrisonWorkType.OTHER,
+  workTypeOther: String? = "Any in-prison work",
+): InPrisonWorkInterest =
+  InPrisonWorkInterest(
+    workType = workType,
+    workTypeOther = workTypeOther,
+  )
+
+fun aValidInPrisonTrainingInterest(
+  trainingType: InPrisonTrainingType = InPrisonTrainingType.OTHER,
+  trainingTypeOther: String? = "Any in-prison training",
+): InPrisonTrainingInterest =
+  InPrisonTrainingInterest(
+    trainingType = trainingType,
+    trainingTypeOther = trainingTypeOther,
+  )


### PR DESCRIPTION
This PR implements the update Induction endpoint (i.e. PUT `/inductions/{prisonNumber}`).

As per the swagger spec, an Induction's property (e.g. `previousWorkExperience`) is only updated if it is provided in the request. This means that when switching from say the "long route" to the "short" one, a Prisoner's previous work experience will remain in-tact, even though it is not asked/provided by the UI during the "short" question set.

Due to the fact that these fields may or may not be provided during an update request, the integration tests have been written from a "business" point of view - i.e. based on what constitutes a "short" or "long" question set, and attempt to mirror what the UI is likely to send.