### PR TITLE
RR-741 - Handle DB exceptions to prevent them being leaked in the error response

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -192,6 +192,14 @@ abstract class IntegrationTestBase {
       .returnResult(CiagInductionResponse::class.java)
       .responseBody.blockFirst()!!
 
+  fun inductionDoesNotExistForPrisoner(prisonNumber: String) =
+    webTestClient.get()
+      .uri(INDUCTION_URI_TEMPLATE, prisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+
   fun getInduction(prisonNumber: String): InductionResponse =
     webTestClient.get()
       .uri(INDUCTION_URI_TEMPLATE, prisonNumber)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
@@ -4,6 +4,7 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -28,6 +29,7 @@ class ActionPlanController(
   @PostMapping("/{prisonNumber}")
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
+  @Transactional
   fun createActionPlan(
     @Valid
     @RequestBody

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CiagInductionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CiagInductionController.kt
@@ -4,6 +4,7 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -34,6 +35,7 @@ class CiagInductionController(
   @PostMapping("/{prisonNumber}")
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
+  @Transactional
   fun createInduction(
     @Valid
     @RequestBody
@@ -54,6 +56,7 @@ class CiagInductionController(
   @PutMapping("/{prisonNumber}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
+  @Transactional
   fun updateInduction(
     @Valid
     @RequestBody

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -4,6 +4,7 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -30,6 +31,7 @@ class GoalController(
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
+  @Transactional
   fun createGoals(
     @Valid
     @RequestBody
@@ -46,6 +48,7 @@ class GoalController(
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
   @GoalReferenceMatchesReferenceInUpdateGoalRequest
+  @Transactional
   fun updateGoal(
     @Valid
     @RequestBody

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/InductionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/InductionController.kt
@@ -4,6 +4,7 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -28,6 +29,7 @@ class InductionController(
   @PostMapping("/{prisonNumber}")
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
+  @Transactional
   fun createInduction(
     @Valid
     @RequestBody
@@ -48,6 +50,7 @@ class InductionController(
   @PutMapping("/{prisonNumber}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
+  @Transactional
   fun updateInduction(
     @Valid
     @RequestBody


### PR DESCRIPTION
This PR handles DB exceptions in the GlobalExceptionHandler to prevent them being leaked in the error response
There's also some minor work around where the transaction boundary is because otherwise the induction would have been created even though it was the timeline record that failed to write (it feels correct that if the timeline failed to update, then the main request should also fail)

Without this fix, this is the error response that leaks details:
```
{
  "status": 500,
  "errorCode": null,
  "userMessage": "Unexpected error: could not execute statement [ERROR: value too long for type character varying(3)] [insert into timeline_event (timeline_id,actioned_by,actioned_by_display_name,contextual_info,correlation_id,created_at,event_type,prison_id,reference,source_reference,timestamp,id) values (?,?,?,?,?,?,?,?,?,?,?,?)]; SQL [insert into timeline_event (timeline_id,actioned_by,actioned_by_display_name,contextual_info,correlation_id,created_at,event_type,prison_id,reference,source_reference,timestamp,id) values (?,?,?,?,?,?,?,?,?,?,?,?)]",
  "developerMessage": "could not execute statement [ERROR: value too long for type character varying(3)] [insert into timeline_event (timeline_id,actioned_by,actioned_by_display_name,contextual_info,correlation_id,created_at,event_type,prison_id,reference,source_reference,timestamp,id) values (?,?,?,?,?,?,?,?,?,?,?,?)]; SQL [insert into timeline_event (timeline_id,actioned_by,actioned_by_display_name,contextual_info,correlation_id,created_at,event_type,prison_id,reference,source_reference,timestamp,id) values (?,?,?,?,?,?,?,?,?,?,?,?)]",
  "moreInfo": null
}
```

With this fix the error response is this:
```
{
  "status": 503,
  "errorCode": "Service Unavailable",
  "userMessage": "Service unavailable",
  "developerMessage": "null",
  "moreInfo": null
}
```
