### PR TITLE
NO_JIRA - Add `prisons` group to `dev` allowlist

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,6 +18,11 @@ generic-service:
     PRISON_API_URL: https://prison-api-dev.prison.service.justice.gov.uk
     SPRING_PROFILES_ACTIVE: dev
 
+  allowlist:
+    groups:
+      - internal
+      - prisons
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:


### PR DESCRIPTION
PR to add the `prisons` group to the `dev` allowlist (dev only)

This is so that a HMPPS analytics team can access the swagger spec for some analysis they are doing. They do not use developer spec laptops, and instead use HMPPS "prison" spec devices. The user is question is coming in on IP `moj-official-ark-c-expo-e: "51.149.249.0/29"` which is part of the `prisons` predefined IP range group.