### PR TITLE
RR-740 - Validate prisonNumber path variables to prevent reflected input style attacks

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/PrisonNumberPathVariableParameterValidationTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/PrisonNumberPathVariableParameterValidationTest.kt
@@ -1,0 +1,137 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithViewAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+
+/**
+ * Integration tests that test and assert the validation of the prisonNumber path parameter in our API endpoints.
+ *
+ * All API endpoints that accept the prisonNumber as a path variable parameter include this validation. Rather than testing
+ * every endpoint, one GET endpoint is tested here with the assumption that all others will validate in the same way.
+ */
+class PrisonNumberPathVariableParameterValidationTest : IntegrationTestBase() {
+
+  companion object {
+    private const val URI_TEMPLATE = "/action-plans/{prisonNumber}"
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      // Non-malicious but malformed prison numbers
+      "A1234B",
+      "1234",
+      "a malformed prison number",
+    ],
+  )
+  fun `should reject request with BAD_REQUEST given prison number is non-malicious but malformed`(malformedPrisonNumber: String) {
+    // Given
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, malformedPrisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(BAD_REQUEST.value())
+      .hasUserMessageContaining("must match \"^[A-Za-z]\\d{4}[A-Za-z]{2}\$\"")
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      // Examples of reflected payload style attacks
+      "<script>alert('Attempt to do something something bad')</script>",
+      "<html><body>Attempt to render back an entirely different document</body></html>",
+    ],
+    // It may be because the malformed prison number is HTML in these scenarios, but for some reason the application server
+    // interprets these requests as content type text/html, hence the response body.
+  )
+  fun `should reject request with BAD_REQUEST given prison number is at attempt at a reflected payload attack`(malformedPrisonNumber: String) {
+    // Given
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, malformedPrisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(String::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual).isEqualTo(
+      """<!doctype html><html lang="en"><head><title>HTTP Status 400 – Bad Request</title><style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 400 – Bad Request</h1></body></html>""",
+    )
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      // Examples of SQL injection style attacks
+      "A1234BC OR 1=1",
+      "\" OR \"\"=\"",
+      "' OR ''='",
+    ],
+  )
+  fun `should reject request with BAD_REQUEST given prison number is an attempt at a SQL injection attack without semicolons`(malformedPrisonNumber: String) {
+    // Given
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, malformedPrisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(BAD_REQUEST.value())
+      .hasUserMessageContaining("must match \"^[A-Za-z]\\d{4}[A-Za-z]{2}\$\"")
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      // Examples of SQL injection style attacks
+      "\"; DROP TABLE induction;",
+      "'; DROP TABLE induction;",
+      "A1234BC; DROP TABLE induction;",
+    ],
+    // It may be because the malformed prison number contains a semicolon in these scenarios, but for some reason the application server
+    // interprets these requests in such a way that it doesn't match the path at all, hence the 401 with a null body response.
+  )
+  fun `should reject request with UNAUTHORISED given prison number is an attempt at a SQL injection attack`(malformedPrisonNumber: String) {
+    // Given
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, malformedPrisonNumber)
+      .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+      .returnResult(Void::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual).isNull()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.ActionPlanResourceMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.PRISON_NUMBER_FORMAT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.ActionPlanService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanSummaryListResponse
@@ -20,6 +23,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GetActionPlanSummariesRequest
 
 @RestController
+@Validated
 @RequestMapping(value = ["/action-plans"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ActionPlanController(
   private val actionPlanService: ActionPlanService,
@@ -34,7 +38,7 @@ class ActionPlanController(
     @Valid
     @RequestBody
     request: CreateActionPlanRequest,
-    @PathVariable prisonNumber: String,
+    @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
   ) {
     actionPlanService.createActionPlan(actionPlanMapper.fromModelToDto(prisonNumber, request))
   }
@@ -42,7 +46,7 @@ class ActionPlanController(
   @GetMapping("/{prisonNumber}")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize(HAS_VIEW_AUTHORITY)
-  fun getActionPlan(@PathVariable prisonNumber: String): ActionPlanResponse =
+  fun getActionPlan(@PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String): ActionPlanResponse =
     with(actionPlanService.getActionPlan(prisonNumber)) {
       actionPlanMapper.fromDomainToModel(this)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CiagInductionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CiagInductionController.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag.CiagInductionResponseMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag.CreateCiagInductionRequestMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.ciag.UpdateCiagInductionRequestMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.PRISON_NUMBER_FORMAT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionSummaryListResponse
@@ -24,6 +27,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GetCi
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateCiagInductionRequest
 
 @RestController
+@Validated
 @RequestMapping(value = ["/ciag/induction"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class CiagInductionController(
   private val inductionService: InductionService,
@@ -40,7 +44,7 @@ class CiagInductionController(
     @Valid
     @RequestBody
     request: CreateCiagInductionRequest,
-    @PathVariable prisonNumber: String,
+    @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
   ) {
     inductionService.createInduction(createInductionRequestMapper.toCreateInductionDto(prisonNumber, request))
   }
@@ -48,7 +52,7 @@ class CiagInductionController(
   @GetMapping("/{prisonNumber}")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize(HAS_VIEW_AUTHORITY)
-  fun getInduction(@PathVariable prisonNumber: String): CiagInductionResponse =
+  fun getInduction(@PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String): CiagInductionResponse =
     with(inductionService.getInductionForPrisoner(prisonNumber)) {
       inductionResponseMapper.fromDomainToModel(this)
     }
@@ -61,7 +65,7 @@ class CiagInductionController(
     @Valid
     @RequestBody
     request: UpdateCiagInductionRequest,
-    @PathVariable prisonNumber: String,
+    @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
   ) {
     inductionService.updateInduction(updateInductionRequestMapper.toUpdateInductionDto(prisonNumber, request))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.GoalResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.GoalReferenceMatchesReferenceInUpdateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.PRISON_NUMBER_FORMAT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.goal.service.GoalService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
@@ -36,7 +38,7 @@ class GoalController(
     @Valid
     @RequestBody
     request: CreateGoalsRequest,
-    @PathVariable prisonNumber: String,
+    @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
   ) {
     goalService.createGoals(
       prisonNumber = prisonNumber,
@@ -53,7 +55,7 @@ class GoalController(
     @Valid
     @RequestBody
     updateGoalRequest: UpdateGoalRequest,
-    @PathVariable prisonNumber: String,
+    @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
     @PathVariable goalReference: UUID,
   ) {
     goalService.updateGoal(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/InductionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/InductionController.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,12 +16,14 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.InductionResourceMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.PRISON_NUMBER_FORMAT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.induction.service.InductionService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateInductionRequest
 
 @RestController
+@Validated
 @RequestMapping(value = ["/inductions"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class InductionController(
   private val inductionService: InductionService,
@@ -34,7 +38,7 @@ class InductionController(
     @Valid
     @RequestBody
     request: CreateInductionRequest,
-    @PathVariable prisonNumber: String,
+    @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
   ) {
     inductionService.createInduction(inductionMapper.toCreateInductionDto(prisonNumber, request))
   }
@@ -42,7 +46,7 @@ class InductionController(
   @GetMapping("/{prisonNumber}")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize(HAS_VIEW_AUTHORITY)
-  fun getInduction(@PathVariable prisonNumber: String): InductionResponse =
+  fun getInduction(@PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String): InductionResponse =
     with(inductionService.getInductionForPrisoner(prisonNumber)) {
       inductionMapper.toInductionResponse(this)
     }
@@ -55,7 +59,7 @@ class InductionController(
     @Valid
     @RequestBody
     request: UpdateInductionRequest,
-    @PathVariable prisonNumber: String,
+    @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
   ) {
     inductionService.updateInduction(inductionMapper.toUpdateInductionDto(prisonNumber, request))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/TimelineController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/TimelineController.kt
@@ -1,18 +1,22 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
+import jakarta.validation.constraints.Pattern
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.timeline.TimelineResourceMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.PRISON_NUMBER_FORMAT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.domain.timeline.service.TimelineService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
 
 @RestController
+@Validated
 @RequestMapping(value = ["/timelines"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class TimelineController(
   private val timelineService: TimelineService,
@@ -22,7 +26,7 @@ class TimelineController(
   @GetMapping("/{prisonNumber}")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize(HAS_VIEW_AUTHORITY)
-  fun getTimeline(@PathVariable prisonNumber: String): TimelineResponse =
+  fun getTimeline(@PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String): TimelineResponse =
     with(timelineService.getTimelineForPrisoner(prisonNumber)) {
       timelineMapper.fromDomainToModel(this)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/ValidatorConstants.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/ValidatorConstants.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator
+
+const val PRISON_NUMBER_FORMAT = "^[A-Za-z]\\d{4}[A-Za-z]{2}$"

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,11 +1,11 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.7.8'
+  version: '1.7.9'
   description: Education and Work Plan API
   contact:
-    name: Matt Wills
-    email: matt.wills@digital.justice.gov.uk
+    name: Learning and Work Progress team
+    email: learningandworkprogress@digital.justice.gov.uk
 servers:
   - url: 'http://localhost:3000'
 #
@@ -38,13 +38,7 @@ paths:
 
   '/action-plans/{prisonNumber}':
     parameters:
-      - name: prisonNumber
-        description: The number of the Prisoner who may have created (or is in the process of creating) an "Action Plan", consisting of one or more Goals. The prisonNumber is the unique identifier of the Action Plan.
-        schema:
-          type: string
-        example: 'A1234BC'
-        in: path
-        required: true
+      - $ref: "#/components/parameters/prisonNumberPathParameter"
     post:
       summary: Creates an Action Plan.
       description: Creates an Action Plan with at least one or more Goals.
@@ -75,13 +69,7 @@ paths:
   # --------------------------------------------------------------------------------
   '/action-plans/{prisonNumber}/goals':
     parameters:
-      - name: prisonNumber
-        description: The number of the Prisoner who may have created (or is in the process of creating) an "Action Plan", consisting of one or more Goals. The prisonNumber is the unique identifier of the Action Plan.
-        schema:
-          type: string
-        example: 'A1234BC'
-        in: path
-        required: true
+      - $ref: "#/components/parameters/prisonNumberPathParameter"
     post:
       summary: Creates one or more Goals.
       description: Creates one or more Goals and saves them to the Prisoner's Action Plan (the latter will be created if it doesn't already exist).
@@ -100,13 +88,7 @@ paths:
 
   '/action-plans/{prisonNumber}/goals/{goalReference}':
     parameters:
-      - name: prisonNumber
-        description: The number of the Prisoner who owns the Goal.
-        schema:
-          type: string
-        example: 'A1234BC'
-        in: path
-        required: true
+      - $ref: "#/components/parameters/prisonNumberPathParameter"
       - name: goalReference
         description: The Goal's unique reference
         schema:
@@ -136,13 +118,7 @@ paths:
   #
   '/timelines/{prisonNumber}':
     parameters:
-      - name: prisonNumber
-        description: The number of the Prisoner who may have relevant Timeline data.
-        schema:
-          type: string
-        example: 'A1234BC'
-        in: path
-        required: true
+      - $ref: "#/components/parameters/prisonNumberPathParameter"
     get:
       summary: Return a Prisoner's Timeline.
       description: Returns a Prisoner's Timeline data, consisting of one or more 'events' of interest in chronological order. For example, it could include events such as when they completed an Induction, or updated a Goal. The prisonNumber is the unique identifier of the Timeline.
@@ -160,13 +136,7 @@ paths:
     #
   '/ciag/induction/{prisonNumber}':
     parameters:
-      - name: prisonNumber
-        description: The number of the Prisoner who may have relevant Induction data.
-        schema:
-          type: string
-        example: 'A1234BC'
-        in: path
-        required: true
+      - $ref: "#/components/parameters/prisonNumberPathParameter"
     post:
       deprecated: true
       summary: Creates an Induction for a Prisoner.
@@ -246,13 +216,7 @@ paths:
     #
   '/inductions/{prisonNumber}':
     parameters:
-      - name: prisonNumber
-        description: The number of the Prisoner who may have relevant Induction data.
-        schema:
-          type: string
-        example: 'A1234BC'
-        in: path
-        required: true
+      - $ref: "#/components/parameters/prisonNumberPathParameter"
     post:
       summary: Creates an Induction for a Prisoner.
       description: |
@@ -308,7 +272,7 @@ paths:
         - Subject Access Request
 
       parameters:
-        - $ref: "#/components/parameters/prisonReferenceNumber"
+        - $ref: "#/components/parameters/prnQueryStringParameter"
         - $ref: "#/components/parameters/fromDate"
         - $ref: "#/components/parameters/toDate"
       responses:
@@ -319,7 +283,7 @@ paths:
         '209':
           description: Subject Identifier is not recognised by this service
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+          $ref: '#/components/responses/400ErrorResponse'
         '401':
           description: The client does not have authorisation to make this request
 
@@ -609,7 +573,8 @@ components:
           description: The Induction's unique reference.
           example: 814ade0a-a3b2-46a3-862f-79211ba13f7b
         offenderId:
-          pattern: "^[A-Z]\\d{4}[A-Z]{2}$"
+          pattern: "^[A-Za-z]\\d{4}[A-Za-z]{2}$"
+          example: "A1234BC"
           type: string
           description: 'The ID of the Prisoner. AKA the prison number.'
         prisonId:
@@ -875,7 +840,7 @@ components:
       properties:
         offenderId:
           type: string
-          pattern: '^[A-Z]\\d{4}[A-Z]{2}$'
+          pattern: '^[A-Za-z]\\d{4}[A-Za-z]{2}$'
           description: The ID of the Prisoner. AKA the prison number.
           example: 'A1234BC'
         desireToWork:
@@ -1453,6 +1418,8 @@ components:
           description: A List of prison numbers whose Action Plans should be retrieved.
           items:
             type: string
+            example: "A1234BC"
+            pattern: "^[A-Za-z]\\d{4}[A-Za-z]{2}$"
       required:
         - prisonNumbers
 
@@ -2244,7 +2211,8 @@ components:
           description: A List of prison numbers whose CIAG Inductions should be retrieved.
           items:
             type: string
-            pattern: "^[A-Z]\\d{4}[A-Z]{2}$"
+            pattern: "^[A-Za-z]\\d{4}[A-Za-z]{2}$"
+            example: "A1234BC"
       required:
         - offenderIds
 
@@ -2750,12 +2718,24 @@ components:
             $ref: '#/components/schemas/UpdateInductionRequest'
 
   parameters:
-    prisonReferenceNumber:
-      name: prn
-      description: NOMIS Prison Reference Number
-      in: query
+    prisonNumberPathParameter:
+      name: prisonNumber
+      description: The NOMIS Prison Reference Number of the Prisoner that the operation is being performed on.
       schema:
         type: string
+        pattern: "^[A-Za-z]\\d{4}[A-Za-z]{2}$"
+      example: 'A1234BC'
+      in: path
+      required: true
+    prnQueryStringParameter:
+      name: prn
+      description: The NOMIS Prison Reference Number of the Prisoner that the operation is being performed on.
+      schema:
+        type: string
+        pattern: "^[A-Za-z]\\d{4}[A-Za-z]{2}$"
+      example: 'A1234BC'
+      in: query
+      required: true
     fromDate:
       name: fromDate
       in: query


### PR DESCRIPTION
This PR adds format validation to the `prisonNumber` path variables in the APIs to prevent reflected input style attacks (as highlighted in the app-sec scan)