### PR TITLE
Fix housekeeping cron schedule in dev and preprod to allow for scheduled downtime

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -31,3 +31,6 @@ generic-prometheus-alerts:
 generic-data-analytics-extractor:
   serviceAccountName: hmpps-education-and-work-plan-dev-to-ap-s3
   cronJobSchedule: '00 7 * * 1-5' # Start at 7am UTC Monday-Friday to allow for the fact that we terminate the resources (inc. RDS) overnight and all weekend in the dev env (see scheduledDowntime above)
+
+hmpps-education-and-work-plan-api-queue-housekeeping:
+  schedule: "*/10 07-21 * * 1-5" # Every 10 minutes between 7am and 9pm UTC Monday-Friday to allow for the fact that we terminate the resources overnight and all weekend in the dev env (see scheduledDowntime above)

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,3 +9,6 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service
+
+hmpps-education-and-work-plan-api-queue-housekeeping:
+  schedule: "*/10 07-21 * * 1-5" # Every 10 minutes between 7am and 9pm UTC Monday-Friday to allow for the fact that we terminate the resources overnight and all weekend in the dev env (see scheduledDowntime above)


### PR DESCRIPTION
This PR changes the cron schedule of the SQS housekeeping job for dev and preprod
It was set to every 10 minutes (and still is in production), but in dev and preprod we shut down a lot of the AWS resources (such as the service itself, and all of its dependant resources like the database etc) from 9pm till 06:30am and all weekend.

Because the main service is shutdown overnight and over the weekend, it meant that we get loads of errors every 10 minutes when the housekeeping job kicks in!

The PR sets the cron schedule (in dev and preprod only) to take the scheduled downtime into consideration