### PR TITLE
RR-797: Get conversation endpoint implementation

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetConversationTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetConversationTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.aValidReference
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithEditAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ConversationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.conversation.aValidCreateReviewConversationRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.conversation.assertThat
+import java.time.OffsetDateTime
+
+class GetConversationTest : IntegrationTestBase() {
+  companion object {
+    private const val URI_TEMPLATE = "/conversations/{reference}"
+  }
+
+  @Test
+  fun `should return unauthorized given no bearer token`() {
+    webTestClient.get()
+      .uri(URI_TEMPLATE, aValidReference())
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `should fail to get conversation given conversation does not exist`() {
+    // Given
+    val conversationReference = aValidReference()
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, conversationReference)
+      .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isNotFound
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.NOT_FOUND.value())
+      .hasUserMessage("Conversation with reference [$conversationReference] not found")
+  }
+
+  @Test
+  fun `should get conversation`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    val note = "Adam is progressing well"
+    val createReviewConversationRequest = aValidCreateReviewConversationRequest(
+      note = note,
+    )
+    val createUsername = "auser_gen"
+    val createDisplayName = "Albert User"
+    val initialDateTime = OffsetDateTime.now()
+
+    // When
+    createConversation(
+      prisonNumber,
+      createReviewConversationRequest,
+    )
+
+    val createdConversation = conversationRepository.findAllByPrisonNumber(prisonNumber).first()
+
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, createdConversation.reference)
+      .bearerToken(
+        aValidTokenWithEditAuthority(
+          privateKey = keyPair.private,
+          username = createUsername,
+          displayName = createDisplayName,
+        ),
+      )
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(ConversationResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .isForPrisonNumber(prisonNumber)
+      .hasNoteContent(note)
+      .wasCreatedAtPrison(createReviewConversationRequest.prisonId)
+      .wasCreatedAfter(initialDateTime)
+      .wasCreatedBy(createUsername)
+      .hasCreatedByDisplayName(createDisplayName)
+      .wasUpdatedAtPrison(createReviewConversationRequest.prisonId)
+      .wasUpdatedAfter(initialDateTime)
+      .wasUpdatedBy(createUsername)
+      .hasUpdatedByDisplayName(createDisplayName)
+  }
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateConversationTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateConversationTest.kt
@@ -18,13 +18,13 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 
 class UpdateConversationTest : IntegrationTestBase() {
   companion object {
-    private const val URI_TEMPLATE = "/conversations/{prisonNumber}/{conversationReference}"
+    private const val URI_TEMPLATE = "/conversations/{conversationReference}"
   }
 
   @Test
   fun `should return unauthorized given no bearer token`() {
     webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
+      .uri(URI_TEMPLATE, aValidReference())
       .contentType(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus()
@@ -34,7 +34,7 @@ class UpdateConversationTest : IntegrationTestBase() {
   @Test
   fun `should return forbidden given bearer token with view only role`() {
     webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
+      .uri(URI_TEMPLATE, aValidReference())
       .withBody(aValidCreateReviewConversationRequest())
       .bearerToken(aValidTokenWithViewAuthority(privateKey = keyPair.private))
       .contentType(MediaType.APPLICATION_JSON)
@@ -47,7 +47,7 @@ class UpdateConversationTest : IntegrationTestBase() {
   fun `should fail to update Conversation given null fields`() {
     // When
     val response = webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
+      .uri(URI_TEMPLATE, aValidReference())
       .bodyValue(
         """
           { }
@@ -70,12 +70,11 @@ class UpdateConversationTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to update Conversation given conversation does not exist`() {
-    val prisonNumber = aValidPrisonNumber()
     val conversationReference = aValidReference()
 
     // When
     val response = webTestClient.put()
-      .uri(URI_TEMPLATE, prisonNumber, conversationReference)
+      .uri(URI_TEMPLATE, conversationReference)
       .withBody(aValidUpdateConversationRequest())
       .bearerToken(aValidTokenWithEditAuthority(privateKey = keyPair.private))
       .contentType(MediaType.APPLICATION_JSON)
@@ -121,7 +120,7 @@ class UpdateConversationTest : IntegrationTestBase() {
     val createdConversation = conversationRepository.findAllByPrisonNumber(prisonNumber).first()
 
     webTestClient.put()
-      .uri(URI_TEMPLATE, prisonNumber, createdConversation.reference)
+      .uri(URI_TEMPLATE, createdConversation.reference)
       .withBody(updateConversationRequest)
       .bearerToken(
         aValidTokenWithEditAuthority(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/conversation/ConversationEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/conversation/ConversationEntityMapper.kt
@@ -36,5 +36,7 @@ interface ConversationEntityMapper {
   @ExcludeReferenceField
   @Mapping(target = "note.content", source = "noteContent")
   @Mapping(target = "note.updatedAtPrison", source = "prisonId")
+  @Mapping(target = "type", ignore = true)
+  @Mapping(target = "prisonNumber", ignore = true)
   fun updateEntityFromDto(@MappingTarget conversationEntity: ConversationEntity, updateConversationDto: UpdateConversationDto)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ConversationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ConversationController.kt
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -41,7 +42,7 @@ class ConversationController(
     conversationService.createConversation(conversationMapper.toCreateConversationDto(request, prisonNumber))
   }
 
-  @PutMapping("/{prisonNumber}/{conversationReference}")
+  @PutMapping("/{conversationReference}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @PreAuthorize(HAS_EDIT_AUTHORITY)
   @Transactional
@@ -49,9 +50,18 @@ class ConversationController(
     @Valid
     @RequestBody
     request: UpdateConversationRequest,
-    @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
     @PathVariable conversationReference: UUID,
   ) {
     conversationService.updateConversation(conversationMapper.toUpdateConversationDto(request, conversationReference))
+  }
+
+  @GetMapping("/{conversationReference}")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize(HAS_VIEW_AUTHORITY)
+  @Transactional
+  fun getConversation(
+    @PathVariable conversationReference: UUID,
+  ) = with(conversationService.getConversation(conversationReference)) {
+    conversationMapper.fromDomainToModel(this)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/conversation/ConversationsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/conversation/ConversationsResourceMapper.kt
@@ -2,13 +2,24 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.conversation.Conversation
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.conversation.dto.CreateConversationDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.conversation.dto.UpdateConversationDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ConversationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateConversationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateConversationRequest
+import java.time.Instant
 import java.util.UUID
 
-@Mapper()
+@Mapper(
+  uses = [
+    InstantMapper::class,
+  ],
+  imports = [
+    Instant::class,
+  ],
+)
 interface ConversationsResourceMapper {
   @Mapping(source = "request.prisonId", target = "note.prisonId")
   @Mapping(source = "request.note", target = "note.content")
@@ -16,4 +27,15 @@ interface ConversationsResourceMapper {
 
   @Mapping(source = "request.note", target = "noteContent")
   fun toUpdateConversationDto(request: UpdateConversationRequest, reference: UUID): UpdateConversationDto
+
+  @Mapping(source = "note.content", target = "note")
+  @Mapping(source = "note.createdBy", target = "createdBy")
+  @Mapping(source = "note.createdByDisplayName", target = "createdByDisplayName")
+  @Mapping(source = "note.createdAt", target = "createdAt")
+  @Mapping(source = "note.createdAtPrison", target = "createdAtPrison")
+  @Mapping(source = "note.lastUpdatedBy", target = "updatedBy")
+  @Mapping(source = "note.lastUpdatedByDisplayName", target = "updatedByDisplayName")
+  @Mapping(source = "note.lastUpdatedAt", target = "updatedAt")
+  @Mapping(source = "note.lastUpdatedAtPrison", target = "updatedAtPrison")
+  fun fromDomainToModel(conversation: Conversation): ConversationResponse
 }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -314,7 +314,7 @@ paths:
           $ref: '#/components/responses/404ErrorResponse'
       operationId: get-prisoner-conversations
 
-  '/conversations/{prisonNumber}/${conversationReference}':
+  '/conversations/${conversationReference}':
     parameters:
       - $ref: "#/components/parameters/prisonNumberPathParameter"
       - name: conversationReference
@@ -1599,6 +1599,18 @@ components:
           type: string
           description: The identifier of the prison that the prisoner was resident at when this resource was updated.
           example: 'BXI'
+      required:
+        - reference
+        - prisonNumber
+        - note
+        - createdBy
+        - createdByDisplayName
+        - createdAt
+        - createdAtPrison
+        - updatedBy
+        - updatedByDisplayName
+        - updatedAt
+        - updatedAtPrison
 
     ConversationsResponse:
       title: ConversationsResponse

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/conversation/ConversationResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/conversation/ConversationResourceMapperTest.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.conversation
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.conversation.aValidConversation
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.conversation.aValidConversationNote
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.conversation.aValidConversationResponse
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+internal class ConversationResourceMapperTest {
+  @InjectMocks
+  private lateinit var mapper: ConversationsResourceMapperImpl
+
+  @Mock
+  private lateinit var instantMapper: InstantMapper
+
+  @Test
+  fun `should map from domain to model`() {
+    // Given
+    val reference = UUID.randomUUID()
+    val prisonNumber = aValidPrisonNumber()
+    val noteContent = "Pay close attention to John's behaviour."
+    val createUsername = "auser_gen"
+    val createDisplayName = "Albert User"
+    val createPrison = "BXI"
+    val updateUsername = "buser_gen"
+    val updateDisplayName = "Bernie User"
+    val updatePrison = "MDI"
+    val expectedDateTime = OffsetDateTime.now()
+    val conversation = aValidConversation(
+      reference = reference,
+      prisonNumber = prisonNumber,
+      note = aValidConversationNote(
+        content = noteContent,
+        createdBy = createUsername,
+        createdByDisplayName = createDisplayName,
+        createdAt = Instant.now(),
+        createdAtPrison = createPrison,
+        lastUpdatedBy = updateUsername,
+        lastUpdatedByDisplayName = updateDisplayName,
+        lastUpdatedAt = Instant.now(),
+        lastUpdatedAtPrison = updatePrison,
+      ),
+    )
+    val expectedConversation = aValidConversationResponse(
+      reference = conversation.reference,
+      prisonNumber = conversation.prisonNumber,
+      note = noteContent,
+      createdBy = createUsername,
+      createdByDisplayName = createDisplayName,
+      createdAt = expectedDateTime,
+      updatedBy = updateUsername,
+      updatedByDisplayName = updateDisplayName,
+      updatedAt = expectedDateTime,
+      updatedAtPrison = updatePrison,
+    )
+    given(instantMapper.toOffsetDateTime(any())).willReturn(expectedDateTime)
+
+    // When
+    val actual = mapper.fromDomainToModel(conversation)
+
+    // Then
+    Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expectedConversation)
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/conversation/ConversationResponse.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/conversation/ConversationResponse.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.conversation
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ConversationResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidConversationResponse(
+  reference: UUID = UUID.randomUUID(),
+  prisonNumber: String = "A1234BC",
+  note: String = "Pay close attention to Peter's behaviour.",
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
+): ConversationResponse = ConversationResponse(
+  reference = reference,
+  prisonNumber = prisonNumber,
+  note = note,
+  createdBy = createdBy,
+  createdByDisplayName = createdByDisplayName,
+  createdAt = createdAt,
+  createdAtPrison = createdAtPrison,
+  updatedBy = updatedBy,
+  updatedByDisplayName = updatedByDisplayName,
+  updatedAt = updatedAt,
+  updatedAtPrison = updatedAtPrison,
+)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/conversation/ConversationResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/conversation/ConversationResponseAssert.kt
@@ -1,0 +1,134 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.conversation
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ConversationResponse
+import java.time.OffsetDateTime
+
+fun assertThat(actual: ConversationResponse?) = ConversationResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for [ConversationResponse]
+ */
+class ConversationResponseAssert(actual: ConversationResponse?) :
+  AbstractObjectAssert<ConversationResponseAssert, ConversationResponse?>(actual, ConversationResponseAssert::class.java) {
+
+  fun isForPrisonNumber(expected: String): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (prisonNumber != expected) {
+        failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  fun hasNoteContent(expected: String): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (note != expected) {
+        failWithMessage("Expected note to be $expected, but was $note")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun hasCreatedByDisplayName(expected: String): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAfter(dateTime: OffsetDateTime): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!createdAt.isAfter(dateTime)) {
+        failWithMessage("Expected createdAt to be after $dateTime, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAfter(dateTime: OffsetDateTime): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun hasUpdatedByDisplayName(expected: String): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): ConversationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+}


### PR DESCRIPTION
## Overview

Adds the implementation for the get conversation endpoint.

This PR also removes the `/{prisonNumber}` path param from the get and update conversation endpoints since it wasn't necessary.