### PR TITLE
RR-920 - Basic setup to listen to HMPPS Domain Events

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,34 +23,23 @@ parameters:
     type: string
     default: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1
 
-executors:
-  integration-test-environment:
-    docker:
-      - image: cimg/openjdk:<< pipeline.parameters.java-version >>
-      - image: cimg/postgres:<< pipeline.parameters.postgres-version >>
-        environment:
-          POSTGRES_PASSWORD: admin_password
-          POSTGRES_USER: admin
-          POSTGRES_DB: education_and_work_plan_api_db
-      - image: localstack/localstack:<< pipeline.parameters.localstack-version >>
-        environment:
-          SERVICES: sns,sqs
-          DATA_DIR: /tmp/localstack/data
-          DOCKER_HOST: unix:///var/run/docker.sock
-          AWS_EXECUTION_ENV: True
-          DEFAULT_REGION: eu-west-2
-          TMPDIR: /private
+jobs:
+  validate:
+    executor:
+      name: hmpps/java_localstack_postgres_with_db_name
+      jdk_tag: << pipeline.parameters.java-version >>
+      java_options: << pipeline.parameters.java-options >>
+      postgres_tag: << pipeline.parameters.postgres-version >>
+      postgres_db: "education_and_work_plan_api_db"
+      postgres_username: "admin"
+      postgres_password: "admin_password"
+      localstack_tag: << pipeline.parameters.localstack-version >>
+      services: "sqs,sns"
     environment:
-      _JAVA_OPTIONS: << pipeline.parameters.java-options >>
       DB_SERVER: localhost
       DB_NAME: education_and_work_plan_api_db
       DB_USER: admin
       DB_PASS: admin_password
-    working_directory: ~/app
-
-jobs:
-  validate:
-    executor: integration-test-environment
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,21 +16,41 @@ parameters:
   postgres-version:
     type: string
     default: "15.5"
+  localstack-version:
+    type: string
+    default: "3.6.0"
+  java-options:
+    type: string
+    default: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1
 
-jobs:
-  validate:
-    executor:
-      name: hmpps/java_postgres
-      jdk_tag: << pipeline.parameters.java-version >>
-      postgres_tag: << pipeline.parameters.postgres-version >>
-      postgres_db: "education_and_work_plan_api_db"
-      postgres_username: "admin"
-      postgres_password: "admin_password"
+executors:
+  integration-test-environment:
+    docker:
+      - image: cimg/openjdk:<< pipeline.parameters.java-version >>
+      - image: cimg/postgres:<< pipeline.parameters.postgres-version >>
+        environment:
+          POSTGRES_PASSWORD: admin_password
+          POSTGRES_USER: admin
+          POSTGRES_DB: education_and_work_plan_api_db
+      - image: localstack/localstack:<< pipeline.parameters.localstack-version >>
+        environment:
+          SERVICES: sns,sqs
+          DATA_DIR: /tmp/localstack/data
+          DOCKER_HOST: unix:///var/run/docker.sock
+          AWS_EXECUTION_ENV: True
+          DEFAULT_REGION: eu-west-2
+          TMPDIR: /private
     environment:
+      _JAVA_OPTIONS: << pipeline.parameters.java-options >>
       DB_SERVER: localhost
       DB_NAME: education_and_work_plan_api_db
       DB_USER: admin
       DB_PASS: admin_password
+    working_directory: ~/app
+
+jobs:
+  validate:
+    executor: integration-test-environment
     steps:
       - checkout
       - restore_cache:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.2"
   id("org.openapi.generator") version "7.7.0"
   kotlin("plugin.spring") version "2.0.0"
   kotlin("plugin.jpa") version "2.0.0"
@@ -23,11 +23,13 @@ val mapstructVersion = "1.5.5.Final"
 val postgresqlVersion = "42.7.3"
 val kotlinLoggingVersion = "3.0.5"
 val springdocOpenapiVersion = "2.6.0"
+val hmppsSqsVersion = "4.2.0"
 val awaitilityVersion = "4.2.1"
-val wiremockVersion = "3.8.0"
+val wiremockVersion = "3.9.1"
 val jsonWebTokenVersion = "0.12.6"
 val nimbusJwtVersion = "9.40"
-val postgressTestContainersVersion = "1.20.0"
+val testContainersVersion = "1.20.1"
+val awsSdkVersion = "1.12.767"
 val buildDirectory: Directory = layout.buildDirectory.get()
 
 ext["jackson-bom.version"] = "2.16.1"
@@ -66,6 +68,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-validation")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:$hmppsSqsVersion")
 
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocOpenapiVersion")
 
@@ -84,7 +87,9 @@ dependencies {
   testImplementation("org.awaitility:awaitility-kotlin:$awaitilityVersion")
 
   // Integration test dependencies
-  integrationTestImplementation("org.testcontainers:postgresql:$postgressTestContainersVersion")
+  integrationTestImplementation("org.testcontainers:postgresql:$testContainersVersion")
+  integrationTestImplementation("org.testcontainers:localstack:$testContainersVersion")
+  integrationTestApi("com.amazonaws:aws-java-sdk-core:$awsSdkVersion") // Needed so Localstack has access to the AWS SDK V1 API
   integrationTestImplementation(testFixtures(project("domain:learningandworkprogress")))
   integrationTestImplementation(testFixtures(project("domain:personallearningplan")))
   integrationTestImplementation(testFixtures(project("domain:timeline")))

--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -25,6 +25,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api.prison.service.justice.gov.uk
     HMPPS_SAR_ADDITIONALACCESSROLE: ROLE_EDUCATION_WORK_PLAN_VIEWER
+    HMPPS_SQS_ENABLED: false
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -44,6 +45,14 @@ generic-service:
     digital-prison-reporting:
       DPR_USER: "DPR_USER"
       DPR_PASSWORD: "DPR_PASSWORD"
+
+    # Inbound SQS config
+    hmpps-domain-events-topic:
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
+    education-and-work-plan-domain-events-sqs-instance-output:
+      HMPPS_SQS_QUEUES_EDUCATIONANDWORKPLAN_QUEUE_NAME: "sqs_queue_name"
+    education-and-work-plan-domain-events-sqs-dl-instance-output:
+      HMPPS_SQS_QUEUES_EDUCATIONANDWORKPLAN_DLQ_NAME: "sqs_queue_name"
 
   allowlist:
     groups:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,6 +17,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api-dev.prison.service.justice.gov.uk
     SPRING_PROFILES_ACTIVE: dev
+    HMPPS_SQS_ENABLED: true
 
   allowlist:
     groups:

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -22,6 +22,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.rep
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.InductionRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.PreviousQualificationsRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.TimelineRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.LocalStackContainer
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.PostgresContainer
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
@@ -54,6 +56,8 @@ abstract class IntegrationTestBase {
 
     private val postgresContainer = PostgresContainer.instance
 
+    private val localStackContainer = LocalStackContainer.instance
+
     @JvmStatic
     @DynamicPropertySource
     fun configureTestContainers(registry: DynamicPropertyRegistry) {
@@ -67,6 +71,7 @@ abstract class IntegrationTestBase {
         registry.add("spring.flyway.user", postgresContainer::getUsername)
         registry.add("spring.flyway.password", postgresContainer::getPassword)
       }
+      localStackContainer?.also { setLocalStackProperties(it, registry) }
     }
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/testcontainers/LocalStackContainer.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/testcontainers/LocalStackContainer.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers
+
+import mu.KotlinLogging
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.io.IOException
+import java.net.ServerSocket
+
+private val log = KotlinLogging.logger {}
+
+object LocalStackContainer {
+  val instance by lazy { startLocalstackIfNotRunning() }
+
+  fun setLocalStackProperties(localStackContainer: LocalStackContainer, registry: DynamicPropertyRegistry) {
+    registry.add("hmpps.sqs.localstackUrl") { localStackContainer.getEndpointOverride(LocalStackContainer.Service.SNS) }
+    registry.add("hmpps.sqs.region") { localStackContainer.region }
+  }
+
+  private fun startLocalstackIfNotRunning(): LocalStackContainer? {
+    if (localstackIsRunning()) return null
+    val logConsumer = Slf4jLogConsumer(log).withPrefix("localstack")
+    return LocalStackContainer(
+      DockerImageName.parse("localstack/localstack").withTag("3.6.0"),
+    ).apply {
+      withServices(LocalStackContainer.Service.SNS, LocalStackContainer.Service.SQS)
+      withEnv("HOSTNAME_EXTERNAL", "localhost")
+      withEnv("DEFAULT_REGION", "eu-west-2")
+      waitingFor(
+        Wait.forLogMessage(".*Ready.*", 1),
+      )
+      start()
+      followOutput(logConsumer)
+    }
+  }
+
+  private fun localstackIsRunning(): Boolean =
+    try {
+      val serverSocket = ServerSocket(4566)
+      serverSocket.localPort == 0
+    } catch (e: IOException) {
+      true
+    }
+}

--- a/src/integrationTest/resources/application-integration-test.yml
+++ b/src/integrationTest/resources/application-integration-test.yml
@@ -17,6 +17,24 @@ spring:
         jwt:
           public-key-location: classpath:local-public-key.pub
 
+hmpps.sqs:
+  enabled: true
+  provider: localstack
+  queues:
+    educationandworkplan:
+      queueName: education-and-work-plan-queue
+      subscribeFilter: "{\"eventType\":[\"prison-offender-events.prisoner.received\", \"prison-offender-events.prisoner.released\"]}"
+      dlqName: education-and-work-plan-dead-letter-queue
+      subscribeTopicId: domainevents
+      dlqMaxReceiveCount: 1
+      visibilityTimeout: 1
+    domaineventsqueue:
+      queueName: domainevents-queue
+      subscribeTopicId: domainevents
+  topics:
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents-topic
+
 prison-api:
   client:
     id: prison-api-client-id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/RawJsonDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/RawJsonDeserializer.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.IOException
+
+/**
+ * Jackson [JsonDeserializer] that deserializes an object property into a string.
+ *
+ * EG. Given the following JSON where the `additionalInformation` property is an object:
+ * ```
+ *         {
+ *           "description": "A prisoner has been received into prison",
+ *           "version": "1.0",
+ *           "additionalInformation": { "nomsNumber": "A6099EA", "reason": "ADMISSION", "details": "ACTIVE IN:ADM-N", "currentLocation": "IN_PRISON", "prisonId": "SWI", "nomisMovementReasonCode": "N", "currentPrisonStatus": "UNDER_PRISON_CARE" }
+ *         }
+ * ```
+ * The `additionalInformation` can be deserialized into a simple string property as follows:
+ * ```
+ * data class SomeType(
+ *   @JsonDeserialize(using = RawJsonDeserializer::class) val additionalInformation: String,
+ *   val description: String,
+ *   val version: String,
+ * )
+ * ```
+ *
+ */
+class RawJsonDeserializer : JsonDeserializer<String>() {
+  @Throws(IOException::class, JsonProcessingException::class)
+  override fun deserialize(jp: JsonParser, ctxt: DeserializationContext): String {
+    val mapper = jp.codec as ObjectMapper
+    val node = mapper.readTree<JsonNode>(jp)
+    return mapper.writeValueAsString(node)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformation.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+/**
+ * Classes modelling the different structures of Additional Information data for different HMPPS Domain Events.
+ *
+ * HMPPS Domain Events supports additional information pertaining to the event through an untyped property `additionalInformation`
+ * in the event message. Each event type can model additional information as relevant to the event.
+ *
+ * The classes here are used when deserializing the `additionalInformation` property for each event type.
+ */
+sealed class AdditionalInformation {
+  /**
+   * Additional Information for the Prisoner Received Into Prison (prison-offender-events.prisoner.received) HMPPS Domain Event
+   */
+  data class PrisonerReceivedAdditionalInformation(
+    val nomsNumber: String,
+    val reason: Reason,
+    val details: String,
+    val currentLocation: Location,
+    val currentPrisonStatus: PrisonStatus,
+    val prisonId: String,
+    val nomisMovementReasonCode: String,
+  ) : AdditionalInformation() {
+    enum class Reason {
+      ADMISSION,
+      TEMPORARY_ABSENCE_RETURN,
+      RETURN_FROM_COURT,
+      TRANSFERRED,
+    }
+
+    enum class Location {
+      IN_PRISON,
+      OUTSIDE_PRISON,
+    }
+
+    enum class PrisonStatus {
+      UNDER_PRISON_CARE,
+      NOT_UNDER_PRISON_CARE,
+    }
+  }
+
+  /**
+   * Additional Information for the Prisoner Released From Prison (prison-offender-events.prisoner.released) HMPPS Domain Event
+   */
+  data class PrisonerReleasedAdditionalInformation(
+    val nomsNumber: String,
+    val reason: Reason,
+    val details: String,
+    val currentLocation: Location,
+    val currentPrisonStatus: PrisonStatus,
+    val prisonId: String,
+    val nomisMovementReasonCode: String,
+  ) : AdditionalInformation() {
+    enum class Reason {
+      TEMPORARY_ABSENCE_RELEASE,
+      RELEASED_TO_HOSPITAL,
+      RELEASED,
+      SENT_TO_COURT,
+      TRANSFERRED,
+      UNKNOWN,
+    }
+
+    enum class Location {
+      IN_PRISON,
+      OUTSIDE_PRISON,
+    }
+
+    enum class PrisonStatus {
+      UNDER_PRISON_CARE,
+      NOT_UNDER_PRISON_CARE,
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/EventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/EventType.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * An enumeration of HMPPS Domain Events that this service consumes and processes.
+ */
+enum class EventType(@JsonValue val eventType: String) {
+  PRISONER_RECEIVED_INTO_PRISON("prison-offender-events.prisoner.received"),
+  PRISONER_RELEASED_FROM_PRISON("prison-offender-events.prisoner.released"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEvent.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.RawJsonDeserializer
+import java.time.Instant
+
+data class InboundEvent(
+  val eventType: EventType,
+  val personReference: PersonReference,
+  @JsonDeserialize(using = RawJsonDeserializer::class) val additionalInformation: String,
+  val occurredAt: Instant,
+  val publishedAt: Instant,
+  val description: String,
+  val version: String,
+) {
+  fun prisonNumber(): String = personReference.identifiers.first { it.type == "NOMS" }.value
+}
+
+data class PersonReference(val identifiers: List<Identifier>)
+
+data class Identifier(val type: String, val value: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsListener.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.awspring.cloud.sqs.annotation.SqsListener
+import mu.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+private const val NOTIFICATION = "Notification"
+
+/**
+ * Simple SQS Listener class that sends all received "Notification" messages to the [InboundEventsService] for further
+ * processing.
+ */
+@Component
+@ConditionalOnProperty(name = ["hmpps.sqs.enabled"], havingValue = "true")
+class InboundEventsListener(
+  private val mapper: ObjectMapper,
+  private val inboundEventsService: InboundEventsService,
+) {
+
+  @SqsListener("educationandworkplan", factory = "hmppsQueueContainerFactoryProxy")
+  internal fun onMessage(sqsMessage: SqsMessage) {
+    log.debug { "Inbound event message: ${sqsMessage.Type}" }
+
+    when (sqsMessage.Type) {
+      NOTIFICATION -> inboundEventsService.process(mapper.readValue(sqsMessage.Message, InboundEvent::class.java))
+      else -> log.info { "Unrecognised message type: ${sqsMessage.Type}" }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsService.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RECEIVED_INTO_PRISON
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RELEASED_FROM_PRISON
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Service class that processes SQS events. For each type the [InboundEvent]'s `additionalInformation` property is
+ * deserialized into it's corresponding type, and then the [InboundEvent] and it's [AdditionalInformation] are sent
+ * to the relevant service specific to that event type.
+ */
+@Service
+class InboundEventsService(
+  private val mapper: ObjectMapper,
+  private val prisonerReceivedIntoPrisonEventService: PrisonerReceivedIntoPrisonEventService,
+  private val prisonerReleasedFromPrisonEventService: PrisonerReleasedFromPrisonEventService,
+) {
+
+  fun process(inboundEvent: InboundEvent) =
+    with(inboundEvent) {
+      log.info { "Processing inbound event $eventType" }
+
+      when (eventType) {
+        PRISONER_RECEIVED_INTO_PRISON -> {
+          val additionalInformation = eventAdditionalInformation<PrisonerReceivedAdditionalInformation>(inboundEvent)
+          prisonerReceivedIntoPrisonEventService.process(inboundEvent, additionalInformation)
+        }
+        PRISONER_RELEASED_FROM_PRISON -> {
+          val additionalInformation = eventAdditionalInformation<PrisonerReleasedAdditionalInformation>(inboundEvent)
+          prisonerReleasedFromPrisonEventService.process(inboundEvent, additionalInformation)
+        }
+      }
+    }
+
+  private inline fun <reified T : AdditionalInformation> eventAdditionalInformation(inboundEvent: InboundEvent): T =
+    this.mapper.readValue(inboundEvent.additionalInformation, T::class.java)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.ADMISSION
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.RETURN_FROM_COURT
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.TEMPORARY_ABSENCE_RETURN
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.TRANSFERRED
+
+private val log = KotlinLogging.logger {}
+
+@Service
+class PrisonerReceivedIntoPrisonEventService {
+  fun process(inboundEvent: InboundEvent, additionalInformation: PrisonerReceivedAdditionalInformation) =
+    when (additionalInformation.reason) {
+      ADMISSION -> {
+        log.info { "Processing Prisoner Received Into Prison Event with reason ${additionalInformation.reason}" }
+        // TODO - process prisoner admission event in respect of what PLP needs to do on this event
+      }
+
+      TRANSFERRED -> {
+        log.info { "Processing Prisoner Received Into Prison Event with reason ${additionalInformation.reason}" }
+        // TODO - process prisoner transfer event in respect of what PLP needs to do on this event
+      }
+
+      TEMPORARY_ABSENCE_RETURN, RETURN_FROM_COURT -> {
+        log.debug { "Ignoring Processing Prisoner Received Into Prison Event with reason ${additionalInformation.reason}" }
+      }
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedFromPrisonEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedFromPrisonEventService.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
+
+private val log = KotlinLogging.logger {}
+
+@Service
+class PrisonerReleasedFromPrisonEventService {
+  fun process(
+    inboundEvent: InboundEvent,
+    additionalInformation: PrisonerReleasedAdditionalInformation,
+  ) =
+    log.info { "Processing Prisoner Released From Prison Event with reason ${additionalInformation.reason}" }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/SqsMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/SqsMessage.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.util.UUID
+
+@JsonNaming(value = PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+data class SqsMessage(
+  val Type: String,
+  val Message: String,
+  val MessageId: UUID,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsListenerTest.kt
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import java.time.Instant
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class InboundEventsListenerTest {
+
+  @Mock
+  private lateinit var objectMapper: ObjectMapper
+
+  @Mock
+  private lateinit var inboundEventsService: InboundEventsService
+
+  @InjectMocks
+  private lateinit var inboundEventsListener: InboundEventsListener
+
+  @Test
+  fun `should send message to service given message is a Notification message`() {
+    // Given
+    val sqsMessage = SqsMessage(
+      Type = "Notification",
+      Message = """
+        {
+          "eventType": "prison-offender-events.prisoner.received",
+          "personReference": { "identifiers": [ { "type": "NOMS", "value": "A1234BC" } ] },
+          "occurredAt": "2024-08-08T09:07:55+01:00",
+          "publishedAt": "2024-08-08T09:08:55.673395103+01:00",
+          "description": "A prisoner has been received into prison",
+          "version": "1.0",
+          "additionalInformation": { "nomsNumber": "A6099EA", "reason": "ADMISSION", "details": "ACTIVE IN:ADM-N", "currentLocation": "IN_PRISON", "prisonId": "SWI", "nomisMovementReasonCode": "N", "currentPrisonStatus": "UNDER_PRISON_CARE" }
+        }        
+      """.trimIndent(),
+      MessageId = UUID.randomUUID(),
+    )
+
+    val expectedInboundEvent = InboundEvent(
+      eventType = EventType.PRISONER_RECEIVED_INTO_PRISON,
+      description = "A prisoner has been received into prison",
+      personReference = PersonReference(
+        identifiers = listOf(Identifier("NOMS", "A1234BC")),
+      ),
+      version = "1.0",
+      occurredAt = Instant.parse("2024-08-08T09:07:55+01:00"),
+      publishedAt = Instant.parse("2024-08-08T09:08:55.673395103+01:00"),
+      additionalInformation = "{ \"nomsNumber\": \"A6099EA\", \"reason\": \"ADMISSION\", \"details\": \"ACTIVE IN:ADM-N\", \"currentLocation\": \"IN_PRISON\", \"prisonId\": \"SWI\", \"nomisMovementReasonCode\": \"N\", \"currentPrisonStatus\": \"UNDER_PRISON_CARE\" }",
+    )
+    given(objectMapper.readValue(any<String>(), any<Class<*>>())).willReturn(expectedInboundEvent)
+
+    // When
+    inboundEventsListener.onMessage(sqsMessage)
+
+    // Then
+    verify(objectMapper).readValue(sqsMessage.Message, InboundEvent::class.java)
+    verify(inboundEventsService).process(expectedInboundEvent)
+  }
+
+  @Test
+  fun `should not send message to service given message is not a Notification message`() {
+    // Given
+    val sqsMessage = SqsMessage(
+      Type = "some-other-message-type",
+      Message = "some message content",
+      MessageId = UUID.randomUUID(),
+    )
+
+    // When
+    inboundEventsListener.onMessage(sqsMessage)
+
+    // Then
+    verifyNoInteractions(objectMapper)
+    verifyNoInteractions(inboundEventsService)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsServiceTest.kt
@@ -1,0 +1,110 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Location.IN_PRISON
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.PrisonStatus.UNDER_PRISON_CARE
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.ADMISSION
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Location.OUTSIDE_PRISON
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.PrisonStatus.NOT_UNDER_PRISON_CARE
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.RELEASED
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+class InboundEventsServiceTest {
+
+  @Mock
+  private lateinit var objectMapper: ObjectMapper
+
+  @Mock
+  private lateinit var prisonerReceivedIntoPrisonEventService: PrisonerReceivedIntoPrisonEventService
+
+  @Mock
+  private lateinit var prisonerReleasedFromPrisonEventService: PrisonerReleasedFromPrisonEventService
+
+  @InjectMocks
+  private lateinit var inboundEventsService: InboundEventsService
+
+  @Test
+  fun `should process inbound event given prisoner received into prison event`() {
+    // Given
+    val inboundEvent = InboundEvent(
+      eventType = EventType.PRISONER_RECEIVED_INTO_PRISON,
+      description = "A prisoner has been received into prison",
+      personReference = PersonReference(
+        identifiers = listOf(Identifier("NOMS", "A1234BC")),
+      ),
+      version = "1.0",
+      occurredAt = Instant.parse("2024-08-08T09:07:55+01:00"),
+      publishedAt = Instant.parse("2024-08-08T09:08:55.673395103+01:00"),
+      additionalInformation = "{ \"nomsNumber\": \"A6099EA\", \"reason\": \"ADMISSION\", \"details\": \"ACTIVE IN:ADM-N\", \"currentLocation\": \"IN_PRISON\", \"prisonId\": \"SWI\", \"nomisMovementReasonCode\": \"N\", \"currentPrisonStatus\": \"UNDER_PRISON_CARE\" }",
+    )
+
+    val expectedAdditionalInformation = PrisonerReceivedAdditionalInformation(
+      nomsNumber = "A1234BC",
+      reason = ADMISSION,
+      details = "ACTIVE IN:ADM-N",
+      prisonId = "SWI",
+      currentLocation = IN_PRISON,
+      nomisMovementReasonCode = "N",
+      currentPrisonStatus = UNDER_PRISON_CARE,
+    )
+    given(objectMapper.readValue(any<String>(), any<Class<*>>())).willReturn(expectedAdditionalInformation)
+
+    // When
+    inboundEventsService.process(inboundEvent)
+
+    // Then
+    verify(objectMapper).readValue(
+      inboundEvent.additionalInformation,
+      PrisonerReceivedAdditionalInformation::class.java,
+    )
+    verify(prisonerReceivedIntoPrisonEventService).process(inboundEvent, expectedAdditionalInformation)
+  }
+
+  @Test
+  fun `should process inbound event given prisoner released from prison event`() {
+    // Given
+    val inboundEvent = InboundEvent(
+      eventType = EventType.PRISONER_RELEASED_FROM_PRISON,
+      description = "A prisoner has been released from prison",
+      personReference = PersonReference(
+        identifiers = listOf(Identifier("NOMS", "A1234BC")),
+      ),
+      version = "1.0",
+      occurredAt = Instant.parse("2024-08-08T09:07:55+01:00"),
+      publishedAt = Instant.parse("2024-08-08T09:08:55.673395103+01:00"),
+      additionalInformation = "{ \"nomsNumber\": \"A8101DY\", \"reason\": \"RELEASED\", \"details\": \"Movement reason code CR\", \"currentLocation\": \"OUTSIDE_PRISON\", \"prisonId\": \"MDI\", \"nomisMovementReasonCode\": \"CR\", \"currentPrisonStatus\": \"NOT_UNDER_PRISON_CARE\" }",
+    )
+
+    val expectedAdditionalInformation = PrisonerReleasedAdditionalInformation(
+      nomsNumber = "A1234BC",
+      reason = RELEASED,
+      details = "Movement reason code CR",
+      prisonId = "MDI",
+      currentLocation = OUTSIDE_PRISON,
+      nomisMovementReasonCode = "CR",
+      currentPrisonStatus = NOT_UNDER_PRISON_CARE,
+    )
+    given(objectMapper.readValue(any<String>(), any<Class<*>>())).willReturn(expectedAdditionalInformation)
+
+    // When
+    inboundEventsService.process(inboundEvent)
+
+    // Then
+    verify(objectMapper).readValue(
+      inboundEvent.additionalInformation,
+      PrisonerReleasedAdditionalInformation::class.java,
+    )
+    verify(prisonerReleasedFromPrisonEventService).process(inboundEvent, expectedAdditionalInformation)
+  }
+}


### PR DESCRIPTION
This PR adds the basic setup and config to consume and process HMPPS Domain Events, specifically  `prison-offender-events.prisoner.received` and `prison-offender-events.prisoner.released`

The actual logic for how we consume each of these events will be in subsequent PRs - this is just the basic infrastructure

The listener bean is disabled in `preprod` and `prod`, but is enabled in `dev`

There are unit tests in this PR. Whilst there are no integration tests yet, the integration test setup including circleci setup has been done.