### PR TITLE
NO-JIRA - Change the start time of the generic-data-analytics-extractor job to a time when the database is up!

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -30,3 +30,4 @@ generic-prometheus-alerts:
 
 generic-data-analytics-extractor:
   serviceAccountName: hmpps-education-and-work-plan-dev-to-ap-s3
+  cronJobSchedule: '00 7 * * 1-5' # Start at 7am UTC Monday-Friday to allow for the fact that we terminate the resources (inc. RDS) overnight and all weekend in the dev env (see scheduledDowntime above)

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,3 +24,4 @@ generic-prometheus-alerts:
 
 generic-data-analytics-extractor:
   serviceAccountName: hmpps-education-and-work-plan-preprod-to-ap-s3
+  cronJobSchedule: '00 7 * * 1-5' # Start at 7am UTC Monday-Friday to allow for the fact that we terminate the resources (inc. RDS) overnight and all weekend in the preprod env (see scheduledDowntime above)


### PR DESCRIPTION
This PR changes the start time of the `generic-data-analytics-extractor` job in `dev` and `preprod` to 07:00 Monday-Friday which is a time when the database is up!
Previously the job ran at 01:00 7 days a week. However in `dev` and `preprod` we terminate resources (like the database!) out of working hours to save a few pennies, so the job could never attach to the database! Doh! 🤣 

This does not change the time in `prod`, which is still set to run at 01:00 every day.

See discussion here: https://mojdt.slack.com/archives/C05BDTUL64E/p1721288755297809

