### PR TITLE
RR-920 - Enable SQS listener in preprod and prod

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -33,7 +33,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api.prison.service.justice.gov.uk
     HMPPS_SAR_ADDITIONALACCESSROLE: ROLE_EDUCATION_WORK_PLAN_VIEWER
-    HMPPS_SQS_ENABLED: false
+    HMPPS_SQS_ENABLED: true
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,7 +17,6 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api-dev.prison.service.justice.gov.uk
     SPRING_PROFILES_ACTIVE: dev
-    HMPPS_SQS_ENABLED: true
 
   allowlist:
     groups:


### PR DESCRIPTION
This PR enables listening to SQS messages in `preprod` and `prod` by setting the env var `HMPPS_SQS_ENABLED` to `true` in all helm deployed environments.