### PR TITLE
RR-901 - Update swagger spec and introduce test fixtures

### DIFF
--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.15.1'
+  version: '1.15.2'
   description: Education and Work Plan API
   contact:
     name: Learning and Work Progress team
@@ -2016,10 +2016,39 @@ components:
     AchievedQualificationResponse:
       title: AchievedQualificationResponse
       type: object
-      description: A qualification that a Prisoner has achieved, including the audit fields of who created/updated it.
+      description: A qualification that a Prisoner has achieved, including the audit fields of who created/updated it and when.
       allOf:
         - $ref: '#/components/schemas/AchievedQualification'
-        - $ref: '#/components/schemas/AuditedResource'
+      properties:
+        reference:
+          type: string
+          format: uuid
+          description: A unique reference reference for this Achieved Qualification.
+          example: 814ade0a-a3b2-46a3-862f-79211ba13f7b
+        createdBy:
+          type: string
+          description: The DPS username of the person who created this resource.
+          example: 'asmith_gen'
+        createdAt:
+          type: string
+          format: date-time
+          description: An ISO-8601 timestamp representing when this resource was created.
+          example: '2023-06-19T09:39:44Z'
+        updatedBy:
+          type: string
+          description: The DPS username of the person who last updated this resource.
+          example: 'asmith_gen'
+        updatedAt:
+          type: string
+          format: date-time
+          description: An ISO-8601 timestamp representing when this resource was last updated. This will be the same as the created date if it has not yet been updated.
+          example: '2023-06-19T09:39:44Z'
+      required:
+        - reference
+        - createdBy
+        - createdAt
+        - updatedBy
+        - updatedAt
 
     GetCiagInductionSummariesRequest:
       title: GetCiagInductionSummariesRequest

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/AchievedQualificationResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/AchievedQualificationResponseAssert.kt
@@ -1,0 +1,119 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualificationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.QualificationLevel
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun assertThat(actual: AchievedQualificationResponse?) = AchievedQualificationResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [AchievedQualificationResponse].
+ */
+class AchievedQualificationResponseAssert(actual: AchievedQualificationResponse?) :
+  AbstractObjectAssert<AchievedQualificationResponseAssert, AchievedQualificationResponse?>(
+    actual,
+    AchievedQualificationResponseAssert::class.java,
+  ) {
+
+  fun hasReference(expected: UUID): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun hasSubject(expected: String): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (subject != expected) {
+        failWithMessage("Expected subject to be $expected, but was $subject")
+      }
+    }
+    return this
+  }
+
+  fun hasLevel(expected: QualificationLevel): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (level != expected) {
+        failWithMessage("Expected level to be $expected, but was $level")
+      }
+    }
+    return this
+  }
+
+  fun hasGrade(expected: String): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (grade != expected) {
+        failWithMessage("Expected level to be $expected, but was $grade")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAfter(dateTime: OffsetDateTime): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!createdAt.isAfter(dateTime)) {
+        failWithMessage("Expected createdAt to be after $dateTime, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAfter(dateTime: OffsetDateTime): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/AchievedQualificationResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/AchievedQualificationResponseBuilder.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualificationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.QualificationLevel
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidAchievedQualificationResponse(
+  reference: UUID = UUID.randomUUID(),
+  subject: String = "English",
+  level: QualificationLevel = QualificationLevel.LEVEL_3,
+  grade: String = "A",
+  createdBy: String = "asmith_gen",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedBy: String = "asmith_gen",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+): AchievedQualificationResponse =
+  AchievedQualificationResponse(
+    reference = reference,
+    subject = subject,
+    level = level,
+    grade = grade,
+    createdBy = createdBy,
+    createdAt = createdAt,
+    updatedBy = updatedBy,
+    updatedAt = updatedAt,
+  )
+
+fun anotherValidAchievedQualificationResponse(
+  reference: UUID = UUID.randomUUID(),
+  subject: String = "Maths",
+  level: QualificationLevel = QualificationLevel.LEVEL_3,
+  grade: String = "B",
+  createdBy: String = "asmith_gen",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedBy: String = "asmith_gen",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+): AchievedQualificationResponse =
+  aValidAchievedQualificationResponse(
+    reference = reference,
+    subject = subject,
+    level = level,
+    grade = grade,
+    createdBy = createdBy,
+    createdAt = createdAt,
+    updatedBy = updatedBy,
+    updatedAt = updatedAt,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/EducationResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/EducationResponseAssert.kt
@@ -1,0 +1,178 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualificationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+import java.util.function.Consumer
+
+fun assertThat(actual: EducationResponse?) = EducationResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [EducationResponse].
+ */
+class EducationResponseAssert(actual: EducationResponse?) :
+  AbstractObjectAssert<EducationResponseAssert, EducationResponse?>(
+    actual,
+    EducationResponseAssert::class.java,
+  ) {
+
+  fun hasReference(expected: UUID): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (reference != expected) {
+        failWithMessage("Expected reference to be $expected, but was $reference")
+      }
+    }
+    return this
+  }
+
+  fun hasEducationLevel(expected: EducationLevel): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (educationLevel != expected) {
+        failWithMessage("Expected educationLevel to be $expected, but was $educationLevel")
+      }
+    }
+    return this
+  }
+
+  fun hasQualifications(expected: List<AchievedQualificationResponse>): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (qualifications != expected) {
+        failWithMessage("Expected qualifications to be $expected, but was $qualifications")
+      }
+    }
+    return this
+  }
+
+  fun hasNumberOfQualifications(expected: Int): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (qualifications.size != expected) {
+        failWithMessage("Expected number of qualifications to be $expected, but was ${qualifications.size}")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [AchievedQualificationResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [AchievedQualificationResponseAssert].
+   * Returns this [EducationResponseAssert] to allow further chained assertions on the parent [EducationResponse]
+   *
+   * The `qualificationNumber` parameter is not zero indexed to make for better readability in tests. IE. the first qualification
+   * should be referenced as `.qualification(1) { .... }`
+   */
+  fun qualification(qualificationNumber: Int, consumer: Consumer<AchievedQualificationResponseAssert>): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val qualification = this.qualifications[qualificationNumber - 1]
+      consumer.accept(assertThat(qualification))
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAfter(dateTime: OffsetDateTime): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!createdAt.isAfter(dateTime)) {
+        failWithMessage("Expected createdAt to be after $dateTime, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAfter(dateTime: OffsetDateTime): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!updatedAt.isAfter(dateTime)) {
+        failWithMessage("Expected updatedAt to be after $dateTime, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedBy(expected: String): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedByDisplayName(expected: String): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedByDisplayName(expected: String): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): EducationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/EducationResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/EducationResponseBuilder.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualificationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationResponse
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidEducationResponse(
+  reference: UUID = UUID.randomUUID(),
+  educationLevel: EducationLevel = EducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
+  qualifications: List<AchievedQualificationResponse> = listOf(
+    aValidAchievedQualificationResponse(),
+    anotherValidAchievedQualificationResponse(),
+  ),
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
+): EducationResponse =
+  EducationResponse(
+    reference = reference,
+    educationLevel = educationLevel,
+    qualifications = qualifications,
+    createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
+    createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
+    updatedBy = updatedBy,
+    updatedByDisplayName = updatedByDisplayName,
+    updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
+  )


### PR DESCRIPTION
This PR is part of a larger piece of work (RR-901, specifically implementing the GET endpoint for returning a prisoner's education/qualifications outside of an induction). I've done the work, but it represents a large PR (40 files), so felt it would be easier for review purposes to break it up and do PRs for each logic section. 
This PR is the first in that process.

---

This PR updates the GET education endpoint definition in the swagger spec, and adds the text fixture classes we will use.

A previous PR had defined the GET endpoint, but on subsequent analysis we determined would could not fulfil all of the data items in the response. Specifically the "display name" of the user who created/updated the education record, and the prisonId where it was created/updated. We are not able to (easily and in a reasonable amount of dev time) provide these data items, so I have removed them from the `EducationResponse` type in the swagger spec.

The other part of this PR is the introduction of the test fixture classes for `EducationResponse`. A "test data builder" class to build instances for the purpose of tests, and an assertJ assertion class. Both will be used in subsequent PRs when we introduce the functionality that requires tests. This is just to get them in in the first place