### PR TITLE
NO_JIRA - fixed deprecated assertion method calls following update to hmpps spring-boot-gradle:6

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,6 +10,3 @@
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
-# Suppression for logback-classic and logback-core as we don't let third parties control our appenders.
-# See https://logback.qos.ch/news.html#1.3.12 for further information.
-CVE-2023-6378

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ dependencies {
   integrationTestImplementation(testFixtures(project("domain:timeline")))
 
   // Test fixtures dependencies
-  testFixturesImplementation("org.assertj:assertj-core")
+  testFixturesImplementation("org.assertj:assertj-core:3.26.0")
   testFixturesImplementation("org.springframework.boot:spring-boot-starter-test")
   testFixturesImplementation("io.projectreactor:reactor-core")
   testFixturesImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/conversation/service/ConversationServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/conversation/service/ConversationServiceTest.kt
@@ -61,10 +61,12 @@ class ConversationServiceTest {
     given(persistenceAdapter.getConversation(any())).willReturn(null)
 
     // When
-    val exception = catchThrowableOfType(
-      { service.getConversation(conversationReference, prisonNumber) },
-      PrisonerConversationNotFoundException::class.java,
-    )
+    val exception = catchThrowableOfType(PrisonerConversationNotFoundException::class.java) {
+      service.getConversation(
+        conversationReference,
+        prisonNumber,
+      )
+    }
 
     // Then
     assertThat(exception.conversationReference).isEqualTo(conversationReference)
@@ -183,10 +185,12 @@ class ConversationServiceTest {
     given(persistenceAdapter.updateConversation(any())).willReturn(null)
 
     // When
-    val exception = catchThrowableOfType(
-      { service.updateConversation(updateConversationDto, prisonNumber) },
-      PrisonerConversationNotFoundException::class.java,
-    )
+    val exception = catchThrowableOfType(PrisonerConversationNotFoundException::class.java) {
+      service.updateConversation(
+        updateConversationDto,
+        prisonNumber,
+      )
+    }
 
     // Then
     assertThat(exception.conversationReference).isEqualTo(conversationReference)

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionServiceTest.kt
@@ -65,10 +65,8 @@ class InductionServiceTest {
       given(persistenceAdapter.getInduction(any())).willReturn(induction)
 
       // When
-      val exception = catchThrowableOfType(
-        { service.createInduction(createInductionDto) },
-        InductionAlreadyExistsException::class.java,
-      )
+      val exception =
+        catchThrowableOfType(InductionAlreadyExistsException::class.java) { service.createInduction(createInductionDto) }
 
       // Then
       assertThat(exception.message).isEqualTo("An Induction already exists for prisoner $PRISON_NUMBER")
@@ -99,10 +97,8 @@ class InductionServiceTest {
       given(persistenceAdapter.getInduction(any())).willReturn(null)
 
       // When
-      val exception = catchThrowableOfType(
-        { service.getInductionForPrisoner(PRISON_NUMBER) },
-        InductionNotFoundException::class.java,
-      )
+      val exception =
+        catchThrowableOfType(InductionNotFoundException::class.java) { service.getInductionForPrisoner(PRISON_NUMBER) }
 
       // Then
       assertThat(exception).hasMessage("Induction not found for prisoner [$PRISON_NUMBER]")
@@ -136,10 +132,8 @@ class InductionServiceTest {
       given(persistenceAdapter.updateInduction(any())).willReturn(null)
 
       // When
-      val exception = catchThrowableOfType(
-        { service.updateInduction(updateInductionDto) },
-        InductionNotFoundException::class.java,
-      )
+      val exception =
+        catchThrowableOfType(InductionNotFoundException::class.java) { service.updateInduction(updateInductionDto) }
 
       // Then
       assertThat(exception).hasMessage("Induction not found for prisoner [$PRISON_NUMBER]")

--- a/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/GoalTest.kt
+++ b/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/GoalTest.kt
@@ -103,26 +103,23 @@ class GoalTest {
     val steps = emptyList<Step>()
 
     // When
-    val exception: InvalidGoalException = catchThrowableOfType(
-      {
-        Goal(
-          reference = goalReference,
-          title = "Improve woodworking skills",
-          targetCompletionDate = LocalDate.now().plusMonths(6),
-          status = ACTIVE,
-          createdBy = "bjones_gen",
-          createdByDisplayName = "Barry Jones",
-          createdAt = Instant.now(),
-          createdAtPrison = "BXI",
-          lastUpdatedBy = "bjones_gen",
-          lastUpdatedByDisplayName = "Barry Jones",
-          lastUpdatedAt = Instant.now(),
-          lastUpdatedAtPrison = "BXI",
-          steps = steps,
-        )
-      },
-      InvalidGoalException::class.java,
-    )
+    val exception: InvalidGoalException = catchThrowableOfType(InvalidGoalException::class.java) {
+      Goal(
+        reference = goalReference,
+        title = "Improve woodworking skills",
+        targetCompletionDate = LocalDate.now().plusMonths(6),
+        status = ACTIVE,
+        createdBy = "bjones_gen",
+        createdByDisplayName = "Barry Jones",
+        createdAt = Instant.now(),
+        createdAtPrison = "BXI",
+        lastUpdatedBy = "bjones_gen",
+        lastUpdatedByDisplayName = "Barry Jones",
+        lastUpdatedAt = Instant.now(),
+        lastUpdatedAtPrison = "BXI",
+        steps = steps,
+      )
+    }
 
     // Then
     assertThat(exception.message).isEqualTo("Cannot create Goal with reference [$goalReference]. At least one Step is required.")

--- a/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/ActionPlanServiceTest.kt
+++ b/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/ActionPlanServiceTest.kt
@@ -65,10 +65,9 @@ class ActionPlanServiceTest {
       val createActionPlanDto = aValidCreateActionPlanDto(prisonNumber = prisonNumber)
 
       // When
-      val exception = catchThrowableOfType(
-        { service.createActionPlan(createActionPlanDto) },
-        ActionPlanAlreadyExistsException::class.java,
-      )
+      val exception = catchThrowableOfType(ActionPlanAlreadyExistsException::class.java) {
+        service.createActionPlan(createActionPlanDto)
+      }
 
       // Then
       assertThat(exception)

--- a/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalServiceTest.kt
+++ b/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalServiceTest.kt
@@ -172,10 +172,8 @@ class GoalServiceTest {
     given(goalPersistenceAdapter.getGoal(any(), any())).willReturn(null)
 
     // When
-    val exception = catchThrowableOfType(
-      { service.getGoal(prisonNumber, goalReference) },
-      GoalNotFoundException::class.java,
-    )
+    val exception =
+      catchThrowableOfType(GoalNotFoundException::class.java) { service.getGoal(prisonNumber, goalReference) }
 
     // Then
     assertThat(exception).hasMessage("Goal with reference [$goalReference] for prisoner [$prisonNumber] not found")
@@ -216,10 +214,8 @@ class GoalServiceTest {
     val updatedGoal = aValidUpdateGoalDto(reference = goalReference)
 
     // When
-    val exception = catchThrowableOfType(
-      { service.updateGoal(prisonNumber, updatedGoal) },
-      GoalNotFoundException::class.java,
-    )
+    val exception =
+      catchThrowableOfType(GoalNotFoundException::class.java) { service.updateGoal(prisonNumber, updatedGoal) }
 
     // Then
     assertThat(exception).hasMessage("Goal with reference [$goalReference] for prisoner [$prisonNumber] not found")

--- a/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/service/TimelineServiceTest.kt
+++ b/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/service/TimelineServiceTest.kt
@@ -100,10 +100,8 @@ class TimelineServiceTest {
     given(prisonTimelineService.getPrisonTimelineEvents(any())).willReturn(emptyList())
 
     // When
-    val exception = catchThrowableOfType(
-      { service.getTimelineForPrisoner(PRISON_NUMBER) },
-      TimelineNotFoundException::class.java,
-    )
+    val exception =
+      catchThrowableOfType(TimelineNotFoundException::class.java) { service.getTimelineForPrisoner(PRISON_NUMBER) }
 
     // Then
     assertThat(exception).hasMessage("Timeline not found for prisoner [$PRISON_NUMBER]")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiClient.kt
@@ -30,7 +30,7 @@ class PrisonApiClient(
       }
       .block()
 
-    val numberOfPeriods = prisonerInPrisonSummary?.prisonPeriod?.size ?: 0
+    val numberOfPeriods = prisonerInPrisonSummary!!.prisonPeriod?.size ?: 0
     log.info { "Retrieved $numberOfPeriods prison periods from the prison-api for prisoner $prisonNumber" }
     return prisonApiMapper.toPrisonMovementEvents(prisonNumber, prisonerInPrisonSummary)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
@@ -51,10 +51,12 @@ class JpaGoalPersistenceAdapterTest {
       given(actionPlanRepository.findByPrisonNumber(any())).willReturn(null)
 
       // When
-      val exception = catchThrowableOfType(
-        { persistenceAdapter.createGoals(prisonNumber, createGoalDtos) },
-        ActionPlanNotFoundException::class.java,
-      )
+      val exception = catchThrowableOfType(ActionPlanNotFoundException::class.java) {
+        persistenceAdapter.createGoals(
+          prisonNumber,
+          createGoalDtos,
+        )
+      }
 
       // Then
       assertThat(exception).hasMessage("Unable to find ActionPlan for prisoner [$prisonNumber]")
@@ -181,14 +183,17 @@ class JpaGoalPersistenceAdapterTest {
       val prisonNumber = aValidPrisonNumber()
       val reference = UUID.randomUUID()
 
-      val goalEntity = aValidGoalEntity(reference = reference, title = "Original goal title", createdBy = "USER1", updatedBy = "USER1")
+      val goalEntity =
+        aValidGoalEntity(reference = reference, title = "Original goal title", createdBy = "USER1", updatedBy = "USER1")
       val actionPlanEntity = aValidActionPlanEntity(prisonNumber = prisonNumber, goals = listOf(goalEntity))
       given(actionPlanRepository.findByPrisonNumber(any())).willReturn(actionPlanEntity)
 
-      val persistedGoalEntity = aValidGoalEntity(reference = reference, title = "Updated goal title", createdBy = "USER1", updatedBy = "USER2")
+      val persistedGoalEntity =
+        aValidGoalEntity(reference = reference, title = "Updated goal title", createdBy = "USER1", updatedBy = "USER2")
       given(goalRepository.saveAndFlush(any<GoalEntity>())).willReturn(persistedGoalEntity)
 
-      val expectedDomainGoal = aValidGoal(reference = reference, title = "Updated goal title", createdBy = "USER1", lastUpdatedBy = "USER2")
+      val expectedDomainGoal =
+        aValidGoal(reference = reference, title = "Updated goal title", createdBy = "USER1", lastUpdatedBy = "USER2")
       given(goalMapper.fromEntityToDomain(any())).willReturn(expectedDomainGoal)
 
       val goalWithProposedUpdates = aValidUpdateGoalDto(reference = reference, title = "Updated goal title")

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/JwtAccessTokenBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/JwtAccessTokenBuilder.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi
 
 import io.jsonwebtoken.Jwts
-import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.Jwts.SIG
 import java.security.PrivateKey
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -52,8 +52,8 @@ fun buildAccessToken(
   privateKey: PrivateKey,
 ): String =
   Jwts.builder()
-    .setSubject(username)
-    .addClaims(
+    .subject(username)
+    .claims(
       mapOf(
         "authorities" to roles,
         "user_name" to username,
@@ -63,7 +63,7 @@ fun buildAccessToken(
         "client_id" to clientId,
       ),
     )
-    .setIssuedAt(Date.from(Instant.now()))
-    .setExpiration(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
-    .signWith(privateKey, SignatureAlgorithm.RS256)
+    .issuedAt(Date.from(Instant.now()))
+    .expiration(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+    .signWith(privateKey, SIG.RS256)
     .compact()


### PR DESCRIPTION
This PR fixes a load of build warnings about the use of a deprecated version of the assertJ method `catchThrowableOfType`
This has come about since the recent update to HMPPS `spring-boot-gradle-plugin:6.0.0` which presumably brings with it a later version of Spring which in turn brings a later version of assertJ as a transitive dependency 🤷‍♂️ 

Anyway, this PR changes the previous use of `catchThrowableOfType` to a different method overload (same method, it's just the args are in a different order)

It also commits the change to `.trivyignore` which again is the result of updating to HMPPS `spring-boot-gradle-plugin:6.0.0` 

And also some changes to the use of some JWTS code, again based on updating `spring-boot-gradle-plugin` which brings in a newer version of JWTS which deprecates some of the stuff we were using previously!