### PR TITLE
RR-592 - Remove feature toggle and change 404 response logic

### DIFF
--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/Timeline.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/Timeline.kt
@@ -22,13 +22,22 @@ class Timeline(
   /**
    * Adds a [TimelineEvent] to the timeline.
    */
-  fun addEvent(timelineEvent: TimelineEvent) =
+  fun addEvent(timelineEvent: TimelineEvent): Timeline {
     events.add(timelineEvent)
+    return this
+  }
 
   /**
    * Adds one or more [TimelineEvent]s to the timeline.
    */
-  fun addEvents(timelineEvents: List<TimelineEvent>) {
+  fun addEvents(timelineEvents: List<TimelineEvent>): Timeline {
     events.addAll(timelineEvents)
+    return this
+  }
+
+  companion object {
+    @JvmStatic
+    fun newTimeline(prisonNumber: String, events: List<TimelineEvent>) =
+      Timeline(UUID.randomUUID(), prisonNumber, events)
   }
 }

--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -24,7 +24,6 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     HMPPS_SQS_USE_WEB_TOKEN: true
-    CALL_PRISON_API_ENABLED: false
     PRISON_API_URL: "https://prison-api.prison.service.justice.gov.uk"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,7 +16,6 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api-dev.prison.service.justice.gov.uk
-    CALL_PRISON_API_ENABLED: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/integrationTest/resources/application-integration-test.yml
+++ b/src/integrationTest/resources/application-integration-test.yml
@@ -59,6 +59,3 @@ prison-api:
 apis:
   prison-api:
     url: http://localhost:9093
-
-featureToggles:
-  call-prison-api-enabled: true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanEventService
@@ -42,9 +41,8 @@ class DomainConfiguration {
   fun timelineDomainService(
     timelinePersistenceAdapter: TimelinePersistenceAdapter,
     prisonTimelineService: PrisonTimelineService,
-    @Value("\${featureToggles.call-prison-api-enabled}") callPrisonApiEnabled: Boolean,
   ): TimelineService =
-    TimelineService(timelinePersistenceAdapter, prisonTimelineService, callPrisonApiEnabled)
+    TimelineService(timelinePersistenceAdapter, prisonTimelineService)
 
   @Bean
   fun inductionDomainService(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,6 +102,3 @@ springdoc:
 apis:
   prison-api:
     url: ${PRISON_API_URL}
-
-featureToggles:
-  call-prison-api-enabled: ${CALL_PRISON_API_ENABLED:false}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/WiremockService.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/WiremockService.kt
@@ -33,4 +33,15 @@ class WiremockService(private val wireMockServer: WireMockServer) {
         ),
     )
   }
+
+  fun stubGetPrisonTimelineNotFound(prisonNumber: String) {
+    wireMockServer.stubFor(
+      get(urlPathMatching("/api/offenders/$prisonNumber/prison-timeline"))
+        .willReturn(
+          responseDefinition()
+            .withStatus(404)
+            .withHeader("Content-Type", "application/json"),
+        ),
+    )
+  }
 }


### PR DESCRIPTION
This PR changes the logic for when a 404 (NOT FOUND) is returned from the GET timeline endpoint. Previously it returned a 404 if no PLP related events existed (i.e. if no Goals or Inductions have been created), which meant that no prison related information would be displayed on the Timeline view. Instead, we want the prisoner's prison history to be displayed, which is useful information for a CIAG, before they embark on an Induction.

This PR also removes the `callPrisonApiEnabled` feature toggle, since calling the prison API has been tested in dev and is ready to be rolled out to the other envs (client credentials have been setup in each env).