### PR TITLE
RR-799 - Async services using Spring's ThreadPoolTaskExecutor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,6 @@ dependencies {
   implementation(project("domain:timeline"))
 
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:0.2.2")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -249,15 +249,15 @@ class UpdateGoalTest : IntegrationTestBase() {
           .wasUpdatedBy("buser_gen")
       }
 
-    val timeline = getTimeline(prisonNumber)
-    assertThat(timeline)
-      .event(3) { // the 3rd Timeline event will be the GOAL_UPDATED event
-        it.hasEventType(TimelineEventType.GOAL_UPDATED)
-          .wasActionedBy("buser_gen")
-          .hasActionedByDisplayName("Bernie User")
-      }
-
     await.untilAsserted {
+      val timeline = getTimeline(prisonNumber)
+      assertThat(timeline)
+        .event(3) { // the 3rd Timeline event will be the GOAL_UPDATED event
+          it.hasEventType(TimelineEventType.GOAL_UPDATED)
+            .wasActionedBy("buser_gen")
+            .hasActionedByDisplayName("Bernie User")
+        }
+
       val eventPropertiesCaptor = ArgumentCaptor.forClass(Map::class.java as Class<Map<String, String>>)
 
       verify(telemetryClient).trackEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/HmppsEducationAndWorkPlanApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/HmppsEducationAndWorkPlanApi.kt
@@ -4,10 +4,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableAsync
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableJpaAuditing
+@EnableAsync
 class HmppsEducationAndWorkPlanApi
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/ThreadPoolConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/ThreadPoolConfiguration.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.TaskExecutor
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+
+@Configuration
+class ThreadPoolConfiguration {
+  @Bean("threadPoolTaskExecutor")
+  fun taskExecutor(): TaskExecutor =
+    ThreadPoolTaskExecutor().apply {
+      corePoolSize = 200
+      maxPoolSize = 1000
+      this.setWaitForTasksToCompleteOnShutdown(true)
+      threadNamePrefix = "Async-"
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncActionPlanEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncActionPlanEventService.kt
@@ -1,8 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlan
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.service.ActionPlanEventService
@@ -15,23 +14,20 @@ private val log = KotlinLogging.logger {}
  * events.
  */
 @Component
+@Async
 class AsyncActionPlanEventService(
   private val telemetryService: TelemetryService,
   private val timelineEventFactory: TimelineEventFactory,
   private val timelineService: TimelineService,
 ) : ActionPlanEventService {
   override fun actionPlanCreated(actionPlan: ActionPlan) {
-    runBlocking {
-      log.info { "ActionPlan created event for prisoner [${actionPlan.prisonNumber}]" }
-      launch {
-        actionPlan.goals.forEach {
-          telemetryService.trackGoalCreatedEvent(it)
-        }
-      }
-      launch {
-        val timelineEvents = timelineEventFactory.actionPlanCreatedEvent(actionPlan)
-        timelineService.recordTimelineEvents(actionPlan.prisonNumber, timelineEvents)
-      }
+    log.info { "ActionPlan created event for prisoner [${actionPlan.prisonNumber}]" }
+
+    actionPlan.goals.forEach {
+      telemetryService.trackGoalCreatedEvent(it)
     }
+
+    val timelineEvents = timelineEventFactory.actionPlanCreatedEvent(actionPlan)
+    timelineService.recordTimelineEvents(actionPlan.prisonNumber, timelineEvents)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncGoalEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncGoalEventService.kt
@@ -1,8 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.Goal
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.service.GoalEventService
@@ -15,6 +14,7 @@ private val log = KotlinLogging.logger {}
  * Implementation of [GoalEventService] for performing additional asynchronous actions related to [Goal] events.
  */
 @Component
+@Async
 class AsyncGoalEventService(
   private val telemetryService: TelemetryService,
   private val timelineEventFactory: TimelineEventFactory,
@@ -24,33 +24,28 @@ class AsyncGoalEventService(
   override fun goalsCreated(prisonNumber: String, createdGoals: List<Goal>) {
     val correlationId = UUID.randomUUID()
     createdGoals.forEach { createdGoal ->
-      runBlocking {
-        log.debug { "Goal created event for prisoner [$prisonNumber]" }
-        launch {
-          recordGoalCreatedTimelineEvent(
-            prisonNumber = prisonNumber,
-            createdGoal = createdGoal,
-            correlationId = correlationId,
-          )
-        }
-        launch { trackGoalCreatedTelemetryEvent(createdGoal = createdGoal) }
-      }
+      log.debug { "Goal created event for prisoner [$prisonNumber]" }
+
+      recordGoalCreatedTimelineEvent(
+        prisonNumber = prisonNumber,
+        createdGoal = createdGoal,
+        correlationId = correlationId,
+      )
+
+      trackGoalCreatedTelemetryEvent(createdGoal = createdGoal)
     }
   }
 
   override fun goalUpdated(prisonNumber: String, previousGoal: Goal, updatedGoal: Goal) {
-    runBlocking {
-      log.debug { "Goal updated event for prisoner [$prisonNumber]" }
+    log.debug { "Goal updated event for prisoner [$prisonNumber]" }
 
-      launch {
-        recordGoalUpdatedTimelineEvents(
-          prisonNumber = prisonNumber,
-          previousGoal = previousGoal,
-          updatedGoal = updatedGoal,
-        )
-      }
-      launch { trackGoalUpdatedTelemetryEvents(previousGoal = previousGoal, updatedGoal = updatedGoal) }
-    }
+    recordGoalUpdatedTimelineEvents(
+      prisonNumber = prisonNumber,
+      previousGoal = previousGoal,
+      updatedGoal = updatedGoal,
+    )
+
+    trackGoalUpdatedTelemetryEvents(previousGoal = previousGoal, updatedGoal = updatedGoal)
   }
 
   private fun recordGoalCreatedTimelineEvent(prisonNumber: String, createdGoal: Goal, correlationId: UUID = UUID.randomUUID()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventService.kt
@@ -1,8 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.Induction
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionEventService
@@ -16,25 +15,22 @@ private val log = KotlinLogging.logger {}
  * Implementation of [InductionEventService] for performing additional asynchronous actions related to [Induction] events.
  */
 @Component
+@Async
 class AsyncInductionEventService(
   private val timelineService: TimelineService,
   private val telemetryService: TelemetryService,
 ) : InductionEventService {
 
   override fun inductionCreated(createdInduction: Induction) {
-    runBlocking {
-      log.debug { "Induction created event for prisoner [${createdInduction.prisonNumber}]" }
-      launch { timelineService.recordTimelineEvent(createdInduction.prisonNumber, buildInductionCreatedEvent(createdInduction)) }
-      launch { telemetryService.trackInductionCreated(induction = createdInduction) }
-    }
+    log.debug { "Induction created event for prisoner [${createdInduction.prisonNumber}]" }
+    timelineService.recordTimelineEvent(createdInduction.prisonNumber, buildInductionCreatedEvent(createdInduction))
+    telemetryService.trackInductionCreated(induction = createdInduction)
   }
 
   override fun inductionUpdated(updatedInduction: Induction) {
-    runBlocking {
-      log.debug { "Induction updated event for prisoner [${updatedInduction.prisonNumber}]" }
-      launch { timelineService.recordTimelineEvent(updatedInduction.prisonNumber, buildInductionUpdatedEvent(updatedInduction)) }
-      launch { telemetryService.trackInductionUpdated(induction = updatedInduction) }
-    }
+    log.debug { "Induction updated event for prisoner [${updatedInduction.prisonNumber}]" }
+    timelineService.recordTimelineEvent(updatedInduction.prisonNumber, buildInductionUpdatedEvent(updatedInduction))
+    telemetryService.trackInductionUpdated(induction = updatedInduction)
   }
 
   private fun buildInductionCreatedEvent(induction: Induction): TimelineEvent =


### PR DESCRIPTION
This PR makes our async services properly async by using Spring's `ThreadPoolTaskExecutor` and the `Async` annotation.
([based on this medium post](https://medium.com/@ahmedmohamedmar3y2017/springboot-asynchronous-methods-58524b444fb4))

The original code was always meant to be async, but was flawed. It attempted to use kotlin coroutines, but the use of the `runBlocking` annotation meant that it wasn't async at all and actually was blocking the main request thread.

(There is an [alternative PR](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/pull/278) that implements these async services using kotlin coroutines)