### PR TITLE
RR-826: Keep type on controller for swagger gen

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/exception/ReturnAnErrorException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/exception/ReturnAnErrorException.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.exception
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
+
+class ReturnAnErrorException(val errorResponse: ErrorResponse) : Exception()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GlobalExceptionHandler.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanAlread
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalNotFoundException
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineNotFoundException
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.exception.ReturnAnErrorException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 
 private val log = KotlinLogging.logger {}
@@ -131,6 +132,11 @@ class GlobalExceptionHandler(
           userMessage = e.message,
         ),
       )
+  }
+
+  @ExceptionHandler(ReturnAnErrorException::class)
+  fun handleReturnAnErrorException(e: ReturnAnErrorException): ResponseEntity<ErrorResponse> {
+    return ResponseEntity.status(e.errorResponse.status).body(e.errorResponse)
   }
 
   /**


### PR DESCRIPTION
Change to throw exception for unhappy paths and return the type directly. This will fix the swagger docs without the need for adding response type annotations.