### PR TITLE
RR-901 - Implementation to update qualifications identified by their reference number

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/PreviousQualifications.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/PreviousQualifications.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education
 
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.KeyAwareDomain
 import java.time.Instant
 import java.util.UUID
 
@@ -27,14 +26,12 @@ data class PreviousQualifications(
 )
 
 data class Qualification(
-  val reference: UUID?,
+  val reference: UUID,
   val subject: String,
   val level: QualificationLevel,
   val grade: String,
-  val createdBy: String?,
-  val createdAt: Instant?,
-  val lastUpdatedBy: String?,
-  val lastUpdatedAt: Instant?,
-) : KeyAwareDomain {
-  override fun key(): String = "${subject.trim()},$level".uppercase()
-}
+  val createdBy: String,
+  val createdAt: Instant,
+  val lastUpdatedBy: String,
+  val lastUpdatedAt: Instant,
+)

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/CreatePreviousQualificationsDto.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/CreatePreviousQualificationsDto.kt
@@ -1,11 +1,10 @@
 package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto
 
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.EducationLevel
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.Qualification
 
 data class CreatePreviousQualificationsDto(
   val prisonNumber: String,
   val educationLevel: EducationLevel,
-  val qualifications: List<Qualification>,
+  val qualifications: List<UpdateOrCreateQualificationDto>,
   val prisonId: String,
 )

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdateOrCreateQualificationDto.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdateOrCreateQualificationDto.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto
+
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.QualificationLevel
+import java.util.UUID
+
+sealed class UpdateOrCreateQualificationDto(
+  open val subject: String,
+  open val level: QualificationLevel,
+  open val grade: String,
+) {
+
+  /**
+   * DTO to create a new Qualification
+   */
+  data class CreateQualificationDto(
+    override val subject: String,
+    override val level: QualificationLevel,
+    override val grade: String,
+  ) : UpdateOrCreateQualificationDto(subject, level, grade)
+
+  /**
+   * DTO to update an existing Qualification identified by it's reference
+   */
+  data class UpdateQualificationDto(
+    val reference: UUID,
+    override val subject: String,
+    override val level: QualificationLevel,
+    override val grade: String,
+  ) : UpdateOrCreateQualificationDto(subject, level, grade)
+}

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdatePreviousQualificationsDto.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdatePreviousQualificationsDto.kt
@@ -1,12 +1,11 @@
 package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto
 
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.EducationLevel
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.Qualification
 import java.util.UUID
 
 data class UpdatePreviousQualificationsDto(
   val reference: UUID?,
   val educationLevel: EducationLevel?,
-  val qualifications: List<Qualification>,
+  val qualifications: List<UpdateOrCreateQualificationDto>,
   val prisonId: String,
 )

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/PreviousQualificationsBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/PreviousQualificationsBuilder.kt
@@ -34,14 +34,14 @@ fun aValidPreviousQualifications(
   )
 
 fun aValidQualification(
-  reference: UUID? = UUID.randomUUID(),
+  reference: UUID = UUID.randomUUID(),
   subject: String = "English",
   level: QualificationLevel = QualificationLevel.LEVEL_1,
   grade: String = "C",
-  createdBy: String? = "asmith_gen",
-  createdAt: Instant? = Instant.now(),
-  lastUpdatedBy: String? = "bjones_gen",
-  lastUpdatedAt: Instant? = Instant.now(),
+  createdBy: String = "asmith_gen",
+  createdAt: Instant = Instant.now(),
+  lastUpdatedBy: String = "bjones_gen",
+  lastUpdatedAt: Instant = Instant.now(),
 ) =
   Qualification(
     reference = reference,
@@ -52,36 +52,4 @@ fun aValidQualification(
     createdAt = createdAt,
     lastUpdatedBy = lastUpdatedBy,
     lastUpdatedAt = lastUpdatedAt,
-  )
-
-fun aNewQualification(
-  subject: String = "English",
-  level: QualificationLevel = QualificationLevel.LEVEL_1,
-  grade: String = "C",
-) =
-  aValidQualification(
-    reference = null,
-    subject = subject,
-    level = level,
-    grade = grade,
-    createdBy = null,
-    createdAt = null,
-    lastUpdatedBy = null,
-    lastUpdatedAt = null,
-  )
-
-fun anUpdatedQualification(
-  subject: String = "English",
-  level: QualificationLevel = QualificationLevel.LEVEL_1,
-  grade: String = "C",
-) =
-  aValidQualification(
-    reference = null,
-    subject = subject,
-    level = level,
-    grade = grade,
-    createdBy = null,
-    createdAt = null,
-    lastUpdatedBy = null,
-    lastUpdatedAt = null,
   )

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/PreviousQualificationsDtoBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/PreviousQualificationsDtoBuilder.kt
@@ -2,14 +2,12 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dt
 
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.EducationLevel
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.EducationLevel.SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.Qualification
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.aValidQualification
 import java.util.UUID
 
 fun aValidCreatePreviousQualificationsDto(
   prisonNumber: String = "A1234AB",
   educationLevel: EducationLevel = SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS,
-  qualifications: List<Qualification> = listOf(aValidQualification()),
+  qualifications: List<UpdateOrCreateQualificationDto> = listOf(aValidCreateQualificationDto()),
   prisonId: String = "BXI",
 ) =
   CreatePreviousQualificationsDto(
@@ -22,7 +20,7 @@ fun aValidCreatePreviousQualificationsDto(
 fun aValidUpdatePreviousQualificationsDto(
   reference: UUID = UUID.randomUUID(),
   educationLevel: EducationLevel = SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS,
-  qualifications: List<Qualification> = listOf(aValidQualification()),
+  qualifications: List<UpdateOrCreateQualificationDto> = listOf(aValidUpdateQualificationDto()),
   prisonId: String = "BXI",
 ) =
   UpdatePreviousQualificationsDto(

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdateOrCreateQualificationDtoBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdateOrCreateQualificationDtoBuilder.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto
+
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.QualificationLevel
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.UpdateOrCreateQualificationDto.CreateQualificationDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.UpdateOrCreateQualificationDto.UpdateQualificationDto
+import java.util.UUID
+
+fun aValidCreateQualificationDto(
+  subject: String = "English",
+  level: QualificationLevel = QualificationLevel.LEVEL_1,
+  grade: String = "C",
+): CreateQualificationDto =
+  CreateQualificationDto(
+    subject = subject,
+    level = level,
+    grade = grade,
+  )
+
+fun aValidUpdateQualificationDto(
+  reference: UUID = UUID.randomUUID(),
+  subject: String = "English",
+  level: QualificationLevel = QualificationLevel.LEVEL_1,
+  grade: String = "C",
+): UpdateQualificationDto =
+  UpdateQualificationDto(
+    reference = reference,
+    subject = subject,
+    level = level,
+    grade = grade,
+  )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
@@ -78,14 +78,14 @@ class JpaInductionPersistenceAdapter(
       if (updateInductionDto.previousQualifications!!.qualifications.isEmpty()) {
         log.info {
           """
-            Prisoner [$prisonNumber] has [${updateInductionDto.previousQualifications!!.qualifications.size}] qualifications recorded, but the Update Induction request contains a PreviousQualifications object containing 0 qualifications. 
+            Prisoner [$prisonNumber] has [${previousQualificationsEntity.qualifications().size}] qualifications recorded, but the Update Induction request contains a PreviousQualifications object containing 0 qualifications. 
             The user has explicitly removed all previously recorded qualifications as part of updating the prisoner's Induction.
           """.trimIndent()
         }
       }
       previousQualificationsMapper.updateExistingEntityFromDto(
         previousQualificationsEntity,
-        updateInductionDto.previousQualifications,
+        updateInductionDto.previousQualifications!!,
       )
       return previousQualificationsRepository.saveAndFlush(previousQualificationsEntity)
     } else {
@@ -99,7 +99,7 @@ class JpaInductionPersistenceAdapter(
         )
       }
       return previousQualificationsRepository.saveAndFlush(
-        previousQualificationsMapper.fromCreateDtoToEntity(createPreviousQualificationsDto)!!,
+        previousQualificationsMapper.fromCreateDtoToEntity(createPreviousQualificationsDto),
       )
     }
   }
@@ -117,7 +117,7 @@ class JpaInductionPersistenceAdapter(
       previousQualificationsEntity?.also {
         log.info {
           """
-            Prisoner [$prisonNumber] has [${it.qualifications!!.size}] qualifications recorded pre-induction, but the Create Induction request does not contain a PreviousQualifications object. 
+            Prisoner [$prisonNumber] has [${it.qualifications().size}] qualifications recorded pre-induction, but the Create Induction request does not contain a PreviousQualifications object. 
             Removing the prisoner's PreviousQualificationsEntity from the database.
           """.trimIndent()
         }
@@ -132,20 +132,20 @@ class JpaInductionPersistenceAdapter(
       if (createInductionDto.previousQualifications!!.qualifications.isEmpty()) {
         log.info {
           """
-            Prisoner [$prisonNumber] has [${createInductionDto.previousQualifications!!.qualifications.size}] qualifications recorded pre-induction, but the Create Induction request contains a PreviousQualifications object containing 0 qualifications. 
+            Prisoner [$prisonNumber] has [${previousQualificationsEntity.qualifications().size}] qualifications recorded pre-induction, but the Create Induction request contains a PreviousQualifications object containing 0 qualifications. 
             The user has explicitly removed all previously recorded qualifications as part of creating the prisoner's Induction.
           """.trimIndent()
         }
       }
       previousQualificationsMapper.updateExistingEntityFromDto(
         previousQualificationsEntity,
-        createInductionDto.previousQualifications,
+        createInductionDto.previousQualifications!!,
       )
       return previousQualificationsRepository.saveAndFlush(previousQualificationsEntity)
     } else {
       // Prisoner does not already have previous qualifications, and the DTO has qualifications. We need to create them
       return previousQualificationsRepository.saveAndFlush(
-        previousQualificationsMapper.fromCreateDtoToEntity(createInductionDto.previousQualifications)!!,
+        previousQualificationsMapper.fromCreateDtoToEntity(createInductionDto.previousQualifications!!),
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/education/EducationResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/education/EducationResourceMapper.kt
@@ -31,11 +31,11 @@ class EducationResourceMapper(private val instantMapper: InstantMapper) {
 
   fun toAchievedQualificationResponse(qualification: Qualification): AchievedQualificationResponse =
     AchievedQualificationResponse(
-      reference = qualification.reference!!,
+      reference = qualification.reference,
       createdAt = instantMapper.toOffsetDateTime(qualification.createdAt)!!,
-      createdBy = qualification.createdBy!!,
+      createdBy = qualification.createdBy,
       updatedAt = instantMapper.toOffsetDateTime(qualification.lastUpdatedAt)!!,
-      updatedBy = qualification.lastUpdatedBy!!,
+      updatedBy = qualification.lastUpdatedBy,
       subject = qualification.subject,
       level = toQualificationLevel(qualification.level),
       grade = qualification.grade,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapterTest.kt
@@ -304,7 +304,7 @@ class JpaInductionPersistenceAdapterTest {
       verify(inductionRepository).saveAndFlush(inductionEntity)
       verify(inductionMapper).updateEntityFromDto(inductionEntity, updateInductionDto)
       verify(previousQualificationsRepository).findByPrisonNumber(prisonNumber)
-      verify(previousQualificationsMapper).updateExistingEntityFromDto(previousQualificationsEntity, updateInductionDto.previousQualifications)
+      verify(previousQualificationsMapper).updateExistingEntityFromDto(previousQualificationsEntity, updateInductionDto.previousQualifications!!)
       verify(previousQualificationsRepository).saveAndFlush(previousQualificationsEntity)
       verify(inductionMapper).fromEntityToDomain(persistedInductionEntity, persistedPreviousQualificationsEntity)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePreviousQualificationsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePreviousQualificationsEntityMapperTest.kt
@@ -1,10 +1,9 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
 
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.Qualification
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.aValidQualification
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.aValidCreateQualificationDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.aValidUpdatePreviousQualificationsDto
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.QualificationEntity
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.aValidUpdateQualificationDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPreviousQualificationsEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidQualificationEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.assertThat
@@ -22,25 +21,21 @@ class UpdatePreviousQualificationsEntityMapperTest {
       isAccessible = true
       set(it, QualificationEntityMapperImpl())
     }
-
-    PreviousQualificationsEntityMapper::class.java.getDeclaredField("entityListManager").apply {
-      isAccessible = true
-      set(it, InductionEntityListManager<QualificationEntity, Qualification>())
-    }
   }
 
   @Test
   fun `should update existing qualifications`() {
     // Given
-    val qualificationReference = UUID.randomUUID()
+    val qualification1Reference = UUID.randomUUID()
     val existingQualificationEntity1 = aValidQualificationEntity(
-      reference = qualificationReference,
+      reference = qualification1Reference,
       subject = "English",
       level = QualificationLevelEntity.LEVEL_3,
       grade = "A",
     )
+    val qualification2Reference = UUID.randomUUID()
     val existingQualificationEntity2 = aValidQualificationEntity(
-      reference = qualificationReference,
+      reference = qualification2Reference,
       subject = "Maths",
       level = QualificationLevelEntity.LEVEL_2,
       grade = "B",
@@ -52,19 +47,20 @@ class UpdatePreviousQualificationsEntityMapperTest {
       qualifications = mutableListOf(existingQualificationEntity1, existingQualificationEntity2),
     )
 
-    // ensure case is ignored
-    val updatedQualification = aValidQualification(
-      subject = "ENGLISH",
+    val updatedQualification = aValidUpdateQualificationDto(
+      reference = qualification1Reference,
+      subject = "English",
       level = QualificationLevelDomain.LEVEL_3,
       grade = "B",
     )
-    val unchangedQualification = aValidQualification(
+    val unchangedQualification = aValidUpdateQualificationDto(
+      reference = qualification2Reference,
       subject = "Maths",
       level = QualificationLevelDomain.LEVEL_2,
       grade = "B",
     )
     val updatedQualificationsDto = aValidUpdatePreviousQualificationsDto(
-      reference = qualificationReference,
+      reference = existingQualificationsReference,
       educationLevel = EducationLevelDomain.FURTHER_EDUCATION_COLLEGE,
       qualifications = listOf(updatedQualification, unchangedQualification),
       prisonId = "MDI",
@@ -76,7 +72,7 @@ class UpdatePreviousQualificationsEntityMapperTest {
       educationLevel = EducationLevelEntity.FURTHER_EDUCATION_COLLEGE
       qualifications = mutableListOf(
         existingQualificationEntity1.deepCopy().apply {
-          subject = "ENGLISH"
+          subject = "English"
           level = QualificationLevelEntity.LEVEL_3
           grade = "B"
         },
@@ -96,12 +92,14 @@ class UpdatePreviousQualificationsEntityMapperTest {
   @Test
   fun `should update existing qualification and add new qualification`() {
     // Given
-    val qualificationReference = UUID.randomUUID()
+    val existingQualificationsReference = UUID.randomUUID()
+    val qualification1Reference = UUID.randomUUID()
     val existingQualificationsEntity = aValidPreviousQualificationsEntity(
+      reference = existingQualificationsReference,
       educationLevel = EducationLevelEntity.SECONDARY_SCHOOL_TOOK_EXAMS,
       qualifications = mutableListOf(
         aValidQualificationEntity(
-          reference = qualificationReference,
+          reference = qualification1Reference,
           subject = "English",
           level = QualificationLevelEntity.LEVEL_3,
           grade = "A",
@@ -110,31 +108,32 @@ class UpdatePreviousQualificationsEntityMapperTest {
     )
 
     // same level as above, so the grade should be updated
-    val updatedQualification = aValidQualification(
+    val updatedQualification = aValidUpdateQualificationDto(
+      reference = qualification1Reference,
       subject = "English",
       level = QualificationLevelDomain.LEVEL_3,
       grade = "B",
     )
     // different level, so should appear as a new qualification
-    val newQualification = aValidQualification(
+    val newQualification = aValidCreateQualificationDto(
       subject = "English",
       level = QualificationLevelDomain.LEVEL_2,
       grade = "C",
     )
     val updatedQualificationsDto = aValidUpdatePreviousQualificationsDto(
-      reference = qualificationReference,
+      reference = existingQualificationsReference,
       educationLevel = EducationLevelDomain.SECONDARY_SCHOOL_TOOK_EXAMS,
       qualifications = listOf(updatedQualification, newQualification),
       prisonId = "MDI",
     )
 
     val expectedEntity = existingQualificationsEntity.deepCopy().apply {
-      id
-      reference = reference
+      reference = existingQualificationsReference
       educationLevel = EducationLevelEntity.SECONDARY_SCHOOL_TOOK_EXAMS
       qualifications = mutableListOf(
         // updated grade
         aValidQualificationEntity(
+          reference = qualification1Reference,
           subject = "English",
           level = QualificationLevelEntity.LEVEL_3,
           grade = "B",
@@ -179,7 +178,8 @@ class UpdatePreviousQualificationsEntityMapperTest {
       qualifications = mutableListOf(firstQualificationEntity, secondQualificationEntity),
     )
 
-    val existingQualification = aValidQualification(
+    val existingQualification = aValidUpdateQualificationDto(
+      reference = qualificationReference,
       subject = "English",
       level = QualificationLevelDomain.LEVEL_3,
       grade = "A",
@@ -192,8 +192,7 @@ class UpdatePreviousQualificationsEntityMapperTest {
     )
 
     val expectedEntity = existingQualificationsEntity.deepCopy().apply {
-      id
-      reference = reference
+      reference = existingQualificationsReference
       educationLevel = EducationLevelEntity.SECONDARY_SCHOOL_TOOK_EXAMS
       qualifications = mutableListOf(firstQualificationEntity)
       createdAtPrison = "BXI"

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/CreatePreviousQualificationsRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/induction/CreatePreviousQualificationsRequestBuilder.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreatePreviousQualificationsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.QualificationLevel
+import java.util.UUID
 
 fun aValidCreatePreviousQualificationsRequest(
   educationLevel: EducationLevel? = EducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
@@ -18,20 +19,24 @@ fun aValidCreatePreviousQualificationsRequest(
   )
 
 fun aValidAchievedQualification(
+  reference: UUID? = null,
   subject: String = "English",
   level: QualificationLevel = QualificationLevel.LEVEL_3,
   grade: String = "A",
 ): CreateOrUpdateAchievedQualificationRequest = CreateOrUpdateAchievedQualificationRequest(
+  reference = reference,
   subject = subject,
   level = level,
   grade = grade,
 )
 
 fun anotherValidAchievedQualification(
+  reference: UUID? = null,
   subject: String = "Maths",
   level: QualificationLevel = QualificationLevel.LEVEL_3,
   grade: String = "B",
 ): CreateOrUpdateAchievedQualificationRequest = CreateOrUpdateAchievedQualificationRequest(
+  reference = reference,
   subject = subject,
   level = level,
   grade = grade,


### PR DESCRIPTION
This PR changes the API implementation re: creating and updating individual qualifications as part of the create or update Induction requests.

Previously when creating an Induction it was assumed there were no child elements of the induction already recorded in the system. (eg: pre-existing qualifications recorded before the Induction was created) This is still true because at time of writing it is not possible to create qualifications (or other resources) outside of the context of the parent Induction.
But we will soon be changing that, so that you will be able to create Qualifications before in the induction.

Therefore, to support that, the Create Induction implementation has been changed so that for any qualifications in the Create Induction request; if they have no reference number they are assumed to be new Qualifications to be recorded. For any that have a reference number they are assumed to either be an update to delete.

The same is now true of the Update Induction implementation.

This does not change the API (we've already done that in previous PRs) and is a non-breaking change to the UI. It simply changes the internal implementation