### PR TITLE
Tidy test warnings re: InductionResponse

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType.APPLICATION_JSON
@@ -101,16 +100,13 @@ class GetInductionTest : IntegrationTestBase() {
       .wasUpdatedByDisplayName("Alex Smith")
       .wasCreatedAtPrison("BXI")
       .wasUpdatedAtPrison("BXI")
-
-    with(actual) {
-      assertThat(workOnRelease).isEquivalentTo(expectedWorkOnRelease)
-      assertThat(previousQualifications).isEquivalentTo(expectedPreviousQualifications)
-      assertThat(previousTraining).isEquivalentTo(expectedPreviousTraining)
-      assertThat(previousWorkExperiences).isNull()
-      assertThat(inPrisonInterests).isEquivalentTo(expectedInPrisonInterests)
-      assertThat(personalSkillsAndInterests).isNull()
-      assertThat(futureWorkInterests).isNull()
-    }
+      .workOnRelease { it.isEquivalentTo(expectedWorkOnRelease) }
+      .previousQualifications { it.isEquivalentTo(expectedPreviousQualifications) }
+      .previousTraining { it.isEquivalentTo(expectedPreviousTraining) }
+      .previousWorkExperiences { it.isNull() }
+      .inPrisonInterests { it.isEquivalentTo(expectedInPrisonInterests) }
+      .personalSkillsAndInterests { it.isNull() }
+      .futureWorkInterests { it.isNull() }
   }
 
   @Test
@@ -151,15 +147,12 @@ class GetInductionTest : IntegrationTestBase() {
       .wasUpdatedByDisplayName("Alex Smith")
       .wasCreatedAtPrison("BXI")
       .wasUpdatedAtPrison("BXI")
-
-    with(actual) {
-      assertThat(workOnRelease).isEquivalentTo(expectedWorkOnRelease)
-      assertThat(previousQualifications).isEquivalentTo(expectedPreviousQualifications)
-      assertThat(previousTraining).isEquivalentTo(expectedPreviousTraining)
-      assertThat(previousWorkExperiences).isEquivalentTo(expectedPreviousWorkExperiences)
-      assertThat(inPrisonInterests).isNull()
-      assertThat(personalSkillsAndInterests).isEquivalentTo(expectedSkillsAndInterests)
-      assertThat(futureWorkInterests).isEquivalentTo(expectedFutureWorkInterests)
-    }
+      .workOnRelease { it.isEquivalentTo(expectedWorkOnRelease) }
+      .previousQualifications { it.isEquivalentTo(expectedPreviousQualifications) }
+      .previousTraining { it.isEquivalentTo(expectedPreviousTraining) }
+      .previousWorkExperiences { it.isEquivalentTo(expectedPreviousWorkExperiences) }
+      .inPrisonInterests { it.isNull() }
+      .personalSkillsAndInterests { it.isEquivalentTo(expectedSkillsAndInterests) }
+      .futureWorkInterests { it.isEquivalentTo(expectedFutureWorkInterests) }
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt
@@ -136,11 +136,11 @@ class GetTimelineTest : IntegrationTestBase() {
         .returnResult(TimelineResponse::class.java)
 
       // Then
-      val actual = response.responseBody.blockFirst()
-      assertThat(actual.events).hasSize(4)
+      val actual = response.responseBody.blockFirst()!!
       val actionPlanCreatedCorrelationId = actual.events[3].correlationId
       assertThat(actual)
         .isForPrisonNumber(prisonNumber)
+        .hasNumberOfEvents(4)
         .event(1) {
           it.hasSourceReference("1")
             .hasEventType(TimelineEventType.PRISON_ADMISSION)
@@ -238,12 +238,12 @@ class GetTimelineTest : IntegrationTestBase() {
         .returnResult(TimelineResponse::class.java)
 
       // Then
-      val actual = response.responseBody.blockFirst()
-      assertThat(actual.events).hasSize(8)
+      val actual = response.responseBody.blockFirst()!!
       val actionPlanCreatedCorrelationId = actual.events[2].correlationId
       val goalUpdatedCorrelationId = actual.events[6].correlationId
       assertThat(actual)
         .isForPrisonNumber(prisonNumber)
+        .hasNumberOfEvents(8)
         .event(1) {
           it.hasSourceReference("1")
             .hasEventType(TimelineEventType.PRISON_ADMISSION)
@@ -337,10 +337,10 @@ class GetTimelineTest : IntegrationTestBase() {
       .returnResult(TimelineResponse::class.java)
 
     // Then
-    val actual = response.responseBody.blockFirst()
-    assertThat(actual.events).hasSize(1)
+    val actual = response.responseBody.blockFirst()!!
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
+      .hasNumberOfEvents(1)
       .event(1) {
         it.hasSourceReference("1")
           .hasEventType(TimelineEventType.PRISON_ADMISSION)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/FutureWorkInterestsResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/FutureWorkInterestsResponseAssert.kt
@@ -1,0 +1,128 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.FutureWorkInterestsResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun assertThat(actual: FutureWorkInterestsResponse?) = FutureWorkInterestsResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [FutureWorkInterestsResponse].
+ */
+class FutureWorkInterestsResponseAssert(actual: FutureWorkInterestsResponse?) :
+  AbstractObjectAssert<FutureWorkInterestsResponseAssert, FutureWorkInterestsResponse?>(
+    actual,
+    FutureWorkInterestsResponseAssert::class.java,
+  ) {
+
+  fun hasReference(expected: UUID): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAfter(dateTime: OffsetDateTime): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!createdAt.isAfter(dateTime)) {
+        failWithMessage("Expected createdAt to be after $dateTime, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAfter(dateTime: OffsetDateTime): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedByDisplayName(expected: String): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedByDisplayName(expected: String): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): FutureWorkInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/InPrisonInterestsResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/InPrisonInterestsResponseAssert.kt
@@ -1,0 +1,128 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InPrisonInterestsResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun assertThat(actual: InPrisonInterestsResponse?) = InPrisonInterestsResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [InPrisonInterestsResponse].
+ */
+class InPrisonInterestsResponseAssert(actual: InPrisonInterestsResponse?) :
+  AbstractObjectAssert<InPrisonInterestsResponseAssert, InPrisonInterestsResponse?>(
+    actual,
+    InPrisonInterestsResponseAssert::class.java,
+  ) {
+
+  fun hasReference(expected: UUID): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAfter(dateTime: OffsetDateTime): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!createdAt.isAfter(dateTime)) {
+        failWithMessage("Expected createdAt to be after $dateTime, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAfter(dateTime: OffsetDateTime): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedByDisplayName(expected: String): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedByDisplayName(expected: String): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): InPrisonInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/InductionResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/InductionResponseAssert.kt
@@ -26,6 +26,7 @@ class InductionResponseAssert(actual: InductionResponse?) :
     }
     return this
   }
+
   fun wasCreatedAt(expected: OffsetDateTime): InductionResponseAssert {
     isNotNull
     with(actual!!) {
@@ -135,6 +136,84 @@ class InductionResponseAssert(actual: InductionResponse?) :
     isNotNull
     with(actual!!) {
       consumer.accept(assertThat(previousWorkExperiences))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the child [FutureWorkInterestsResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [FutureWorkInterestsResponseAssert].
+   * Returns this [InductionResponseAssert] to allow further chained assertions on the parent [InductionResponse]
+   */
+  fun futureWorkInterests(consumer: Consumer<FutureWorkInterestsResponseAssert>): InductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      consumer.accept(assertThat(futureWorkInterests))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the child [WorkOnReleaseResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [WorkOnReleaseResponseAssert].
+   * Returns this [InductionResponseAssert] to allow further chained assertions on the parent [InductionResponse]
+   */
+  fun workOnRelease(consumer: Consumer<WorkOnReleaseResponseAssert>): InductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      consumer.accept(assertThat(workOnRelease))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the child [PreviousTrainingResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [PreviousTrainingResponseAssert].
+   * Returns this [InductionResponseAssert] to allow further chained assertions on the parent [InductionResponse]
+   */
+  fun previousTraining(consumer: Consumer<PreviousTrainingResponseAssert>): InductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      consumer.accept(assertThat(previousTraining))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the child [PersonalSkillsAndInterestsResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [PersonalSkillsAndInterestsResponseAssert].
+   * Returns this [InductionResponseAssert] to allow further chained assertions on the parent [InductionResponse]
+   */
+  fun personalSkillsAndInterests(consumer: Consumer<PersonalSkillsAndInterestsResponseAssert>): InductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      consumer.accept(assertThat(personalSkillsAndInterests))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the child [PreviousQualificationsResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [PreviousQualificationsResponseAssert].
+   * Returns this [InductionResponseAssert] to allow further chained assertions on the parent [InductionResponse]
+   */
+  fun previousQualifications(consumer: Consumer<PreviousQualificationsResponseAssert>): InductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      consumer.accept(assertThat(previousQualifications))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the child [InPrisonInterestsResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [InPrisonInterestsResponseAssert].
+   * Returns this [InductionResponseAssert] to allow further chained assertions on the parent [InductionResponse]
+   */
+  fun inPrisonInterests(consumer: Consumer<InPrisonInterestsResponseAssert>): InductionResponseAssert {
+    isNotNull
+    with(actual!!) {
+      consumer.accept(assertThat(inPrisonInterests))
     }
     return this
   }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PersonalSkillsAndInterestsResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PersonalSkillsAndInterestsResponseAssert.kt
@@ -1,0 +1,128 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalSkillsAndInterestsResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun assertThat(actual: PersonalSkillsAndInterestsResponse?) = PersonalSkillsAndInterestsResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [PersonalSkillsAndInterestsResponse].
+ */
+class PersonalSkillsAndInterestsResponseAssert(actual: PersonalSkillsAndInterestsResponse?) :
+  AbstractObjectAssert<PersonalSkillsAndInterestsResponseAssert, PersonalSkillsAndInterestsResponse?>(
+    actual,
+    PersonalSkillsAndInterestsResponseAssert::class.java,
+  ) {
+
+  fun hasReference(expected: UUID): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAfter(dateTime: OffsetDateTime): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!createdAt.isAfter(dateTime)) {
+        failWithMessage("Expected createdAt to be after $dateTime, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAfter(dateTime: OffsetDateTime): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedByDisplayName(expected: String): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedByDisplayName(expected: String): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): PersonalSkillsAndInterestsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousQualificationsResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousQualificationsResponseAssert.kt
@@ -1,0 +1,128 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousQualificationsResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun assertThat(actual: PreviousQualificationsResponse?) = PreviousQualificationsResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [PreviousQualificationsResponse].
+ */
+class PreviousQualificationsResponseAssert(actual: PreviousQualificationsResponse?) :
+  AbstractObjectAssert<PreviousQualificationsResponseAssert, PreviousQualificationsResponse?>(
+    actual,
+    PreviousQualificationsResponseAssert::class.java,
+  ) {
+
+  fun hasReference(expected: UUID): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAfter(dateTime: OffsetDateTime): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!createdAt.isAfter(dateTime)) {
+        failWithMessage("Expected createdAt to be after $dateTime, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAfter(dateTime: OffsetDateTime): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedByDisplayName(expected: String): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedByDisplayName(expected: String): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousTrainingResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousTrainingResponseAssert.kt
@@ -1,0 +1,128 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousTrainingResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun assertThat(actual: PreviousTrainingResponse?) = PreviousTrainingResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [PreviousTrainingResponse].
+ */
+class PreviousTrainingResponseAssert(actual: PreviousTrainingResponse?) :
+  AbstractObjectAssert<PreviousTrainingResponseAssert, PreviousTrainingResponse?>(
+    actual,
+    PreviousTrainingResponseAssert::class.java,
+  ) {
+
+  fun hasReference(expected: UUID): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAfter(dateTime: OffsetDateTime): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!createdAt.isAfter(dateTime)) {
+        failWithMessage("Expected createdAt to be after $dateTime, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAfter(dateTime: OffsetDateTime): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedByDisplayName(expected: String): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedByDisplayName(expected: String): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): PreviousTrainingResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/WorkOnReleaseResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/WorkOnReleaseResponseAssert.kt
@@ -1,0 +1,128 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.WorkOnReleaseResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun assertThat(actual: WorkOnReleaseResponse?) = WorkOnReleaseResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [WorkOnReleaseResponse].
+ */
+class WorkOnReleaseResponseAssert(actual: WorkOnReleaseResponse?) :
+  AbstractObjectAssert<WorkOnReleaseResponseAssert, WorkOnReleaseResponse?>(
+    actual,
+    WorkOnReleaseResponseAssert::class.java,
+  ) {
+
+  fun hasReference(expected: UUID): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAfter(dateTime: OffsetDateTime): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!createdAt.isAfter(dateTime)) {
+        failWithMessage("Expected createdAt to be after $dateTime, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAfter(dateTime: OffsetDateTime): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedByDisplayName(expected: String): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedByDisplayName(expected: String): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): WorkOnReleaseResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+}


### PR DESCRIPTION
PR to tidy a few test compile time warnings, specifically those to do with kotlin non-null safe operations:
```
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:106:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:107:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:108:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:109:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:110:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:111:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:112:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:156:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:157:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:158:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:159:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:160:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:161:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt:162:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt:140:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt:141:44 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt:242:18 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt:243:44 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt:244:38 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse?'.
w: file:///Users/nathan.russell/projects/hmpps/hmpps-education-and-work-plan-api/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt:341:16 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse?'.
```


 