### PR TITLE
RR-900 - Fix bug when updating induction with new qualifications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.Induction
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionSummary
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.CreateInductionDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.CreatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.UpdateInductionDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionPersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.PreviousQualificationsEntity
@@ -89,8 +90,16 @@ class JpaInductionPersistenceAdapter(
       return previousQualificationsRepository.saveAndFlush(previousQualificationsEntity)
     } else {
       // Prisoner does not already have previous qualifications, and the DTO has qualifications. We need to create them
+      val createPreviousQualificationsDto = with(updateInductionDto.previousQualifications!!) {
+        CreatePreviousQualificationsDto(
+          prisonNumber = prisonNumber,
+          educationLevel = educationLevel!!,
+          qualifications = qualifications,
+          prisonId = prisonId,
+        )
+      }
       return previousQualificationsRepository.saveAndFlush(
-        previousQualificationsMapper.fromUpdateDtoToNewEntity(updateInductionDto.previousQualifications)!!,
+        previousQualificationsMapper.fromCreateDtoToEntity(createPreviousQualificationsDto)!!,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/GoalEntityMapper.kt
@@ -36,13 +36,18 @@ abstract class GoalEntityMapper {
    * Maps the supplied [CreateGoalDto] into a new un-persisted [GoalEntity].
    * A new reference number is generated and mapped. The JPA managed fields are not mapped.
    * This method is suitable for creating a new [GoalEntity] to be subsequently persisted to the database.
+   *
+   * `archiveReason` and `archiveReasonOther` are not mapped as they have no corresponding fields in the source `CreateGoalDto` instance
+   * because it is not possible to create a new goal that is already in an archived state.
    */
   @BeanMapping(qualifiedByName = ["addNewStepsDuringCreate"])
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields
   @GenerateNewReference
   @Mapping(target = "createdAtPrison", source = "prisonId")
   @Mapping(target = "updatedAtPrison", source = "prisonId")
-  @Mapping(target = "steps", ignore = true)
+  @Mapping(target = "steps", ignore = true) // Steps are mapped in via the AfterMapping method addNewStepsDuringCreate
+  @Mapping(target = "archiveReason", ignore = true)
+  @Mapping(target = "archiveReasonOther", ignore = true)
   abstract fun fromDtoToEntity(createGoalDto: CreateGoalDto): GoalEntity
 
   @Named("addNewStepsDuringCreate")
@@ -63,12 +68,18 @@ abstract class GoalEntityMapper {
   /**
    * Updates the supplied [GoalEntity] with fields from the supplied [UpdateGoalDtp]. The updated [GoalEntity] can then be
    * persisted to the database.
+   *
+   * `status`, `archiveReason` and `archiveReasonOther` are not mapped as they have no corresponding fields in the source `UpdateGoalDto` instance
+   * because it is not possible to either update a goal's status or update an archived goal via the Update Goal operation.
    */
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields
   @ExcludeReferenceField
   @Mapping(target = "createdAtPrison", ignore = true)
   @Mapping(target = "updatedAtPrison", source = "prisonId")
   @Mapping(target = "steps", expression = "java( updateSteps(goalEntity, updatedGoalDto) )")
+  @Mapping(target = "status", ignore = true)
+  @Mapping(target = "archiveReason", ignore = true)
+  @Mapping(target = "archiveReasonOther", ignore = true)
   abstract fun updateEntityFromDto(@MappingTarget goalEntity: GoalEntity, updatedGoalDto: UpdateGoalDto)
 
   abstract fun archiveReasonFromDomainToEntity(reason: ReasonToArchiveGoal): ReasonToArchiveGoalEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapper.kt
@@ -80,6 +80,7 @@ abstract class PreviousQualificationsEntityMapper {
 
   @ExcludeJpaManagedFieldsIncludingDisplayNameFields
   @ExcludeReferenceField
+  @Mapping(target = "prisonNumber", ignore = true) // Updating the prison number associated with a prisoner's qualifications is not supported
   @Mapping(target = "createdAtPrison", ignore = true)
   @Mapping(target = "updatedAtPrison", source = "prisonId")
   @Mapping(target = "qualifications", expression = "java( updateQualificationsFromUpdateDto(entity, dto) )")
@@ -100,20 +101,6 @@ abstract class PreviousQualificationsEntityMapper {
     entityListManager.deleteRemoved(existingQualifications, updatedQualifications)
 
     return existingQualifications
-  }
-
-  @BeanMapping(qualifiedByName = ["addNewQualificationsDuringUpdate"])
-  @ExcludeJpaManagedFieldsIncludingDisplayNameFields
-  @GenerateNewReference
-  @Mapping(target = "createdAtPrison", source = "prisonId")
-  @Mapping(target = "updatedAtPrison", source = "prisonId")
-  @Mapping(target = "qualifications", ignore = true)
-  abstract fun fromUpdateDtoToNewEntity(previousQualifications: UpdatePreviousQualificationsDto?): PreviousQualificationsEntity?
-
-  @Named("addNewQualificationsDuringUpdate")
-  @AfterMapping
-  protected fun addNewQualificationsDuringUpdate(dto: UpdatePreviousQualificationsDto, @MappingTarget entity: PreviousQualificationsEntity) {
-    addNewQualifications(dto.qualifications, entity)
   }
 
   private fun addNewQualifications(qualifications: List<Qualification>, entity: PreviousQualificationsEntity) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapterTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aFu
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidInductionSummary
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidPreviousQualifications
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidWorkOnRelease
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.CreatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.aValidCreateInductionDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.aValidCreatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.aValidUpdateInductionDto
@@ -335,7 +336,7 @@ class JpaInductionPersistenceAdapterTest {
       given(inductionRepository.saveAndFlush(any<InductionEntity>())).willReturn(persistedInductionEntity)
 
       val newPreviousQualificationsEntity = aValidPreviousQualificationsEntity(prisonNumber = prisonNumber)
-      given(previousQualificationsMapper.fromUpdateDtoToNewEntity(any())).willReturn(newPreviousQualificationsEntity)
+      given(previousQualificationsMapper.fromCreateDtoToEntity(any())).willReturn(newPreviousQualificationsEntity)
       val persistedPreviousQualificationsEntity = aValidPreviousQualificationsEntityWithJpaFieldsPopulated(prisonNumber = prisonNumber)
       given(previousQualificationsRepository.saveAndFlush(any<PreviousQualificationsEntity>())).willReturn(persistedPreviousQualificationsEntity)
 
@@ -357,6 +358,13 @@ class JpaInductionPersistenceAdapterTest {
         previousQualifications = aValidUpdatePreviousQualificationsDto(),
       )
 
+      val expectedCreatePreviousQualificationsDto = CreatePreviousQualificationsDto(
+        prisonNumber,
+        updateInductionDto.previousQualifications!!.educationLevel!!,
+        updateInductionDto.previousQualifications!!.qualifications,
+        updateInductionDto.previousQualifications!!.prisonId,
+      )
+
       // When
       val actual = persistenceAdapter.updateInduction(updateInductionDto)
 
@@ -366,7 +374,7 @@ class JpaInductionPersistenceAdapterTest {
       verify(inductionRepository).saveAndFlush(inductionEntity)
       verify(inductionMapper).updateEntityFromDto(inductionEntity, updateInductionDto)
       verify(previousQualificationsRepository).findByPrisonNumber(prisonNumber)
-      verify(previousQualificationsMapper).fromUpdateDtoToNewEntity(updateInductionDto.previousQualifications)
+      verify(previousQualificationsMapper).fromCreateDtoToEntity(expectedCreatePreviousQualificationsDto)
       verify(previousQualificationsRepository).saveAndFlush(newPreviousQualificationsEntity)
       verify(inductionMapper).fromEntityToDomain(persistedInductionEntity, persistedPreviousQualificationsEntity)
     }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousQualificationsResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousQualificationsResponseAssert.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
 
 import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousQualificationsResponse
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -21,6 +23,26 @@ class PreviousQualificationsResponseAssert(actual: PreviousQualificationsRespons
     with(actual!!) {
       if (reference != expected) {
         failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun hasEducationLevel(expected: EducationLevel): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (educationLevel != expected) {
+        failWithMessage("Expected educationLevel to be $expected, but was $educationLevel")
+      }
+    }
+    return this
+  }
+
+  fun hasQualifications(expected: List<AchievedQualification>): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (qualifications != expected) {
+        failWithMessage("Expected educationLevel to be $qualifications, but was $qualifications")
       }
     }
     return this


### PR DESCRIPTION
This PR fixes a bug when updating an induction that previous had no qualifications, but the update now contains qualifications.

Specifically the scenario is:
* An `Induction` exists, and when that induction was first created no `previousQualifications` (Highest Level of Education, or Qualifications) were added
(Highest Level of Education and Qualifications used to be entirely optional at the UI, so there will be existing `Induction` records in the database where the corresponding `PreviousQualificationsEntity` is null
* The `Induction` is subsequently updated in the UI by adding previous qualifications (either Highest Level of Education, or Qualifications)

This always used to work, but now that `PreviousQualificationsEntity` contains the `prisonNumber` field, we now have a bug in the above scenario because `prisonNumber` is not mapped.

All other scenarios involving `Induction`s (creating and updating) and `previousQualifications` (adding new or updating existing) work as the `prisonNumber` is either correctly mapped in the create flows, or already exists in the update flows.

This scenario is a bit of a weird one as its a combination of an update flow (updating the existing Induction) and a create flow (creating previousQualifications on the already existing Induction)