### PR TITLE
RR-641 Temporary add legacy (incorrect) secrets

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -41,6 +41,14 @@ generic-service:
       DPR_USER: "DPR_USER"
       DPR_PASSWORD: "DPR_PASSWORD"
 
+    # Inbound SQS config
+    hmpps-domain-events-topic:
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
+    education-and-work-plan-domain-events-sqs-instance-output:
+      HMPPS_SQS_QUEUES_EDUCATION_AND_WORK_PLAN_QUEUE_NAME: "sqs_queue_name"
+    education-and-work-plan-domain-events-sqs-dl-instance-output:
+      HMPPS_SQS_QUEUES_EDUCATION_AND_WORK_PLAN_DLQ_NAME: "sqs_queue_name"
+
   allowlist:
     groups:
       - internal


### PR DESCRIPTION
There's a bit of history to this PR, but in a nutshell we have 2 secret variables hanging around which we need to remove. Otherwise, we can't remove the subsequent SQS secrets from CPE and fully decommission the remnants of the CIAG API.

This PR adds temporary secret variables, which we will then remove in a subsequent PR and hope that helm removes them from the environment.