### PR TITLE
RR-935 - Add createdAtPrison and updatedAtPrison to individual qualifications

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/PreviousQualifications.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/PreviousQualifications.kt
@@ -31,7 +31,9 @@ data class Qualification(
   val level: QualificationLevel,
   val grade: String,
   val createdBy: String,
+  val createdAtPrison: String,
   val createdAt: Instant,
   val lastUpdatedBy: String,
   val lastUpdatedAt: Instant,
+  val lastUpdatedAtPrison: String,
 )

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdateOrCreateQualificationDto.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdateOrCreateQualificationDto.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.Qua
 import java.util.UUID
 
 sealed class UpdateOrCreateQualificationDto(
+  open val prisonId: String,
   open val subject: String,
   open val level: QualificationLevel,
   open val grade: String,
@@ -13,18 +14,20 @@ sealed class UpdateOrCreateQualificationDto(
    * DTO to create a new Qualification
    */
   data class CreateQualificationDto(
+    override val prisonId: String,
     override val subject: String,
     override val level: QualificationLevel,
     override val grade: String,
-  ) : UpdateOrCreateQualificationDto(subject, level, grade)
+  ) : UpdateOrCreateQualificationDto(prisonId, subject, level, grade)
 
   /**
    * DTO to update an existing Qualification identified by it's reference
    */
   data class UpdateQualificationDto(
     val reference: UUID,
+    override val prisonId: String,
     override val subject: String,
     override val level: QualificationLevel,
     override val grade: String,
-  ) : UpdateOrCreateQualificationDto(subject, level, grade)
+  ) : UpdateOrCreateQualificationDto(prisonId, subject, level, grade)
 }

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/PreviousQualificationsBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/PreviousQualificationsBuilder.kt
@@ -40,8 +40,10 @@ fun aValidQualification(
   grade: String = "C",
   createdBy: String = "asmith_gen",
   createdAt: Instant = Instant.now(),
+  createdAtPrison: String = "BXI",
   lastUpdatedBy: String = "bjones_gen",
   lastUpdatedAt: Instant = Instant.now(),
+  lastUpdatedAtPrison: String = "BXI",
 ) =
   Qualification(
     reference = reference,
@@ -50,6 +52,8 @@ fun aValidQualification(
     grade = grade,
     createdBy = createdBy,
     createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
     lastUpdatedBy = lastUpdatedBy,
     lastUpdatedAt = lastUpdatedAt,
+    lastUpdatedAtPrison = lastUpdatedAtPrison,
   )

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdateOrCreateQualificationDtoBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdateOrCreateQualificationDtoBuilder.kt
@@ -6,11 +6,13 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto
 import java.util.UUID
 
 fun aValidCreateQualificationDto(
+  prisonId: String = "BXI",
   subject: String = "English",
   level: QualificationLevel = QualificationLevel.LEVEL_1,
   grade: String = "C",
 ): CreateQualificationDto =
   CreateQualificationDto(
+    prisonId = prisonId,
     subject = subject,
     level = level,
     grade = grade,
@@ -18,11 +20,13 @@ fun aValidCreateQualificationDto(
 
 fun aValidUpdateQualificationDto(
   reference: UUID = UUID.randomUUID(),
+  prisonId: String = "BXI",
   subject: String = "English",
   level: QualificationLevel = QualificationLevel.LEVEL_1,
   grade: String = "C",
 ): UpdateQualificationDto =
   UpdateQualificationDto(
+    prisonId = prisonId,
     reference = reference,
     subject = subject,
     level = level,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateEducationTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateEducationTest.kt
@@ -88,7 +88,7 @@ class CreateEducationTest : IntegrationTestBase() {
     // When
     webTestClient.post()
       .uri(URI_TEMPLATE, prisonNumber)
-      .withBody(aValidCreateEducationRequest())
+      .withBody(aValidCreateEducationRequest(prisonId = "MDI"))
       .bearerToken(
         aValidTokenWithAuthority(
           EDUCATION_RW,
@@ -104,6 +104,15 @@ class CreateEducationTest : IntegrationTestBase() {
     val education = getEducation(prisonNumber)
     assertThat(education)
       .wasCreatedAtOrAfter(earliestCreateTime)
+      .hasNumberOfQualifications(2)
+      .qualification(1) {
+        it.wasCreatedAtPrison("MDI")
+          .wasUpdatedAtPrison("MDI")
+      }
+      .qualification(2) {
+        it.wasCreatedAtPrison("MDI")
+          .wasUpdatedAtPrison("MDI")
+      }
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -465,7 +465,10 @@ class UpdateInductionTest : IntegrationTestBase() {
     val prisonNumber = aValidPrisonNumber()
     createInduction(
       prisonNumber = prisonNumber,
-      createInductionRequest = aValidCreateInductionRequestForPrisonerNotLookingToWork(previousQualifications = null),
+      createInductionRequest = aValidCreateInductionRequestForPrisonerNotLookingToWork(
+        prisonId = "BXI",
+        previousQualifications = null,
+      ),
     )
 
     val persistedInduction = getInduction(prisonNumber)
@@ -518,6 +521,8 @@ class UpdateInductionTest : IntegrationTestBase() {
             it.hasSubject("English")
               .hasLevel(QualificationLevel.LEVEL_3)
               .hasGrade("A")
+              .wasCreatedAtPrison("BXI")
+              .wasUpdatedAtPrison("BXI")
           }
       }
   }
@@ -584,6 +589,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       username = "auser_gen",
       prisonNumber = prisonNumber,
       createInductionRequest = aValidCreateInductionRequestForPrisonerNotLookingToWork(
+        prisonId = "LFI",
         previousQualifications = aValidCreatePreviousQualificationsRequest(
           educationLevel = EducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,
           qualifications = listOf(
@@ -599,6 +605,7 @@ class UpdateInductionTest : IntegrationTestBase() {
     val referenceOfPhysicsQualification = persistedInduction.previousQualifications!!.qualifications.first { it.subject == "Physics" }.reference
 
     val updateInductionRequest = aValidUpdateInductionRequestForPrisonerNotLookingToWork(
+      prisonId = "MDI",
       reference = persistedInduction.reference,
       previousQualifications = aValidUpdatePreviousQualificationsRequest(
         reference = persistedInduction.previousQualifications!!.reference,
@@ -645,7 +652,9 @@ class UpdateInductionTest : IntegrationTestBase() {
         .hasLevel(QualificationLevel.LEVEL_3)
         .hasGrade("D")
         .wasCreatedBy("auser_gen")
+        .wasCreatedAtPrison("LFI")
         .wasUpdatedBy("buser_gen") // this record was updated so expect the updatedBy field to reflect that
+        .wasUpdatedAtPrison("MDI")
 
       val physicsQualification = qualifications.first { it.subject == "Physics" }
       assertThat(physicsQualification)
@@ -654,7 +663,9 @@ class UpdateInductionTest : IntegrationTestBase() {
         .hasLevel(QualificationLevel.LEVEL_3)
         .hasGrade("C")
         .wasCreatedBy("auser_gen")
+        .wasCreatedAtPrison("LFI")
         .wasUpdatedBy("auser_gen") // this record was not updated so expect the updatedBy field to be the user who created it
+        .wasUpdatedAtPrison("LFI")
 
       val spanishQualification = qualifications.first { it.subject == "Spanish" }
       assertThat(spanishQualification)
@@ -662,7 +673,9 @@ class UpdateInductionTest : IntegrationTestBase() {
         .hasLevel(QualificationLevel.LEVEL_4)
         .hasGrade("A*")
         .wasCreatedBy("buser_gen") // this record was created as part of this update request so expect the createdBy and updatedBy fields to be the user who performed the Induction update
+        .wasCreatedAtPrison("MDI")
         .wasUpdatedBy("buser_gen")
+        .wasCreatedAtPrison("MDI")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaEducationPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaEducationPersistenceAdapter.kt
@@ -27,6 +27,6 @@ class JpaEducationPersistenceAdapter(
     val previousQualificationsEntity = previousQualificationsRepository.saveAndFlush(
       previousQualificationsMapper.fromCreateDtoToEntity(createInductionDto),
     )
-    return previousQualificationsMapper.fromEntityToDomain(previousQualificationsEntity)
+    return previousQualificationsMapper.fromEntityToDomain(previousQualificationsEntity)!!
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntity.kt
@@ -151,6 +151,10 @@ class QualificationEntity(
   @CreationTimestamp
   var createdAt: Instant? = null,
 
+  @Column
+  @field:NotNull
+  var createdAtPrison: String? = null,
+
   @Column(updatable = false)
   @CreatedBy
   var createdBy: String? = null,
@@ -158,6 +162,10 @@ class QualificationEntity(
   @Column
   @UpdateTimestamp
   var updatedAt: Instant? = null,
+
+  @Column
+  @field:NotNull
+  var updatedAtPrison: String? = null,
 
   @Column
   @LastModifiedBy

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/education/EducationResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/education/EducationResourceMapper.kt
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.PreviousQualifications
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.Qualification
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.CreatePreviousQualificationsDto
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.UpdateOrCreateQualificationDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.UpdateOrCreateQualificationDto.CreateQualificationDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.AchievedQualificationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateAchievedQualificationRequest
@@ -37,7 +37,7 @@ class EducationResourceMapper(private val instantMapper: InstantMapper) {
     CreatePreviousQualificationsDto(
       prisonNumber = prisonNumber,
       educationLevel = toEducationLevel(request.educationLevel),
-      qualifications = toUpdateOrCreateQualificationDtos(request.qualifications),
+      qualifications = toCreateQualificationDtos(request.qualifications, request.prisonId),
       prisonId = request.prisonId,
     )
 
@@ -46,8 +46,10 @@ class EducationResourceMapper(private val instantMapper: InstantMapper) {
       reference = qualification.reference,
       createdAt = instantMapper.toOffsetDateTime(qualification.createdAt)!!,
       createdBy = qualification.createdBy,
+      createdAtPrison = qualification.createdAtPrison,
       updatedAt = instantMapper.toOffsetDateTime(qualification.lastUpdatedAt)!!,
       updatedBy = qualification.lastUpdatedBy,
+      updatedAtPrison = qualification.lastUpdatedAtPrison,
       subject = qualification.subject,
       level = toQualificationLevel(qualification.level),
       grade = qualification.grade,
@@ -56,17 +58,18 @@ class EducationResourceMapper(private val instantMapper: InstantMapper) {
   private fun toAchievedQualificationResponses(qualifications: List<Qualification>): List<AchievedQualificationResponse> =
     qualifications.map { toAchievedQualificationResponse(it) }
 
-  private fun toUpdateOrCreateQualificationDto(createAchievedQualificationRequest: CreateAchievedQualificationRequest): UpdateOrCreateQualificationDto =
+  private fun toCreateQualificationDto(createAchievedQualificationRequest: CreateAchievedQualificationRequest, prisonId: String): CreateQualificationDto =
     with(createAchievedQualificationRequest) {
-      UpdateOrCreateQualificationDto.CreateQualificationDto(
+      CreateQualificationDto(
         subject = subject,
         level = toQualificationLevel(level),
         grade = grade,
+        prisonId = prisonId,
       )
     }
 
-  private fun toUpdateOrCreateQualificationDtos(createAchievedQualificationRequests: List<CreateAchievedQualificationRequest>): List<UpdateOrCreateQualificationDto> =
-    createAchievedQualificationRequests.map { toUpdateOrCreateQualificationDto(it) }
+  private fun toCreateQualificationDtos(createAchievedQualificationRequests: List<CreateAchievedQualificationRequest>, prisonId: String): List<CreateQualificationDto> =
+    createAchievedQualificationRequests.map { toCreateQualificationDto(it, prisonId) }
 
   private fun toEducationLevel(educationLevel: EducationLevelDomain): EducationLevelApi =
     when (educationLevel) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapper.kt
@@ -27,7 +27,7 @@ class QualificationsResourceMapper(private val instantMapper: InstantMapper) {
       prisonNumber = prisonNumber,
       prisonId = prisonId,
       educationLevel = request.educationLevel?.let { toEducationLevel(it) } ?: EducationLevelDomain.NOT_SURE,
-      qualifications = request.qualifications?.let { toUpdateOrCreateQualificationDtos(it) } ?: emptyList(),
+      qualifications = request.qualifications?.let { toUpdateOrCreateQualificationDtos(it, prisonId) } ?: emptyList(),
     )
 
   fun toPreviousQualificationsResponse(previousQualifications: PreviousQualifications?): PreviousQualificationsResponse? =
@@ -53,18 +53,20 @@ class QualificationsResourceMapper(private val instantMapper: InstantMapper) {
       prisonNumber = prisonNumber,
       prisonId = prisonId,
       educationLevel = toEducationLevel(request.educationLevel),
-      qualifications = toUpdateOrCreateQualificationDtos(request.qualifications ?: emptyList()),
+      qualifications = toUpdateOrCreateQualificationDtos(request.qualifications ?: emptyList(), prisonId),
     )
 
-  fun toUpdateOrCreateQualificationDto(achievedQualification: CreateOrUpdateAchievedQualificationRequest): UpdateOrCreateQualificationDto =
+  fun toUpdateOrCreateQualificationDto(achievedQualification: CreateOrUpdateAchievedQualificationRequest, prisonId: String): UpdateOrCreateQualificationDto =
     if (achievedQualification.reference == null) {
       CreateQualificationDto(
+        prisonId = prisonId,
         subject = achievedQualification.subject,
         level = toQualificationLevel(achievedQualification.level),
         grade = achievedQualification.grade,
       )
     } else {
       UpdateQualificationDto(
+        prisonId = prisonId,
         reference = achievedQualification.reference!!,
         subject = achievedQualification.subject,
         level = toQualificationLevel(achievedQualification.level),
@@ -72,8 +74,8 @@ class QualificationsResourceMapper(private val instantMapper: InstantMapper) {
       )
     }
 
-  fun toUpdateOrCreateQualificationDtos(achievedQualifications: List<CreateOrUpdateAchievedQualificationRequest>): List<UpdateOrCreateQualificationDto> =
-    achievedQualifications.map { toUpdateOrCreateQualificationDto(it) }
+  fun toUpdateOrCreateQualificationDtos(achievedQualifications: List<CreateOrUpdateAchievedQualificationRequest>, prisonId: String): List<UpdateOrCreateQualificationDto> =
+    achievedQualifications.map { toUpdateOrCreateQualificationDto(it, prisonId) }
 
   fun toAchievedQualificationResponse(qualification: Qualification): AchievedQualificationResponse =
     AchievedQualificationResponse(
@@ -83,8 +85,10 @@ class QualificationsResourceMapper(private val instantMapper: InstantMapper) {
       grade = qualification.grade,
       createdBy = qualification.createdBy,
       createdAt = instantMapper.toOffsetDateTime(qualification.createdAt)!!,
+      createdAtPrison = qualification.createdAtPrison,
       updatedBy = qualification.lastUpdatedBy,
       updatedAt = instantMapper.toOffsetDateTime(qualification.lastUpdatedAt)!!,
+      updatedAtPrison = qualification.lastUpdatedAtPrison,
     )
 
   fun toAchievedQualificationResponses(qualifications: List<Qualification>): List<AchievedQualificationResponse> =

--- a/src/main/resources/db/migration/common/V2024.11.09.0001__add_prison_id_fields_to_qualification.sql
+++ b/src/main/resources/db/migration/common/V2024.11.09.0001__add_prison_id_fields_to_qualification.sql
@@ -1,0 +1,22 @@
+--- Add created_at_prison and updated_at_prison fields to qualification
+--- and update existing records with the value from the parent previous_qualifications table
+
+ALTER TABLE qualification ADD COLUMN created_at_prison VARCHAR(3);
+ALTER TABLE qualification ADD COLUMN updated_at_prison VARCHAR(3);
+
+UPDATE qualification q
+SET
+    created_at_prison = (
+        SELECT pq.created_at_prison
+        FROM previous_qualifications pq
+        WHERE q.prev_qualifications_id = pq.id
+    ),
+    updated_at_prison = (
+        SELECT pq.updated_at_prison
+        FROM previous_qualifications pq
+        WHERE q.prev_qualifications_id = pq.id
+    )
+;
+
+ALTER TABLE qualification ALTER COLUMN created_at_prison SET NOT NULL;
+ALTER TABLE qualification ALTER COLUMN updated_at_prison SET NOT NULL;

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.16.0'
+  version: '1.16.1'
   description: Education and Work Plan API
   contact:
     name: Learning and Work Progress team
@@ -2188,6 +2188,10 @@ components:
           format: date-time
           description: An ISO-8601 timestamp representing when this resource was created.
           example: '2023-06-19T09:39:44Z'
+        createdAtPrison:
+          type: string
+          description: The identifier of the prison that the prisoner was resident at when this resource was created.
+          example: 'BXI'
         updatedBy:
           type: string
           description: The DPS username of the person who last updated this resource.
@@ -2197,6 +2201,10 @@ components:
           format: date-time
           description: An ISO-8601 timestamp representing when this resource was last updated. This will be the same as the created date if it has not yet been updated.
           example: '2023-06-19T09:39:44Z'
+        updatedAtPrison:
+          type: string
+          description: The identifier of the prison that the prisoner was resident at when this resource was updated.
+          example: 'BXI'
       required:
         - reference
         - subject
@@ -2204,8 +2212,10 @@ components:
         - grade
         - createdBy
         - createdAt
+        - createdAtPrison
         - updatedBy
         - updatedAt
+        - updatedAtPrison
 
     GetCiagInductionSummariesRequest:
       title: GetCiagInductionSummariesRequest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousQualificationsEntityMapperTest.kt
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 @ExtendWith(MockitoExtension::class)
 class PreviousQualificationsEntityMapperTest {
   @InjectMocks
-  private lateinit var mapper: PreviousQualificationsEntityMapperImpl
+  private lateinit var mapper: PreviousQualificationsEntityMapper
 
   @Mock
   private lateinit var qualificationEntityMapper: QualificationEntityMapper

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePreviousQualificationsEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/UpdatePreviousQualificationsEntityMapperTest.kt
@@ -16,12 +16,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 
 class UpdatePreviousQualificationsEntityMapperTest {
 
-  private val mapper = PreviousQualificationsEntityMapperImpl().also {
-    PreviousQualificationsEntityMapper::class.java.getDeclaredField("qualificationEntityMapper").apply {
-      isAccessible = true
-      set(it, QualificationEntityMapperImpl())
-    }
-  }
+  private val mapper = PreviousQualificationsEntityMapper(QualificationEntityMapper())
 
   @Test
   fun `should update existing qualifications`() {
@@ -32,6 +27,8 @@ class UpdatePreviousQualificationsEntityMapperTest {
       subject = "English",
       level = QualificationLevelEntity.LEVEL_3,
       grade = "A",
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
     )
     val qualification2Reference = UUID.randomUUID()
     val existingQualificationEntity2 = aValidQualificationEntity(
@@ -39,12 +36,16 @@ class UpdatePreviousQualificationsEntityMapperTest {
       subject = "Maths",
       level = QualificationLevelEntity.LEVEL_2,
       grade = "B",
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
     )
     val existingQualificationsReference = UUID.randomUUID()
     val existingQualificationsEntity = aValidPreviousQualificationsEntity(
       reference = existingQualificationsReference,
       educationLevel = EducationLevelEntity.SECONDARY_SCHOOL_TOOK_EXAMS,
       qualifications = mutableListOf(existingQualificationEntity1, existingQualificationEntity2),
+      createdAtPrison = "BXI",
+      updatedAtPrison = "BXI",
     )
 
     val updatedQualification = aValidUpdateQualificationDto(
@@ -52,12 +53,14 @@ class UpdatePreviousQualificationsEntityMapperTest {
       subject = "English",
       level = QualificationLevelDomain.LEVEL_3,
       grade = "B",
+      prisonId = "MDI",
     )
     val unchangedQualification = aValidUpdateQualificationDto(
       reference = qualification2Reference,
       subject = "Maths",
       level = QualificationLevelDomain.LEVEL_2,
       grade = "B",
+      prisonId = "MDI",
     )
     val updatedQualificationsDto = aValidUpdatePreviousQualificationsDto(
       reference = existingQualificationsReference,
@@ -75,7 +78,10 @@ class UpdatePreviousQualificationsEntityMapperTest {
           subject = "English"
           level = QualificationLevelEntity.LEVEL_3
           grade = "B"
+          createdAtPrison = "BXI"
+          updatedAtPrison = "MDI"
         },
+        // qualification 2 should not have been updated at all because it's subject, level and grade had not changed in the request object
         existingQualificationEntity2.deepCopy(),
       )
       createdAtPrison = "BXI"

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousQualificationsEntityBuilder.kt
@@ -71,10 +71,22 @@ fun aValidQualificationEntity(
   subject: String = "English",
   level: QualificationLevel? = QualificationLevel.LEVEL_3,
   grade: String? = "A",
+  createdAt: Instant? = null,
+  createdAtPrison: String = "BXI",
+  createdBy: String? = null,
+  updatedAt: Instant? = null,
+  updatedAtPrison: String = "BXI",
+  updatedBy: String? = null,
 ) =
   QualificationEntity(
     reference = reference,
     subject = subject,
     level = level,
     grade = grade,
+    createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
+    createdBy = createdBy,
+    updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
+    updatedBy = updatedBy,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/AchievedQualificationResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/AchievedQualificationResponseAssert.kt
@@ -67,6 +67,16 @@ class AchievedQualificationResponseAssert(actual: AchievedQualificationResponse?
     return this
   }
 
+  fun wasCreatedAtPrison(expected: String): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
   fun wasCreatedAfter(dateTime: OffsetDateTime): AchievedQualificationResponseAssert {
     isNotNull
     with(actual!!) {
@@ -82,6 +92,16 @@ class AchievedQualificationResponseAssert(actual: AchievedQualificationResponse?
     with(actual!!) {
       if (updatedAt != expected) {
         failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): AchievedQualificationResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/AchievedQualificationResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/education/AchievedQualificationResponseBuilder.kt
@@ -12,8 +12,10 @@ fun aValidAchievedQualificationResponse(
   grade: String = "A",
   createdBy: String = "asmith_gen",
   createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
   updatedBy: String = "asmith_gen",
   updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
 ): AchievedQualificationResponse =
   AchievedQualificationResponse(
     reference = reference,
@@ -22,8 +24,10 @@ fun aValidAchievedQualificationResponse(
     grade = grade,
     createdBy = createdBy,
     createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
     updatedBy = updatedBy,
     updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
   )
 
 fun anotherValidAchievedQualificationResponse(


### PR DESCRIPTION
This PR adds the `createdAtPrison` and `updatedAtPrison` audit fields to individual qualifications.

The Previous Qualifications object (that is effectively a container for all things "qualifications") contains the prisoner's Highest Level of Education and a collection of Qualifications. It has always contained the full set of "audit" fields (`createdAt`, `createdBy`, `createdByDisplayName`, `createdAtPrison`, `updatedAt`, `updatedBy`, `updatedByDisplayName`, `updatedAtPrison`)
Individual qualifications previously only had a subset of these audit fields because that suited the requirements at the time - 
(`createdAt`, `createdBy`, `updatedAt`, `updatedBy`)

This PR adds the `createdAtPrison` and `updatedAtPrison` audit fields to individual qualifications. The updates to the mappers ensures the fields are correctly populated/updated as necessary; and the new fields are returned as part of qualifications in REST API responses.