### PR TITLE
RR-920 - Fix enums and message field cardinality

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformation.kt
@@ -15,9 +15,9 @@ sealed class AdditionalInformation {
   data class PrisonerReceivedAdditionalInformation(
     val nomsNumber: String,
     val reason: Reason,
-    val details: String,
-    val currentLocation: Location,
-    val currentPrisonStatus: PrisonStatus,
+    val details: String?,
+    val currentLocation: Location?,
+    val currentPrisonStatus: PrisonStatus?,
     val prisonId: String,
     val nomisMovementReasonCode: String,
   ) : AdditionalInformation() {
@@ -31,6 +31,7 @@ sealed class AdditionalInformation {
     enum class Location {
       IN_PRISON,
       OUTSIDE_PRISON,
+      BEING_TRANSFERRED,
     }
 
     enum class PrisonStatus {
@@ -45,9 +46,9 @@ sealed class AdditionalInformation {
   data class PrisonerReleasedAdditionalInformation(
     val nomsNumber: String,
     val reason: Reason,
-    val details: String,
-    val currentLocation: Location,
-    val currentPrisonStatus: PrisonStatus,
+    val details: String?,
+    val currentLocation: Location?,
+    val currentPrisonStatus: PrisonStatus?,
     val prisonId: String,
     val nomisMovementReasonCode: String,
   ) : AdditionalInformation() {
@@ -63,6 +64,7 @@ sealed class AdditionalInformation {
     enum class Location {
       IN_PRISON,
       OUTSIDE_PRISON,
+      BEING_TRANSFERRED,
     }
 
     enum class PrisonStatus {


### PR DESCRIPTION
This PR adds some missing enum values and fixes field cardinality in respect of the HMPPS Domain Events that we listen to.

At the moment we are seeing a couple of problems in `prod` where the messages cannot be deserialized into our types. Most of these seem to be from the missing enum value `BEING_TRANSFERRED`, and some are based on the fact that we have the `details` field as non-nullable where in reality it can be null.

eg:
![Screenshot 2024-08-13 at 16 38 57](https://github.com/user-attachments/assets/3292c135-9f2d-4b0d-aa3a-592fddd8daa5)

The offender events swagger spec (where I was pointed at by the HMPPS dev community initially) is misleading / wrong, so I will separately raise a PR on that to correct it.
![Screenshot 2024-08-13 at 16 40 40](https://github.com/user-attachments/assets/ed77e94b-4773-444b-a6cc-a272ff24de20)

Notice the missing enum value `BEING_TRANSFERRED`, the fact that `details` is incorrectly spelt as `detail` and none of the fields describe whether they are nullable or not.
