### PR TITLE
RR-880 - getGoals now supports multiple statuses as a query string parameter filter

### DIFF
--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/GetGoalsDto.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/GetGoalsDto.kt
@@ -2,4 +2,4 @@ package uk.gov.justice.digital.hmpps.domain.personallearningplan.dto
 
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus
 
-data class GetGoalsDto(val prisonNumber: String, val status: GoalStatus?)
+data class GetGoalsDto(val prisonNumber: String, val statuses: Set<GoalStatus>?)

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalService.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalService.kt
@@ -64,7 +64,7 @@ class GoalService(
 
   fun getGoals(getGoalsDto: GetGoalsDto): GetGoalsResult {
     return goalPersistenceAdapter.getGoals(getGoalsDto.prisonNumber)
-      ?.filter { getGoalsDto.status == null || getGoalsDto.status == it.status }
+      ?.filter { getGoalsDto.statuses.isNullOrEmpty() || getGoalsDto.statuses.contains(it.status) }
       ?.let { GetGoalsResult.Success(it) }
       ?: GetGoalsResult.PrisonerNotFound(getGoalsDto.prisonNumber)
   }

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalService.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalService.kt
@@ -64,7 +64,7 @@ class GoalService(
 
   fun getGoals(getGoalsDto: GetGoalsDto): GetGoalsResult {
     return goalPersistenceAdapter.getGoals(getGoalsDto.prisonNumber)
-      ?.filter { getGoalsDto.statuses.isNullOrEmpty() || getGoalsDto.statuses.contains(it.status) }
+      ?.filter { getGoalsDto.statuses.isNullOrEmpty() || it.status in getGoalsDto.statuses }
       ?.let { GetGoalsResult.Success(it) }
       ?: GetGoalsResult.PrisonerNotFound(getGoalsDto.prisonNumber)
   }

--- a/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalServiceTest.kt
+++ b/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalServiceTest.kt
@@ -424,14 +424,35 @@ class GoalServiceTest {
       verify(goalPersistenceAdapter).getGoals(prisonNumber)
     }
 
-    @ParameterizedTest
-    @EnumSource(GoalStatus::class)
-    fun `should return only goals matching status if a filter is set`(status: GoalStatus) {
+    @Test
+    fun `should return all goals given empty filter`() {
       // Given
       given(goalPersistenceAdapter.getGoals(any())).willReturn(listOf(activeGoal, archivedGoal, completedGoal))
 
       // When
-      val actual = service.getGoals(GetGoalsDto(prisonNumber, status))
+      val actual = service.getGoals(GetGoalsDto(prisonNumber, emptySet()))
+
+      // Then
+      assertThat(actual).isEqualTo(
+        GetGoalsResult.Success(
+          listOf(
+            activeGoal,
+            archivedGoal,
+            completedGoal,
+          ),
+        ),
+      )
+      verify(goalPersistenceAdapter).getGoals(prisonNumber)
+    }
+
+    @ParameterizedTest
+    @EnumSource(GoalStatus::class)
+    fun `should return only goals matching status if a filter is set with a single status`(status: GoalStatus) {
+      // Given
+      given(goalPersistenceAdapter.getGoals(any())).willReturn(listOf(activeGoal, archivedGoal, completedGoal))
+
+      // When
+      val actual = service.getGoals(GetGoalsDto(prisonNumber, setOf(status)))
 
       // Then
       assertThat(actual).isInstanceOf(GetGoalsResult.Success::class.java)

--- a/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalServiceTest.kt
+++ b/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalServiceTest.kt
@@ -463,6 +463,23 @@ class GoalServiceTest {
     }
 
     @Test
+    fun `should return only goals matching status if a filter is set with multiple statuses`() {
+      // Given
+      given(goalPersistenceAdapter.getGoals(any())).willReturn(listOf(activeGoal, archivedGoal, completedGoal))
+
+      // When
+      val actual = service.getGoals(GetGoalsDto(prisonNumber, setOf(GoalStatus.ACTIVE, GoalStatus.COMPLETED)))
+
+      // Then
+      assertThat(actual).isInstanceOf(GetGoalsResult.Success::class.java)
+      val goals = (actual as GetGoalsResult.Success).goals
+      assertThat(goals).hasSize(2)
+      assertThat(goals[0].reference).isEqualTo(activeGoal.reference)
+      assertThat(goals[1].reference).isEqualTo(completedGoal.reference)
+      verify(goalPersistenceAdapter).getGoals(prisonNumber)
+    }
+
+    @Test
     fun `should return an empty list if the prisoner has no matching goals`() {
       // Given
       given(goalPersistenceAdapter.getGoals(any())).willReturn(emptyList())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -129,10 +129,10 @@ class GoalController(
   @Transactional
   fun getGoals(
     @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
-    @RequestParam(required = false) status: GoalStatus?,
+    @RequestParam(required = false, name = "status") statuses: Set<GoalStatus>?,
   ): GetGoalsResponse {
     return goalService.getGoals(
-      GetGoalsDto(prisonNumber, status?.let { goalResourceMapper.fromModelToDto(status) }),
+      GetGoalsDto(prisonNumber, statuses?.map { status -> goalResourceMapper.fromModelToDto(status) }?.toSet()),
     ).let { result ->
       when (result) {
         is GetGoalsResult.Success -> goalResourceMapper.fromDomainToModel(result)

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.12.1'
+  version: '1.13.0'
   description: Education and Work Plan API
   contact:
     name: Learning and Work Progress team
@@ -71,11 +71,26 @@ paths:
     parameters:
       - $ref: "#/components/parameters/prisonNumberPathParameter"
     get:
-      summary: Lists the Goals for a prisoner
-      description: Lists the Goals for a prisoner with an optional filter on Goal status
+      summary: Lists the Goals for a prisoner with an optional filter on Goal status
+      description: | 
+        Returns Goals for the specified prisoner, optionally filtered on Goal status with the `status` query string parameter.  
+        The optional `status` query string parameter can be one or more of the supported Goal statuses (see the `GoalStatus` schema definition for valid statuses).  
+        If specifying multiple statuses these can either be a comma delimited list in a single `status` query string parameter, or multiple instances of the `status` query string parameter can be used.    
+        
+        * If the `status` query string parameter is used and the prisoner has Goals but none that match the specified status(es) a 200 response is returned with an empty `goals` collection.  
+        * If the specified prisoner has no Goals at all, irrespective of whether the `status` query string parameter was used, a 404 response is returned.  
+        * If the `status` query string parameter is used with one or more invalid values a 400 response is returned (see the `GoalStatus` schema definition for valid statuses). 
+
       parameters:
         - name: status
-          description: Only goals with this status will be returned
+          description: Returned Goals will be filtered by the specified Goal status. Multiple values can be specified by comma delimiting them.
+          examples:
+            Single value:
+              description: A single status value
+              value: ACTIVE
+            Multiple values:
+              description: Multiple status values specified as a comma delimited list
+              value: ACTIVE,COMPLETED
           schema:
             $ref: '#/components/schemas/GoalStatus'
           in: query

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalControllerTest.kt
@@ -57,7 +57,7 @@ class GoalControllerTest {
   }
 
   @Test
-  fun `should get goals successfully with a filter`() {
+  fun `should get goals successfully with a filter containing a single value`() {
     val aValidGoalDto = aValidGoal()
     val aValidGoalResponse = aValidGoalResponse()
     given(goalService.getGoals(any())).willReturn(GetGoalsResult.Success(listOf(aValidGoalDto)))
@@ -70,10 +70,35 @@ class GoalControllerTest {
       ),
     )
 
-    val response = controller.getGoals(prisonNumber, GoalStatus.ACTIVE)
+    val response = controller.getGoals(prisonNumber, setOf(GoalStatus.ACTIVE))
 
     assertThat(response).isEqualTo(GetGoalsResponse(listOf(aValidGoalResponse)))
-    verify(goalService).getGoals(GetGoalsDto(prisonNumber, GoalStatusDto.ACTIVE))
+    verify(goalService).getGoals(GetGoalsDto(prisonNumber, setOf(GoalStatusDto.ACTIVE)))
+  }
+
+  @Test
+  fun `should get goals successfully with a filter containing multiple values`() {
+    val anActiveGoalDto = aValidGoal(status = GoalStatusDto.ACTIVE)
+    val anArchivedGoalDto = aValidGoal(status = GoalStatusDto.ARCHIVED)
+    given(goalService.getGoals(any())).willReturn(GetGoalsResult.Success(listOf(anActiveGoalDto, anArchivedGoalDto)))
+
+    val anActiveGoalResponse = aValidGoalResponse(status = GoalStatus.ACTIVE)
+    val anArchivedGoalResponse = aValidGoalResponse(status = GoalStatus.ARCHIVED)
+    given(goalResourceMapper.fromDomainToModel(any<Goal>())).willReturn(anActiveGoalResponse, anArchivedGoalResponse)
+
+    given(goalResourceMapper.fromDomainToModel(any<GetGoalsResult.Success>())).willReturn(
+      GetGoalsResponse(
+        listOf(
+          anActiveGoalResponse,
+          anArchivedGoalResponse,
+        ),
+      ),
+    )
+
+    val response = controller.getGoals(prisonNumber, setOf(GoalStatus.ACTIVE, GoalStatus.ARCHIVED))
+
+    assertThat(response).isEqualTo(GetGoalsResponse(listOf(anActiveGoalResponse, anArchivedGoalResponse)))
+    verify(goalService).getGoals(GetGoalsDto(prisonNumber, setOf(GoalStatusDto.ACTIVE, GoalStatusDto.ARCHIVED)))
   }
 
   @Test


### PR DESCRIPTION
This PR introduces support for the getGoals API endpoint to specify zero, one or more statuses on the `status` query string parameter.

![Screenshot 2024-07-17 at 13 14 12](https://github.com/user-attachments/assets/4aaf4321-3b4f-412d-9668-781bab5cc0b9)
