### PR TITLE
Dependency bumps to fix OWASP vulnerabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,8 @@ import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.11.0"
-  id("org.openapi.generator") version "7.0.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.3"
+  id("org.openapi.generator") version "7.3.0"
   kotlin("plugin.spring") version "1.9.21"
   kotlin("plugin.jpa") version "1.9.21"
   kotlin("kapt") version "1.9.21"
@@ -19,19 +19,21 @@ plugins {
 apply(plugin = "org.openapi.generator")
 
 val mapstructVersion = "1.5.5.Final"
-val postgresqlVersion = "42.6.0"
+val postgresqlVersion = "42.7.2"
 val kotlinLoggingVersion = "3.0.5"
-val springdocOpenapiVersion = "2.2.0"
+val springdocOpenapiVersion = "2.3.0"
 val awaitilityVersion = "4.2.0"
+val wiremockVersion = "3.4.1"
+val jsonWebTokenVersion = "0.12.5"
+val nimbusJwtVersion = "9.37.3"
 
-ext["logback.version"] = "1.4.14"
-ext["jackson-bom.version"] = "2.16.0"
+ext["jackson-bom.version"] = "2.16.1"
 
 allOpen {
   annotations(
     "javax.persistence.Entity",
     "javax.persistence.MappedSuperclass",
-    "javax.persistence.Embeddable"
+    "javax.persistence.Embeddable",
   )
 }
 
@@ -90,12 +92,12 @@ dependencies {
   testFixturesImplementation("io.projectreactor:reactor-core")
   testFixturesImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
   // Libraries to support creating JWTs in test fixtures
-  testFixturesImplementation("io.jsonwebtoken:jjwt-impl:0.11.5")
-  testFixturesImplementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
-  testFixturesImplementation("com.nimbusds:nimbus-jose-jwt:9.31")
+  testFixturesImplementation("io.jsonwebtoken:jjwt-impl:$jsonWebTokenVersion")
+  testFixturesImplementation("io.jsonwebtoken:jjwt-jackson:$jsonWebTokenVersion")
+  testFixturesImplementation("com.nimbusds:nimbus-jose-jwt:$nimbusJwtVersion")
 
-  integrationTestImplementation("com.github.tomakehurst:wiremock-jre8-standalone:2.35.1")
-  testFixturesImplementation("com.github.tomakehurst:wiremock-jre8-standalone:2.35.1")
+  integrationTestImplementation("org.wiremock:wiremock-standalone:$wiremockVersion")
+  testFixturesImplementation("org.wiremock:wiremock-standalone:$wiremockVersion")
 }
 
 java {
@@ -133,7 +135,7 @@ tasks.named("assemble") {
     delete(
       fileTree(project.buildDir.absolutePath)
         .include("libs/*-plain.jar")
-        .include("libs/*-test-fixtures.jar")
+        .include("libs/*-test-fixtures.jar"),
     )
   }
 }
@@ -183,13 +185,13 @@ tasks.register<GenerateTask>("buildEducationAndWorkPlanModel") {
       "serializationLibrary" to "jackson",
       "useBeanValidation" to "true",
       "useSpringBoot3" to "true",
-      "enumPropertyNaming" to "UPPERCASE"
-    )
+      "enumPropertyNaming" to "UPPERCASE",
+    ),
   )
   globalProperties.set(
     mapOf(
-      "models" to ""
-    )
+      "models" to "",
+    ),
   )
 }
 
@@ -206,13 +208,13 @@ tasks.register<GenerateTask>("buildPrisonApiModel") {
       "serializationLibrary" to "jackson",
       "useBeanValidation" to "true",
       "useSpringBoot3" to "true",
-      "enumPropertyNaming" to "UPPERCASE"
-    )
+      "enumPropertyNaming" to "UPPERCASE",
+    ),
   )
   globalProperties.set(
     mapOf(
-      "models" to ""
-    )
+      "models" to "",
+    ),
   )
 }
 

--- a/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalTest.kt
+++ b/domain/goal/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/goal/GoalTest.kt
@@ -22,7 +22,8 @@ class GoalTest {
     val goal = aValidGoal(steps = mutableListOf(step2, step3, step1)) // Steps passed into the goal out of sequence
 
     // Then
-    assertThat(goal.steps.map { it.title }).containsExactly( // steps are returned in correct sequence based on sequenceNumber
+    assertThat(goal.steps.map { it.title }).containsExactly(
+      // steps are returned in correct sequence based on sequenceNumber
       "Book course",
       "Attend course",
       "Pass exam",
@@ -44,7 +45,8 @@ class GoalTest {
       goal.addStep(newStep) // add "Attend course" step
 
       // Then
-      assertThat(goal.steps.map { it.title }).containsExactly( // steps are returned in correct sequence
+      assertThat(goal.steps.map { it.title }).containsExactly(
+        // steps are returned in correct sequence
         "Book course",
         "Attend course",
         "Pass exam",
@@ -64,7 +66,8 @@ class GoalTest {
       goal.addStep(newStep)
 
       // Then
-      assertThat(goal.steps.map { it.title }).containsExactly( // steps are returned in correct sequence
+      assertThat(goal.steps.map { it.title }).containsExactly(
+        // steps are returned in correct sequence
         "The new step",
         "Book course",
         "Pass exam",
@@ -84,7 +87,8 @@ class GoalTest {
       goal.addStep(newStep)
 
       // Then
-      assertThat(goal.steps.map { it.title }).containsExactly( // steps are returned in correct sequence
+      assertThat(goal.steps.map { it.title }).containsExactly(
+        // steps are returned in correct sequence
         "Book course",
         "Pass exam",
         "The new step",

--- a/domain/induction/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionServiceTest.kt
+++ b/domain/induction/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/induction/service/InductionServiceTest.kt
@@ -35,7 +35,7 @@ class InductionServiceTest {
   private lateinit var inductionEventService: InductionEventService
 
   companion object {
-    private const val prisonNumber = "A1234AB"
+    private const val PRISON_NUMBER = "A1234AB"
   }
 
   @Nested
@@ -52,7 +52,7 @@ class InductionServiceTest {
       service.createInduction(createInductionDto)
 
       // Then
-      verify(persistenceAdapter).getInduction(prisonNumber)
+      verify(persistenceAdapter).getInduction(PRISON_NUMBER)
       verify(persistenceAdapter).createInduction(createInductionDto)
       verify(inductionEventService).inductionCreated(induction)
     }
@@ -71,8 +71,8 @@ class InductionServiceTest {
       )
 
       // Then
-      assertThat(exception.message).isEqualTo("An Induction already exists for prisoner $prisonNumber")
-      verify(persistenceAdapter).getInduction(prisonNumber)
+      assertThat(exception.message).isEqualTo("An Induction already exists for prisoner $PRISON_NUMBER")
+      verify(persistenceAdapter).getInduction(PRISON_NUMBER)
       verifyNoInteractions(inductionEventService)
     }
   }
@@ -86,11 +86,11 @@ class InductionServiceTest {
       given(persistenceAdapter.getInduction(any())).willReturn(expected)
 
       // When
-      val actual = service.getInductionForPrisoner(prisonNumber)
+      val actual = service.getInductionForPrisoner(PRISON_NUMBER)
 
       // Then
       assertThat(actual).isEqualTo(expected)
-      verify(persistenceAdapter).getInduction(prisonNumber)
+      verify(persistenceAdapter).getInduction(PRISON_NUMBER)
     }
 
     @Test
@@ -100,14 +100,14 @@ class InductionServiceTest {
 
       // When
       val exception = catchThrowableOfType(
-        { service.getInductionForPrisoner(prisonNumber) },
+        { service.getInductionForPrisoner(PRISON_NUMBER) },
         InductionNotFoundException::class.java,
       )
 
       // Then
-      assertThat(exception).hasMessage("Induction not found for prisoner [$prisonNumber]")
-      assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
-      verify(persistenceAdapter).getInduction(prisonNumber)
+      assertThat(exception).hasMessage("Induction not found for prisoner [$PRISON_NUMBER]")
+      assertThat(exception.prisonNumber).isEqualTo(PRISON_NUMBER)
+      verify(persistenceAdapter).getInduction(PRISON_NUMBER)
     }
   }
 
@@ -116,8 +116,8 @@ class InductionServiceTest {
     @Test
     fun `should update induction`() {
       // Given
-      val updateInductionDto = aValidUpdateInductionDto(prisonNumber = prisonNumber)
-      val expected = aFullyPopulatedInduction(prisonNumber = prisonNumber)
+      val updateInductionDto = aValidUpdateInductionDto(prisonNumber = PRISON_NUMBER)
+      val expected = aFullyPopulatedInduction(prisonNumber = PRISON_NUMBER)
       given(persistenceAdapter.updateInduction(any())).willReturn(expected)
 
       // When
@@ -132,7 +132,7 @@ class InductionServiceTest {
     @Test
     fun `should fail to update induction given it does not exist`() {
       // Given
-      val updateInductionDto = aValidUpdateInductionDto(prisonNumber = prisonNumber)
+      val updateInductionDto = aValidUpdateInductionDto(prisonNumber = PRISON_NUMBER)
       given(persistenceAdapter.updateInduction(any())).willReturn(null)
 
       // When
@@ -142,7 +142,7 @@ class InductionServiceTest {
       )
 
       // Then
-      assertThat(exception).hasMessage("Induction not found for prisoner [$prisonNumber]")
+      assertThat(exception).hasMessage("Induction not found for prisoner [$PRISON_NUMBER]")
       verify(persistenceAdapter).updateInduction(updateInductionDto)
       verifyNoInteractions(inductionEventService)
     }

--- a/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimelineTest.kt
+++ b/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/TimelineTest.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 class TimelineTest {
 
   companion object {
-    private const val prisonNumber = "A1234AB"
+    private const val PRISON_NUMBER = "A1234AB"
 
     private val earliestEvent = aValidTimelineEvent(
       eventType = TimelineEventType.ACTION_PLAN_CREATED,
@@ -31,7 +31,7 @@ class TimelineTest {
     val events = listOf(middleEvent, earliestEvent, latestEvent)
 
     // When
-    val actual = Timeline(reference = reference, prisonNumber = prisonNumber, events = events)
+    val actual = Timeline(reference = reference, prisonNumber = PRISON_NUMBER, events = events)
 
     // Then
     assertThat(actual.events).containsExactly(
@@ -46,7 +46,7 @@ class TimelineTest {
     // Given
     val reference = UUID.randomUUID()
     val initialEvents = listOf(earliestEvent, latestEvent)
-    val timeline = Timeline(reference = reference, prisonNumber = prisonNumber, events = initialEvents)
+    val timeline = Timeline(reference = reference, prisonNumber = PRISON_NUMBER, events = initialEvents)
 
     // When
     timeline.addEvent(middleEvent)

--- a/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
+++ b/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/domain/timeline/service/TimelineServiceTest.kt
@@ -30,7 +30,7 @@ class TimelineServiceTest {
   private lateinit var prisonTimelineService: PrisonTimelineService
 
   companion object {
-    private const val prisonNumber = "A1234AB"
+    private const val PRISON_NUMBER = "A1234AB"
   }
 
   @Test
@@ -39,10 +39,10 @@ class TimelineServiceTest {
     val timelineEvent = aValidTimelineEvent()
 
     // When
-    service.recordTimelineEvent(prisonNumber, timelineEvent)
+    service.recordTimelineEvent(PRISON_NUMBER, timelineEvent)
 
     // Then
-    verify(persistenceAdapter).recordTimelineEvent(prisonNumber, timelineEvent)
+    verify(persistenceAdapter).recordTimelineEvent(PRISON_NUMBER, timelineEvent)
   }
 
   @Test
@@ -51,10 +51,10 @@ class TimelineServiceTest {
     val timelineEvents = listOf(aValidTimelineEvent(), aValidTimelineEvent())
 
     // When
-    service.recordTimelineEvents(prisonNumber, timelineEvents)
+    service.recordTimelineEvents(PRISON_NUMBER, timelineEvents)
 
     // Then
-    verify(persistenceAdapter).recordTimelineEvents(prisonNumber, timelineEvents)
+    verify(persistenceAdapter).recordTimelineEvents(PRISON_NUMBER, timelineEvents)
   }
 
   @Test
@@ -67,12 +67,12 @@ class TimelineServiceTest {
     expectedTimeline.addEvents(prisonEvents)
 
     // When
-    val actual = service.getTimelineForPrisoner(prisonNumber)
+    val actual = service.getTimelineForPrisoner(PRISON_NUMBER)
 
     // Then
     assertThat(actual).isEqualTo(expectedTimeline)
-    verify(persistenceAdapter).getTimelineForPrisoner(prisonNumber)
-    verify(prisonTimelineService).getPrisonTimelineEvents(prisonNumber)
+    verify(persistenceAdapter).getTimelineForPrisoner(PRISON_NUMBER)
+    verify(prisonTimelineService).getPrisonTimelineEvents(PRISON_NUMBER)
   }
 
   @Test
@@ -82,15 +82,15 @@ class TimelineServiceTest {
     val prisonEvents = listOf(aValidPrisonMovementTimelineEvent())
     given(persistenceAdapter.getTimelineForPrisoner(any())).willReturn(plpTimeline)
     given(prisonTimelineService.getPrisonTimelineEvents(any())).willReturn(prisonEvents)
-    val expectedTimeline = Timeline(UUID.randomUUID(), prisonNumber, prisonEvents)
+    val expectedTimeline = Timeline(UUID.randomUUID(), PRISON_NUMBER, prisonEvents)
 
     // When
-    val actual = service.getTimelineForPrisoner(prisonNumber)
+    val actual = service.getTimelineForPrisoner(PRISON_NUMBER)
 
     // Then
     assertThat(actual).usingRecursiveComparison().ignoringFields("reference").isEqualTo(expectedTimeline)
-    verify(persistenceAdapter).getTimelineForPrisoner(prisonNumber)
-    verify(prisonTimelineService).getPrisonTimelineEvents(prisonNumber)
+    verify(persistenceAdapter).getTimelineForPrisoner(PRISON_NUMBER)
+    verify(prisonTimelineService).getPrisonTimelineEvents(PRISON_NUMBER)
   }
 
   @Test
@@ -101,14 +101,14 @@ class TimelineServiceTest {
 
     // When
     val exception = catchThrowableOfType(
-      { service.getTimelineForPrisoner(prisonNumber) },
+      { service.getTimelineForPrisoner(PRISON_NUMBER) },
       TimelineNotFoundException::class.java,
     )
 
     // Then
-    assertThat(exception).hasMessage("Timeline not found for prisoner [$prisonNumber]")
-    assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
-    verify(persistenceAdapter).getTimelineForPrisoner(prisonNumber)
-    verify(prisonTimelineService).getPrisonTimelineEvents(prisonNumber)
+    assertThat(exception).hasMessage("Timeline not found for prisoner [$PRISON_NUMBER]")
+    assertThat(exception.prisonNumber).isEqualTo(PRISON_NUMBER)
+    verify(persistenceAdapter).getTimelineForPrisoner(PRISON_NUMBER)
+    verify(prisonTimelineService).getPrisonTimelineEvents(PRISON_NUMBER)
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -324,7 +324,8 @@ class UpdateGoalTest : IntegrationTestBase() {
           status = step1.status,
           sequenceNumber = step1.sequenceNumber,
         ),
-        newStep, // this is the only thing that is changed in the request - add a new Step
+        // the New Step is the only thing that is changed in the request - add a new Step
+        newStep,
       ),
     )
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -147,7 +147,8 @@ class UpdateInductionTest : IntegrationTestBase() {
         reference = persistedInduction.workOnRelease.reference,
       ),
       inPrisonInterests = aValidUpdateInPrisonInterestsRequest(),
-      previousQualifications = null, // null means these values won't be changed
+      // null means these values won't be changed
+      previousQualifications = null,
       previousTraining = null,
       previousWorkExperiences = null,
       personalSkillsAndInterests = null,
@@ -207,10 +208,12 @@ class UpdateInductionTest : IntegrationTestBase() {
       createdAtPrison = "BXI",
       updatedBy = updateUsername,
       updatedByDisplayName = updateDisplayName,
-      updatedAtPrison = "MDI", // different prison to the create request
+      // different prison to the create request
+      updatedAtPrison = "MDI",
     )
     val expectedInPrisonInterests = aValidInPrisonInterestsResponse(
-      createdBy = updateUsername, // in-prison interests didn't exist previously, so will be created by the update request
+      // in-prison interests didn't exist previously, so will be created by the update request
+      createdBy = updateUsername,
       createdByDisplayName = updateDisplayName,
       createdAtPrison = "MDI",
       updatedBy = updateUsername,
@@ -341,11 +344,13 @@ class UpdateInductionTest : IntegrationTestBase() {
       createdAtPrison = "BXI",
       updatedBy = updateUsername,
       updatedByDisplayName = updateDisplayName,
-      updatedAtPrison = "MDI", // different prison to the create request
+      // different prison to the create request
+      updatedAtPrison = "MDI",
     )
     val expectedPreviousQualifications = aValidPreviousQualificationsResponse(
       educationLevel = HighestEducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
-      createdBy = createUsername, // didn't exist previously, so will be created by the update request
+      // didn't exist previously, so will be created by the update request
+      createdBy = createUsername,
       createdByDisplayName = createDisplayName,
       createdAtPrison = "BXI",
       updatedBy = updateUsername,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/CreateCiagInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/CreateCiagInductionTest.kt
@@ -199,7 +199,8 @@ class CreateCiagInductionTest : IntegrationTestBase() {
       workExperience = null,
       skillsAndInterests = null,
       qualificationsAndTraining = aValidCreateEducationAndQualificationsRequest(
-        educationLevel = null, // not set in short route
+        // education level is not set in short route
+        educationLevel = null,
         qualifications = setOf(aValidAchievedQualification()),
         additionalTraining = setOf(TrainingType.NONE),
         additionalTrainingOther = null,
@@ -311,7 +312,8 @@ class CreateCiagInductionTest : IntegrationTestBase() {
       ),
       qualificationsAndTraining = aValidCreateEducationAndQualificationsRequest(
         qualifications = emptySet(),
-        additionalTraining = emptySet(), // not possible via the UI
+        // additional training set to an empty collection is not possible via the UI but technically the API supports it so is tested here
+        additionalTraining = emptySet(),
         additionalTrainingOther = null,
       ),
       inPrisonInterests = aValidCreatePrisonWorkAndEducationRequest(
@@ -397,7 +399,8 @@ class CreateCiagInductionTest : IntegrationTestBase() {
       qualificationsAndTraining = aValidCreateEducationAndQualificationsRequest(
         educationLevel = null,
         qualifications = null,
-        additionalTraining = setOf(TrainingType.NONE), // cannot set to null
+        // additional training cannot be set to null
+        additionalTraining = setOf(TrainingType.NONE),
         additionalTrainingOther = null,
       ),
       inPrisonInterests = aValidCreatePrisonWorkAndEducationRequest(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/GetCiagInductionSummariesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/GetCiagInductionSummariesTest.kt
@@ -93,7 +93,8 @@ class GetCiagInductionSummariesTest : IntegrationTestBase() {
           offenderId = prisonNumber1,
           desireToWork = false,
           hopingToGetWork = NO,
-          createdBy = "auser_gen", // expected createdBy and modifiedBy will be the user that created the inductions via the `createInduction` method call above
+          // expected createdBy and modifiedBy will be the user that created the inductions via the `createInduction` method call above
+          createdBy = "auser_gen",
           modifiedBy = "auser_gen",
         ),
         aValidCiagInductionSummaryResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiMapperTest.kt
@@ -48,7 +48,8 @@ class PrisonApiMapperTest {
     // Given
     val prisonNumber = aValidPrisonNumber()
     val prisonSummary = aValidPrisonerInPrisonSummary(
-      prisonPeriod = emptyList(), // not expected to happen in practice - there should always be an admission event
+      // not expected to happen in practice - there should always be an admission event
+      prisonPeriod = emptyList(),
     )
     val expected = aValidPrisonMovementEvents(prisonNumber = prisonNumber, prisonBookings = emptyMap())
 
@@ -66,7 +67,8 @@ class PrisonApiMapperTest {
     val prisonSummary = aValidPrisonerInPrisonSummary(
       prisonPeriod = listOf(
         aValidPrisonPeriod(
-          movementDates = emptyList(), // not expected to happen in practice - there should always be an admission event
+          // not expected to happen in practice - there should always be an admission event
+          movementDates = emptyList(),
           transfers = emptyList(),
         ),
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateFutureWorkInterestsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdateFutureWorkInterestsEntityMapperTest.kt
@@ -158,7 +158,8 @@ class UpdateFutureWorkInterestsEntityMapperTest {
       reference = futureWorkInterestsReference,
       interests = listOf(
         aValidWorkInterest(
-          workType = WorkInterestTypeDomain.OTHER, // only first interest above included
+          // only first interest above included
+          workType = WorkInterestTypeDomain.OTHER,
           workTypeOther = "Any job I can get",
           role = "Any role",
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePreviousQualificationsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePreviousQualificationsEntityMapperTest.kt
@@ -52,8 +52,9 @@ class UpdatePreviousQualificationsEntityMapperTest {
       qualifications = mutableListOf(existingQualificationEntity1, existingQualificationEntity2),
     )
 
+    // ensure case is ignored
     val updatedQualification = aValidQualification(
-      subject = "ENGLISH", // ensure case is ignored
+      subject = "ENGLISH",
       level = QualificationLevelDomain.LEVEL_3,
       grade = "B",
     )
@@ -108,14 +109,16 @@ class UpdatePreviousQualificationsEntityMapperTest {
       ),
     )
 
+    // same level as above, so the grade should be updated
     val updatedQualification = aValidQualification(
       subject = "English",
-      level = QualificationLevelDomain.LEVEL_3, // same level as above, so the grade should be updated
+      level = QualificationLevelDomain.LEVEL_3,
       grade = "B",
     )
+    // different level, so should appear as a new qualification
     val newQualification = aValidQualification(
       subject = "English",
-      level = QualificationLevelDomain.LEVEL_2, // different level, so should appear as a new qualification
+      level = QualificationLevelDomain.LEVEL_2,
       grade = "C",
     )
     val updatedQualificationsDto = aValidUpdatePreviousQualificationsDto(
@@ -130,15 +133,17 @@ class UpdatePreviousQualificationsEntityMapperTest {
       reference = reference
       educationLevel = HighestEducationLevelEntity.SECONDARY_SCHOOL_TOOK_EXAMS
       qualifications = mutableListOf(
+        // updated grade
         aValidQualificationEntity(
           subject = "English",
           level = QualificationLevelEntity.LEVEL_3,
-          grade = "B", // updated grade
+          grade = "B",
         ),
+        // new qualification
         aValidQualificationEntity(
           subject = "English",
           level = QualificationLevelEntity.LEVEL_2,
-          grade = "C", // new qualification
+          grade = "C",
         ),
       )
       createdAtPrison = "BXI"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TelemetryServiceTest.kt
@@ -214,7 +214,8 @@ class TelemetryServiceTest {
 
       val updateEventTypes = listOf(
         GOAL_UPDATED,
-        STEP_REMOVED, // 2 STEP_REMOVED event types to trigger 2 corresponding telemetry events.
+        // 2 STEP_REMOVED event types to trigger 2 corresponding telemetry events.
+        STEP_REMOVED,
         STEP_REMOVED,
         // The follow event types will be supported in the future.
         // They are included here to break the test as and when the implementation handles them.

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonerInPrisonSummaryBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonerInPrisonSummaryBuilder.kt
@@ -110,13 +110,18 @@ fun aValidPrisonerInPrisonSummary(
 fun aValidPrisonPeriod(
   entryDate: LocalDateTime = LocalDateTime.now().minusMonths(6),
   movementDates: List<SignificantMovement> = listOf(
-    aValidSignificantMovementAdmission(), // into BMI
-    aValidSignificantMovementRelease(), // from MDI
-    aValidSignificantMovementAdmissionAndRelease(), // in and out of BXI
+    // movement into BMI
+    aValidSignificantMovementAdmission(),
+    // movement from MDI
+    aValidSignificantMovementRelease(),
+    // admission and release in and out of BXI
+    aValidSignificantMovementAdmissionAndRelease(),
   ),
   transfers: List<TransferDetail> = listOf(
-    aValidTransferDetail(), // BMI to MDI
-    anotherValidTransferDetail(), // MDI to BXI
+    // BMI to MDI
+    aValidTransferDetail(),
+    // MDI to BXI
+    anotherValidTransferDetail(),
   ),
   prisons: List<String> = listOf("BMI", "MDI", "BXI"),
   bookNumber: String = "1234A",
@@ -136,9 +141,11 @@ fun aValidPrisonPeriod(
 fun anotherValidPrisonPeriod(
   entryDate: LocalDateTime = LocalDateTime.now().minusMonths(1),
   movementDates: List<SignificantMovement> = listOf(
-    aValidSignificantMovementAdmissionAndRelease(), // in and out of BXI
+    // An admission and release in and out of BXI
+    aValidSignificantMovementAdmissionAndRelease(),
   ),
-  transfers: List<TransferDetail> = emptyList(), // according to the swagger spec, this will never be null
+  // as per the swagger spec, transfers will never be null
+  transfers: List<TransferDetail> = emptyList(),
   prisons: List<String> = listOf("BXI"),
   bookNumber: String = "5678B",
   bookingId: Long = 2,


### PR DESCRIPTION
This PR bumps the dependency versions of the gradle build to the latest versions to fix the latest OWASP vulnerabilities that are being logged in the nightly scan.

It's actually quite a big PR - bigger than what I anticipated, but I think thats a reflection of the fact we've not done this for a while (and perhaps should do more often)

Anyway, as well as the version bumps in the gradle build, theres a lot of "code changes" caused by linting errors (you're gonna love this @mattwills-moj-digital ! )
It seems one of the more recent changes in HMPPS Spring Boot gradle plugin has changed the linting rules! 😢 (either by bumping the version of the linter, or making a conscious decision to change them. Either way, I've had to make quite a few changes to the code to fix them!
The main (annoying) change is the positioning of comments!

Anyway, if you can get past the changes to comments and commas, then its just a PR that bumps a few versions! 👍 