### PR TITLE
RR-759: Prevent session creation on auth failure

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/ResourceServerConfiguration.kt
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.invoke
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache
+import org.springframework.security.web.savedrequest.RequestCache
 
 @Configuration
 @EnableWebSecurity
@@ -39,5 +41,12 @@ class ResourceServerConfiguration {
     }
 
     return http.build()
+  }
+
+  @Bean
+  fun httpSessionRequestCache(): RequestCache {
+    val httpSessionRequestCache = HttpSessionRequestCache()
+    httpSessionRequestCache.setCreateSessionAllowed(false)
+    return httpSessionRequestCache
   }
 }


### PR DESCRIPTION
APSEC reported that a JSESSIONID cookie is being set in some scenarios.  We make no use of the session and therefore session hijack is not an issue, however it could conceivably be a denial of service attack vector.

If unauthenticated, Spring security was rejecting the request and creating the session so that it could store the original URL and redirect back to it if this was part of an authentication flow. That is something not supported in our auth model and can be disabled.