### PR TITLE
RR-579 - Prisoner movement model and skeleton service class

### DIFF
--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/Timeline.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/Timeline.kt
@@ -24,4 +24,11 @@ class Timeline(
    */
   fun addEvent(timelineEvent: TimelineEvent) =
     events.add(timelineEvent)
+
+  /**
+   * Adds one or more [TimelineEvent]s to the timeline.
+   */
+  fun addEvents(timelineEvents: List<TimelineEvent>) {
+    events.addAll(timelineEvents)
+  }
 }

--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/PrisonTimelineService.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/PrisonTimelineService.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
+
+interface PrisonTimelineService {
+
+  /**
+   * Returns a [List] of [TimelineEvent]s that represent whenever a Prisoner entered or left a Prison, or transferred
+   * between Prisons.
+   */
+  fun getPrisonTimelineEvents(prisonNumber: String): List<TimelineEvent>
+}

--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineService.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Time
 class TimelineService(
   private val persistenceAdapter: TimelinePersistenceAdapter,
   private val prisonTimelineService: PrisonTimelineService,
+  private val callPrisonApiEnabled: Boolean,
 ) {
 
   /**
@@ -39,7 +40,9 @@ class TimelineService(
     val prisonerTimeline =
       persistenceAdapter.getTimelineForPrisoner(prisonNumber) ?: throw TimelineNotFoundException(prisonNumber)
 
-    prisonerTimeline.addEvents(prisonTimelineService.getPrisonTimelineEvents(prisonNumber))
+    if (callPrisonApiEnabled) {
+      prisonerTimeline.addEvents(prisonTimelineService.getPrisonTimelineEvents(prisonNumber))
+    }
     return prisonerTimeline
   }
 }

--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineService.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.Time
  */
 class TimelineService(
   private val persistenceAdapter: TimelinePersistenceAdapter,
+  private val prisonTimelineService: PrisonTimelineService,
 ) {
 
   /**
@@ -34,6 +35,11 @@ class TimelineService(
    * Returns the [Timeline] for the prisoner identified by their prison number. Otherwise, throws
    * [TimelineNotFoundException] if it cannot be found.
    */
-  fun getTimelineForPrisoner(prisonNumber: String): Timeline =
-    persistenceAdapter.getTimelineForPrisoner(prisonNumber) ?: throw TimelineNotFoundException(prisonNumber)
+  fun getTimelineForPrisoner(prisonNumber: String): Timeline {
+    val prisonerTimeline =
+      persistenceAdapter.getTimelineForPrisoner(prisonNumber) ?: throw TimelineNotFoundException(prisonNumber)
+
+    prisonerTimeline.addEvents(prisonTimelineService.getPrisonTimelineEvents(prisonNumber))
+    return prisonerTimeline
+  }
 }

--- a/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
+++ b/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
@@ -10,6 +10,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineNotFoundException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimeline
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aValidTimelineEvent
@@ -22,6 +24,9 @@ class TimelineServiceTest {
 
   @Mock
   private lateinit var persistenceAdapter: TimelinePersistenceAdapter
+
+  @Mock
+  private lateinit var prisonTimelineService: PrisonTimelineService
 
   companion object {
     private const val prisonNumber = "A1234AB"
@@ -55,7 +60,11 @@ class TimelineServiceTest {
   fun `should get timeline for prisoner`() {
     // Given
     val expected = aValidTimeline()
+    // TODO RR-566 - populate prisonEvents
+    val prisonEvents = emptyList<TimelineEvent>()
     given(persistenceAdapter.getTimelineForPrisoner(any())).willReturn(expected)
+    given(prisonTimelineService.getPrisonTimelineEvents(any())).willReturn(prisonEvents)
+    expected.addEvents(prisonEvents)
 
     // When
     val actual = service.getTimelineForPrisoner(prisonNumber)
@@ -63,6 +72,7 @@ class TimelineServiceTest {
     // Then
     assertThat(actual).isEqualTo(expected)
     verify(persistenceAdapter).getTimelineForPrisoner(prisonNumber)
+    verify(prisonTimelineService).getPrisonTimelineEvents(prisonNumber)
   }
 
   @Test
@@ -81,5 +91,6 @@ class TimelineServiceTest {
     assertThat(exception).hasMessage("Timeline not found for prisoner [$prisonNumber]")
     assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
     verify(persistenceAdapter).getTimelineForPrisoner(prisonNumber)
+    verifyNoInteractions(prisonTimelineService)
   }
 }

--- a/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
+++ b/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
@@ -2,9 +2,9 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.ser
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aVal
 @ExtendWith(MockitoExtension::class)
 class TimelineServiceTest {
 
-  @InjectMocks
   private lateinit var service: TimelineService
 
   @Mock
@@ -27,6 +26,13 @@ class TimelineServiceTest {
 
   @Mock
   private lateinit var prisonTimelineService: PrisonTimelineService
+
+  private val callPrisonApiEnabled = true
+
+  @BeforeEach
+  fun setup() {
+    service = TimelineService(persistenceAdapter, prisonTimelineService, callPrisonApiEnabled)
+  }
 
   companion object {
     private const val prisonNumber = "A1234AB"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiClient.kt
@@ -1,9 +1,12 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi
 
+import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.prisonapi.resource.model.PrisonerInPrisonSummary
+
+private val log = KotlinLogging.logger {}
 
 @Component
 class PrisonApiClient(private val prisonApiWebClient: WebClient) {
@@ -13,8 +16,8 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
    *
    *  @throws [PrisonApiException] if there is a problem retrieving the data.
    */
-  fun getPrisonMovementEvents(prisonNumber: String): PrisonMovementEvents? {
-    prisonApiWebClient
+  fun getPrisonMovementEvents(prisonNumber: String): PrisonMovementEvents {
+    val prisonerInPrisonSummary = prisonApiWebClient
       .get()
       .uri("/api/offenders/$prisonNumber/prison-timeline")
       .retrieve()
@@ -25,6 +28,8 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       }
       .block()
     // TODO RR-580 - map PrisonerInPrisonSummary to PrisonMovementEvents
+    val numberOfPeriods = prisonerInPrisonSummary?.prisonPeriod?.size ?: 0
+    log.info { "Retrieved $numberOfPeriods prison periods from the prison-api for prisoner $prisonNumber" }
     return PrisonMovementEvents(prisonNumber, emptyMap())
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiClient.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi
 
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -9,11 +9,11 @@ import uk.gov.justice.digital.hmpps.prisonapi.resource.model.PrisonerInPrisonSum
 class PrisonApiClient(private val prisonApiWebClient: WebClient) {
 
   /**
-   * Retrieves a Prisoner's current and previous prisons, including the date they entered each prison.
+   * Retrieves a Prisoner's current and previous prisons, including the dates they entered/exited each prison.
    *
    *  @throws [PrisonApiException] if there is a problem retrieving the data.
    */
-  fun getPrisonTimeline(prisonNumber: String): PrisonerInPrisonSummary? =
+  fun getPrisonMovementEvents(prisonNumber: String): PrisonMovementEvents? {
     prisonApiWebClient
       .get()
       .uri("/api/offenders/$prisonNumber/prison-timeline")
@@ -24,4 +24,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
         Mono.error(PrisonApiException("Error retrieving prison history for Prisoner $prisonNumber", it))
       }
       .block()
+    // TODO RR-580 - map PrisonerInPrisonSummary to PrisonMovementEvents
+    return PrisonMovementEvents(prisonNumber, emptyMap())
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiException.kt
@@ -1,3 +1,3 @@
-package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi
 
 class PrisonApiException(message: String, throwable: Throwable) : RuntimeException(message, throwable)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonMovementEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonMovementEvent.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi
+
+import java.time.LocalDate
+
+/**
+ * Represents a Prisoner's movement in or out of prison, or a transfer between Prisons. In the case of the latter, both
+ * `fromPrisonId` and `toPrisonId` should be populated, otherwise only one of them will be.
+ *
+ * Note that this is a high level abstraction from the prison-api and is intended to capture when a Prisoner was in
+ * each Prison, rather than temporary absences (TAPs) for things like hospital appointments etc.
+ */
+data class PrisonMovementEvent(
+  val date: LocalDate,
+  val movementType: PrisonMovementType,
+  val fromPrisonId: String?,
+  val toPrisonId: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonMovementEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonMovementEvents.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi
+
+/**
+ * Holds a list Prisoner's movements in or out of Prison, or transfers between Prisons, for each "Booking". The
+ * latter can be described as the time spent in Prison for one or more related Sentences. If the Prisoner is released
+ * into the community and then subsequently prosecuted for a separate offence later, then this will result in a new
+ * "Booking".
+ *
+ * Note that this is a high level abstraction from the prison-api and is intended to capture when a Prisoner was in
+ * each Prison, rather than temporary absences (TAPs) for things like hospital appointments etc.
+ */
+data class PrisonMovementEvents(
+  val prisonNumber: String,
+  val prisonMovements: Map<Long, List<PrisonMovementEvent>>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonMovementType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonMovementType.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi
+
+/**
+ * A simple enum to represent the types of movements in or out of Prisons, or between Prisons.
+ */
+enum class PrisonMovementType {
+  ARRIVAL,
+  RELEASE,
+  TRANSFER,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionEventService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionPersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.PrisonTimelineService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelinePersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelineService
 
@@ -37,8 +38,11 @@ class DomainConfiguration {
     ActionPlanService(actionPlanPersistenceAdapter, actionPlanEventService)
 
   @Bean
-  fun timelineDomainService(timelinePersistenceAdapter: TimelinePersistenceAdapter): TimelineService =
-    TimelineService(timelinePersistenceAdapter)
+  fun timelineDomainService(
+    timelinePersistenceAdapter: TimelinePersistenceAdapter,
+    prisonTimelineService: PrisonTimelineService,
+  ): TimelineService =
+    TimelineService(timelinePersistenceAdapter, prisonTimelineService)
 
   @Bean
   fun inductionDomainService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanEventService
@@ -41,8 +42,9 @@ class DomainConfiguration {
   fun timelineDomainService(
     timelinePersistenceAdapter: TimelinePersistenceAdapter,
     prisonTimelineService: PrisonTimelineService,
+    @Value("\${featureToggles.call-prison-api-enabled}") callPrisonApiEnabled: Boolean,
   ): TimelineService =
-    TimelineService(timelinePersistenceAdapter, prisonTimelineService)
+    TimelineService(timelinePersistenceAdapter, prisonTimelineService, callPrisonApiEnabled)
 
   @Bean
   fun inductionDomainService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaTimelinePersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaTimelinePersistenceAdapter.kt
@@ -1,11 +1,8 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
 
 import mu.KotlinLogging
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.PrisonApiClient
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.PrisonApiException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.TimelineEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.TimelineEntity.Companion.newTimelineForPrisoner
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.timeline.TimelineEntityMapper
@@ -22,9 +19,6 @@ class JpaTimelinePersistenceAdapter(
   private val timelineRepository: TimelineRepository,
   private val timelineMapper: TimelineEntityMapper,
   private val timelineEventMapper: TimelineEventEntityMapper,
-  // TODO RR-566 - call prisonApiClient via service class
-  private val prisonApiClient: PrisonApiClient,
-  @Value("\${featureToggles.call-prison-api-enabled}") private val callPrisonApiEnabled: Boolean,
 ) : TimelinePersistenceAdapter {
 
   @Transactional
@@ -60,16 +54,6 @@ class JpaTimelinePersistenceAdapter(
   @Transactional
   override fun getTimelineForPrisoner(prisonNumber: String): Timeline? {
     log.info { "Getting Timeline for prisoner [$prisonNumber]" }
-
-    // TODO RR-566 - remove this temporary code
-    if (callPrisonApiEnabled) {
-      try {
-        val numberOfPrisonPeriods = prisonApiClient.getPrisonTimeline(prisonNumber).let { it?.prisonPeriod?.size ?: 0 }
-        log.info { "Retrieved $numberOfPrisonPeriods prison periods from the prison-api for prisoner $prisonNumber" }
-      } catch (e: PrisonApiException) {
-        log.error("Unable to retrieve data from the prison-api: ", e)
-      }
-    }
 
     val timelineEntity = timelineRepository.findByPrisonNumber(prisonNumber)
     return if (timelineEntity != null) timelineMapper.fromEntityToDomain(timelineEntity) else null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineService.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi.PrisonApiClient
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.PrisonTimelineService
+
+@Component
+class PrisonerApiTimelineService(private val prisonApiClient: PrisonApiClient) : PrisonTimelineService {
+
+  override fun getPrisonTimelineEvents(prisonNumber: String): List<TimelineEvent> {
+    // TODO RR-566 map to a list of TimelineEvents
+    // val prisonMovements = prisonApiClient.getPrisonMovementEvents(prisonNumber)
+    return emptyList()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineService.kt
@@ -1,16 +1,26 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
+import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi.PrisonApiClient
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi.PrisonApiException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.PrisonTimelineService
+
+private val log = KotlinLogging.logger {}
 
 @Component
 class PrisonerApiTimelineService(private val prisonApiClient: PrisonApiClient) : PrisonTimelineService {
 
   override fun getPrisonTimelineEvents(prisonNumber: String): List<TimelineEvent> {
-    // TODO RR-566 map to a list of TimelineEvents
-    // val prisonMovements = prisonApiClient.getPrisonMovementEvents(prisonNumber)
-    return emptyList()
+    return try {
+      // TODO RR-566 map to a list of TimelineEvents
+      val prisonMovements = prisonApiClient.getPrisonMovementEvents(prisonNumber)
+      log.info { "Retrieved prison movements for prisoner $prisonNumber" }
+      emptyList()
+    } catch (e: PrisonApiException) {
+      log.warn("Error retrieving prison movements for prisoner $prisonNumber", e)
+      emptyList()
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaTimelinePersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaTimelinePersistenceAdapterTest.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
+import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -15,7 +15,6 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.PrisonApiClient
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.TimelineEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.aValidTimelineEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.aValidTimelineEventEntity
@@ -28,6 +27,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.aVal
 @ExtendWith(MockitoExtension::class)
 class JpaTimelinePersistenceAdapterTest {
 
+  @InjectMocks
   private lateinit var persistenceAdapter: JpaTimelinePersistenceAdapter
 
   @Mock
@@ -39,23 +39,8 @@ class JpaTimelinePersistenceAdapterTest {
   @Mock
   private lateinit var timelineEventMapper: TimelineEventEntityMapper
 
-  @Mock
-  private lateinit var prisonApiClient: PrisonApiClient
-
   @Captor
   private lateinit var timelineEntityCaptor: ArgumentCaptor<TimelineEntity>
-
-  @BeforeEach
-  fun setup() {
-    persistenceAdapter = JpaTimelinePersistenceAdapter(
-      timelineRepository = timelineRepository,
-      timelineMapper = timelineMapper,
-      timelineEventMapper = timelineEventMapper,
-      prisonApiClient = prisonApiClient,
-      // TODO RR-566 - remove this boolean and revert back to @InjectMocks
-      callPrisonApiEnabled = false,
-    )
-  }
 
   @Nested
   inner class AddTimelineEvent {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineServiceTest.kt
@@ -6,8 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi.PrisonApiClient
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi.PrisonApiException
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi.PrisonMovementEvents
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
 
 @ExtendWith(MockitoExtension::class)
@@ -24,7 +29,7 @@ class PrisonerApiTimelineServiceTest {
     // Given
     val prisonNumber = aValidPrisonNumber()
     // TODO RR-580 populate and map PrisonMovementEvents
-    // given(prisonApiClient.getPrisonMovementEvents(any())).willReturn(PrisonMovementEvents(prisonNumber, emptyMap()))
+    given(prisonApiClient.getPrisonMovementEvents(any())).willReturn(PrisonMovementEvents(prisonNumber, emptyMap()))
     val expected = emptyList<TimelineEvent>()
 
     // When
@@ -32,6 +37,23 @@ class PrisonerApiTimelineServiceTest {
 
     // Then
     assertThat(actual).isEqualTo(expected)
-    // verify(prisonApiClient).getPrisonMovementEvents(prisonNumber)
+    verify(prisonApiClient).getPrisonMovementEvents(prisonNumber)
+  }
+
+  @Test
+  fun `should fail to get Prison timeline events given prison-api is unavailable`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    given(prisonApiClient.getPrisonMovementEvents(any())).willThrow(
+      PrisonApiException("Error retrieving prison history for Prisoner $prisonNumber", RuntimeException()),
+    )
+    val expected = emptyList<TimelineEvent>()
+
+    // When
+    val actual = prisonerApiTimelineService.getPrisonTimelineEvents(prisonNumber)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+    verify(prisonApiClient).getPrisonMovementEvents(prisonNumber)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineServiceTest.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi.PrisonApiClient
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.TimelineEvent
+
+@ExtendWith(MockitoExtension::class)
+class PrisonerApiTimelineServiceTest {
+
+  @InjectMocks
+  private lateinit var prisonerApiTimelineService: PrisonerApiTimelineService
+
+  @Mock
+  private lateinit var prisonApiClient: PrisonApiClient
+
+  @Test
+  fun `should get Prison timeline events`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    // TODO RR-580 populate and map PrisonMovementEvents
+    // given(prisonApiClient.getPrisonMovementEvents(any())).willReturn(PrisonMovementEvents(prisonNumber, emptyMap()))
+    val expected = emptyList<TimelineEvent>()
+
+    // When
+    val actual = prisonerApiTimelineService.getPrisonTimelineEvents(prisonNumber)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+    // verify(prisonApiClient).getPrisonMovementEvents(prisonNumber)
+  }
+}


### PR DESCRIPTION
This PR models the prisoner movement data we receive from the `prison-api` into a simplified set of data classes. The mapping between these and the `prison-api` classes, plus the subsequent inclusion into the prisoner `Timeline` domain will be done in subsequent PRs (I've added TODOs where relevant).

This PR also reverts the temporary code I added to the `JpaTimelinePersistenceAdapter` to test the connection to the `prison-api`.