### PR TITLE
RR-641 - Restore serviceAccountName (test)

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -12,6 +12,9 @@ generic-service:
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-education-and-work-plan-api-cert
 
+  # Used to access resources like SQS queues and SNS topics
+  serviceAccountName: hmpps-education-and-work-plan-api
+
   # Environment variables to load into the deployment
   env:
     JAVA_OPTS: "-Xmx512m"


### PR DESCRIPTION
Clutching at straws here, but I was a bit reluctant about removing this property in my previous PR (even though I added it for the domain-events SQS functionality a few months ago).