### PR TITLE
RR-901 - Return AchievedQualificationResponse as part of REST API InductionResponse

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -20,8 +20,11 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HasWorkedBefore
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.QualificationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.aValidAchievedQualificationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.anotherValidAchievedQualificationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequestForPrisonerLookingToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequestForPrisonerNotLookingToWork
@@ -178,6 +181,10 @@ class UpdateInductionTest : IntegrationTestBase() {
     )
     val expectedUnchangedQualifications = aValidPreviousQualificationsResponse(
       reference = persistedInduction.previousQualifications!!.reference,
+      qualifications = listOf(
+        aValidAchievedQualificationResponse(createdBy = createUsername, updatedBy = createUsername),
+        anotherValidAchievedQualificationResponse(createdBy = createUsername, updatedBy = createUsername),
+      ),
       createdBy = createUsername,
       createdByDisplayName = createDisplayName,
       createdAt = persistedInduction.previousQualifications!!.createdAt,
@@ -253,7 +260,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       .wasUpdatedAtPrison("MDI")
     assertThat(updatedInduction.previousWorkExperiences).isEqualTo(expectedUnchangedWorkExperience)
     assertThat(updatedInduction.personalSkillsAndInterests).isEqualTo(expectedUnchangedSkillsAndInterests)
-    assertThat(updatedInduction.previousQualifications).isEqualTo(expectedUnchangedQualifications)
+    assertThat(updatedInduction.previousQualifications).isEquivalentTo(expectedUnchangedQualifications)
     assertThat(updatedInduction.previousTraining).isEqualTo(expectedUnchangedTraining)
     assertThat(updatedInduction.futureWorkInterests).isEqualTo(expectedUnchangedWorkInterests)
     // for the updated objects, we do not have the auto generated values, so use isEquivalentTo()
@@ -351,6 +358,10 @@ class UpdateInductionTest : IntegrationTestBase() {
     val expectedPreviousQualifications = aValidPreviousQualificationsResponse(
       educationLevel = EducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
       // didn't exist previously, so will be created by the update request
+      qualifications = listOf(
+        aValidAchievedQualificationResponse(createdBy = createUsername, updatedBy = createUsername),
+        anotherValidAchievedQualificationResponse(createdBy = createUsername, updatedBy = createUsername),
+      ),
       createdBy = createUsername,
       createdByDisplayName = createDisplayName,
       createdAtPrison = "BXI",
@@ -468,7 +479,13 @@ class UpdateInductionTest : IntegrationTestBase() {
         // there is no reference at this point as the previous induction had no previous qualifications. We are adding qualifications into the existing Induction where they did not exist before
         reference = null,
         educationLevel = EducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
-        qualifications = listOf(aValidAchievedQualification()),
+        qualifications = listOf(
+          aValidAchievedQualification(
+            subject = "English",
+            level = QualificationLevel.LEVEL_3,
+            grade = "A",
+          ),
+        ),
       ),
       // these fields were provided in the create request and won't be changed
       previousWorkExperiences = null,
@@ -494,7 +511,12 @@ class UpdateInductionTest : IntegrationTestBase() {
     assertThat(induction)
       .previousQualifications {
         it.hasEducationLevel(EducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS)
-          .hasQualifications(listOf(aValidAchievedQualification()))
+          .hasNumberOfQualifications(1)
+          .qualification(1) {
+            it.hasSubject("English")
+              .hasLevel(QualificationLevel.LEVEL_3)
+              .hasGrade("A")
+          }
       }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapper.kt
@@ -3,12 +3,14 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.mapstruct.NullValueMappingStrategy
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.PreviousQualifications
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.Qualification
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.CreatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.UpdatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualificationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousQualificationsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdatePreviousQualificationsRequest
@@ -24,6 +26,10 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Quali
   nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
 )
 abstract class QualificationsResourceMapper {
+
+  @Autowired
+  private lateinit var instantMapper: InstantMapper
+
   fun toCreatePreviousQualificationsDto(request: CreatePreviousQualificationsRequest, prisonNumber: String, prisonId: String): CreatePreviousQualificationsDto =
     CreatePreviousQualificationsDto(
       prisonNumber = prisonNumber,
@@ -55,6 +61,21 @@ abstract class QualificationsResourceMapper {
   fun toQualifications(achievedQualifications: List<AchievedQualification>): List<Qualification> =
     achievedQualifications.map { toQualification(it) }
 
+  fun toAchievedQualificationResponse(qualification: Qualification): AchievedQualificationResponse =
+    AchievedQualificationResponse(
+      reference = qualification.reference!!,
+      subject = qualification.subject,
+      level = toQualificationLevel(qualification.level),
+      grade = qualification.grade,
+      createdBy = qualification.createdBy!!,
+      createdAt = instantMapper.toOffsetDateTime(qualification.createdAt)!!,
+      updatedBy = qualification.lastUpdatedBy!!,
+      updatedAt = instantMapper.toOffsetDateTime(qualification.lastUpdatedAt)!!,
+    )
+
+  fun toAchievedQualificationResponses(qualifications: List<Qualification>): List<AchievedQualificationResponse> =
+    qualifications.map { toAchievedQualificationResponse(it) }
+
   fun toEducationLevel(educationLevel: EducationLevelApi?): EducationLevelDomain? =
     when (educationLevel) {
       EducationLevelApi.NOT_SURE -> EducationLevelDomain.NOT_SURE
@@ -78,5 +99,18 @@ abstract class QualificationsResourceMapper {
       QualificationLevelApi.LEVEL_6 -> QualificationLevelDomain.LEVEL_6
       QualificationLevelApi.LEVEL_7 -> QualificationLevelDomain.LEVEL_7
       QualificationLevelApi.LEVEL_8 -> QualificationLevelDomain.LEVEL_8
+    }
+
+  fun toQualificationLevel(qualificationLevel: QualificationLevelDomain): QualificationLevelApi =
+    when (qualificationLevel) {
+      QualificationLevelDomain.ENTRY_LEVEL -> QualificationLevelApi.ENTRY_LEVEL
+      QualificationLevelDomain.LEVEL_1 -> QualificationLevelApi.LEVEL_1
+      QualificationLevelDomain.LEVEL_2 -> QualificationLevelApi.LEVEL_2
+      QualificationLevelDomain.LEVEL_3 -> QualificationLevelApi.LEVEL_3
+      QualificationLevelDomain.LEVEL_4 -> QualificationLevelApi.LEVEL_4
+      QualificationLevelDomain.LEVEL_5 -> QualificationLevelApi.LEVEL_5
+      QualificationLevelDomain.LEVEL_6 -> QualificationLevelApi.LEVEL_6
+      QualificationLevelDomain.LEVEL_7 -> QualificationLevelApi.LEVEL_7
+      QualificationLevelDomain.LEVEL_8 -> QualificationLevelApi.LEVEL_8
     }
 }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.15.2'
+  version: '1.15.3'
   description: Education and Work Plan API
   contact:
     name: Learning and Work Progress team
@@ -1049,7 +1049,7 @@ components:
           type: array
           description: A list of the Prisoner's previous qualifications. Can be empty but not null.
           items:
-            $ref: '#/components/schemas/AchievedQualification'
+            $ref: '#/components/schemas/AchievedQualificationResponse'
         createdBy:
           type: string
           description: The DPS username of the person who created this resource.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapperTest.kt
@@ -15,12 +15,13 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.anU
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.aValidCreatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.aValidUpdatePreviousQualificationsDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidAchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.aValidAchievedQualificationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.anotherValidAchievedQualificationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreatePreviousQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidPreviousQualificationsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidUpdatePreviousQualificationsRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.anotherValidAchievedQualification
 import java.time.OffsetDateTime
+import java.util.UUID
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.EducationLevel as EducationLevelDomain
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.QualificationLevel as QualificationLevelDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationLevel as EducationLevelApi
@@ -69,34 +70,54 @@ class QualificationsResourceMapperTest {
   fun `should map to PreviousQualificationsResponse`() {
     // Given
     val domain = aValidPreviousQualifications(
+      reference = UUID.fromString("52ac8188-f372-4a7a-8de1-14b8160f0a2b"),
       educationLevel = EducationLevelDomain.SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS,
       qualifications = listOf(
         aValidQualification(
+          reference = UUID.fromString("c823568e-efe4-42fc-9a4e-227eb4e69ad0"),
           subject = "English",
           level = QualificationLevelDomain.LEVEL_3,
           grade = "A",
+          createdBy = "asmith_gen",
+          lastUpdatedBy = "bjones_gen",
         ),
         aValidQualification(
+          reference = UUID.fromString("371c25f7-ec55-4323-b296-11a643f12307"),
           subject = "Maths",
           level = QualificationLevelDomain.LEVEL_4,
           grade = "B",
+          createdBy = "fbloggs_gen",
+          lastUpdatedBy = "fnorth_gen",
         ),
       ),
     )
+
     val expectedDateTime = OffsetDateTime.now()
+    given(instantMapper.toOffsetDateTime(any())).willReturn(expectedDateTime)
+
     val expected = aValidPreviousQualificationsResponse(
-      reference = domain.reference,
+      reference = UUID.fromString("52ac8188-f372-4a7a-8de1-14b8160f0a2b"),
       educationLevel = EducationLevelApi.SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS,
       qualifications = listOf(
-        aValidAchievedQualification(
+        aValidAchievedQualificationResponse(
+          reference = UUID.fromString("c823568e-efe4-42fc-9a4e-227eb4e69ad0"),
           subject = "English",
           level = QualificationLevelApi.LEVEL_3,
           grade = "A",
+          createdBy = "asmith_gen",
+          createdAt = expectedDateTime,
+          updatedBy = "bjones_gen",
+          updatedAt = expectedDateTime,
         ),
-        anotherValidAchievedQualification(
+        anotherValidAchievedQualificationResponse(
+          reference = UUID.fromString("371c25f7-ec55-4323-b296-11a643f12307"),
           subject = "Maths",
           level = QualificationLevelApi.LEVEL_4,
           grade = "B",
+          createdAt = expectedDateTime,
+          createdBy = "fbloggs_gen",
+          updatedAt = expectedDateTime,
+          updatedBy = "fnorth_gen",
         ),
       ),
       createdAt = expectedDateTime,
@@ -104,7 +125,6 @@ class QualificationsResourceMapperTest {
       updatedBy = "bjones_gen",
       updatedByDisplayName = "Barry Jones",
     )
-    given(instantMapper.toOffsetDateTime(any())).willReturn(expectedDateTime)
 
     // When
     val actual = mapper.toPreviousQualificationsResponse(domain)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousQualificationsResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousQualificationsResponseAssert.kt
@@ -1,11 +1,15 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
 
 import org.assertj.core.api.AbstractObjectAssert
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualificationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationLevel
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.AchievedQualificationResponseAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.assertThat
 import java.time.OffsetDateTime
 import java.util.UUID
+import java.util.function.Consumer
 
 fun assertThat(actual: PreviousQualificationsResponse?) = PreviousQualificationsResponseAssert(actual)
 
@@ -38,12 +42,42 @@ class PreviousQualificationsResponseAssert(actual: PreviousQualificationsRespons
     return this
   }
 
-  fun hasQualifications(expected: List<AchievedQualification>): PreviousQualificationsResponseAssert {
+  fun hasQualifications(expected: List<AchievedQualificationResponse>): PreviousQualificationsResponseAssert {
     isNotNull
     with(actual!!) {
       if (qualifications != expected) {
-        failWithMessage("Expected educationLevel to be $qualifications, but was $qualifications")
+        failWithMessage("Expected educationLevel to be $expected, but was $qualifications")
       }
+    }
+    return this
+  }
+
+  fun hasNumberOfQualifications(expected: Int): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (qualifications.size != expected) {
+        failWithMessage("Expected educationLevel to have $expected qualifications, but has ${qualifications.size}")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [AchievedQualificationResponseAssert]. Takes a lambda as the method argument
+   * to call assertion methods provided by [AchievedQualificationResponseAssert].
+   * Returns this [PreviousQualificationsResponseAssert] to allow further chained assertions on the parent [GoalResponse]
+   *
+   * The `qualificationNumber` parameter is not zero indexed to make for better readability in tests. IE. the first qualification
+   * should be referenced as `.qualification(1) { .... }`
+   */
+  fun qualification(
+    qualificationNumber: Int,
+    consumer: Consumer<AchievedQualificationResponseAssert>,
+  ): PreviousQualificationsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val qualification = qualifications[qualificationNumber - 1]
+      consumer.accept(assertThat(qualification))
     }
     return this
   }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousQualificationsResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/PreviousQualificationsResponseBuilder.kt
@@ -1,17 +1,19 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction
 
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualification
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualificationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PreviousQualificationsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.aValidAchievedQualificationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.anotherValidAchievedQualificationResponse
 import java.time.OffsetDateTime
 import java.util.UUID
 
 fun aValidPreviousQualificationsResponse(
   reference: UUID = UUID.randomUUID(),
   educationLevel: EducationLevel = EducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
-  qualifications: List<AchievedQualification> = listOf(
-    aValidAchievedQualification(),
-    anotherValidAchievedQualification(),
+  qualifications: List<AchievedQualificationResponse> = listOf(
+    aValidAchievedQualificationResponse(),
+    anotherValidAchievedQualificationResponse(),
   ),
   createdBy: String = "asmith_gen",
   createdByDisplayName: String = "Alex Smith",


### PR DESCRIPTION
This PR changes the REST API `GET /inductions/{prisonNumber}` response so that it returns qualifications as collection of `AchievedQualificationResponse` rather that a collection of `AchievedQualification`

`AchievedQualificationResponse` as a type already exists and is the same as `AchievedQualification` except that it also contains the reference and audit fields (who/when created & updated). 

The reason we need this is part of supporting the changes we need to make for Qualifications and the change to the user journey. We need to show the audit fields (who/when created & updated) for each Qualification; and also we will need to be able to have better control over how we edit the prisoner's Qualifications, so having the reference for each Qualification will allow us to edit individual Qualifications.

For the UI this is a non breaking change as it is simply adding a few new fields to the response body object graph.
I will create a PR on the UI shortly to make use of these new fields.