### PR TITLE
RR-901 - Refactor UpdatePreviousQualificationsDto to include the prisonNumber

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdatePreviousQualificationsDto.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/UpdatePreviousQualificationsDto.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 
 data class UpdatePreviousQualificationsDto(
   val reference: UUID?,
+  val prisonNumber: String,
   val educationLevel: EducationLevel?,
   val qualifications: List<UpdateOrCreateQualificationDto>,
   val prisonId: String,

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/PreviousQualificationsDtoBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/education/dto/PreviousQualificationsDtoBuilder.kt
@@ -19,12 +19,14 @@ fun aValidCreatePreviousQualificationsDto(
 
 fun aValidUpdatePreviousQualificationsDto(
   reference: UUID = UUID.randomUUID(),
+  prisonNumber: String = "A1234AB",
   educationLevel: EducationLevel = SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS,
   qualifications: List<UpdateOrCreateQualificationDto> = listOf(aValidUpdateQualificationDto()),
   prisonId: String = "BXI",
 ) =
   UpdatePreviousQualificationsDto(
     reference = reference,
+    prisonNumber = prisonNumber,
     educationLevel = educationLevel,
     qualifications = qualifications,
     prisonId = prisonId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionPersistenceAdapter.kt
@@ -29,7 +29,7 @@ class JpaInductionPersistenceAdapter(
   override fun createInduction(createInductionDto: CreateInductionDto): Induction {
     val prisonNumber = createInductionDto.prisonNumber
     val inductionEntity = inductionRepository.saveAndFlush(inductionMapper.fromCreateDtoToEntity(createInductionDto))
-    val previousQualificationsEntity = createOrUpdatePreviousQualifications(createInductionDto, prisonNumber)
+    val previousQualificationsEntity = createOrUpdatePreviousQualifications(createInductionDto)
     return inductionMapper.fromEntityToDomain(inductionEntity, previousQualificationsEntity)
   }
 
@@ -48,7 +48,7 @@ class JpaInductionPersistenceAdapter(
       inductionMapper.updateEntityFromDto(inductionEntity, updateInductionDto)
       inductionEntity.updateLastUpdatedAt() // force the main Induction's JPA managed fields to update
       val updatedInductionEntity = inductionRepository.saveAndFlush(inductionEntity)
-      val previousQualificationsEntity = createOrUpdatePreviousQualifications(updateInductionDto, prisonNumber)
+      val previousQualificationsEntity = createOrUpdatePreviousQualifications(updateInductionDto)
       inductionMapper.fromEntityToDomain(updatedInductionEntity, previousQualificationsEntity)
     } else {
       null
@@ -61,10 +61,8 @@ class JpaInductionPersistenceAdapter(
       inductionMapper.fromEntitySummariesToDomainSummaries(it)
     }
 
-  private fun createOrUpdatePreviousQualifications(
-    updateInductionDto: UpdateInductionDto,
-    prisonNumber: String,
-  ): PreviousQualificationsEntity? {
+  private fun createOrUpdatePreviousQualifications(updateInductionDto: UpdateInductionDto): PreviousQualificationsEntity? {
+    val prisonNumber = updateInductionDto.prisonNumber
     val previousQualificationsEntity = previousQualificationsRepository.findByPrisonNumber(prisonNumber)
 
     if (updateInductionDto.previousQualifications == null) {
@@ -104,10 +102,8 @@ class JpaInductionPersistenceAdapter(
     }
   }
 
-  private fun createOrUpdatePreviousQualifications(
-    createInductionDto: CreateInductionDto,
-    prisonNumber: String,
-  ): PreviousQualificationsEntity? {
+  private fun createOrUpdatePreviousQualifications(createInductionDto: CreateInductionDto): PreviousQualificationsEntity? {
+    val prisonNumber = createInductionDto.prisonNumber
     val previousQualificationsEntity = previousQualificationsRepository.findByPrisonNumber(prisonNumber)
 
     if (createInductionDto.previousQualifications == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InductionResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InductionResourceMapper.kt
@@ -80,7 +80,11 @@ class InductionResourceMapper(
         workOnReleaseMapper.toUpdateWorkOnReleaseDto(request = it, prisonId = prisonId)
       },
       previousQualifications = request.previousQualifications?.let {
-        qualificationsMapper.toUpdatePreviousQualificationsDto(request = it, prisonId = prisonId)
+        qualificationsMapper.toUpdatePreviousQualificationsDto(
+          request = it,
+          prisonNumber = prisonNumber,
+          prisonId = prisonId,
+        )
       },
       previousTraining = request.previousTraining?.let {
         previousTrainingMapper.toUpdatePreviousTrainingDto(request = it, prisonId = prisonId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InductionResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/InductionResourceMapperTest.kt
@@ -142,7 +142,7 @@ class InductionResourceMapperTest {
     val workInterests = aValidUpdateFutureWorkInterestsDto()
 
     given(workOnReleaseMapper.toUpdateWorkOnReleaseDto(any(), any())).willReturn(workOnRelease)
-    given(qualificationsMapper.toUpdatePreviousQualificationsDto(any(), any())).willReturn(qualifications)
+    given(qualificationsMapper.toUpdatePreviousQualificationsDto(any(), any(), any())).willReturn(qualifications)
     given(previousTrainingMapper.toUpdatePreviousTrainingDto(any(), any())).willReturn(training)
     given(workExperiencesMapper.toUpdatePreviousWorkExperiencesDto(any(), any())).willReturn(workExperiences)
     given(inPrisonInterestsMapper.toUpdateInPrisonInterestsDto(any(), any())).willReturn(inPrisonInterests)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/QualificationsResourceMapperTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
+import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.aValidPreviousQualifications
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.aValidQualification
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.education.dto.aValidCreatePreviousQualificationsDto
@@ -33,7 +34,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Quali
 class QualificationsResourceMapperTest {
 
   @InjectMocks
-  private lateinit var mapper: QualificationsResourceMapperImpl
+  private lateinit var mapper: QualificationsResourceMapper
 
   @Mock
   private lateinit var instantMapper: InstantMapper
@@ -174,6 +175,7 @@ class QualificationsResourceMapperTest {
   @Test
   fun `should map to UpdatePreviousQualificationsDto given qualification without a reference`() {
     // Given
+    val prisonNumber = aValidPrisonNumber()
     val prisonId = "BXI"
     val request = aValidUpdatePreviousQualificationsRequest(
       qualifications = listOf(
@@ -183,6 +185,8 @@ class QualificationsResourceMapperTest {
 
     val expected = aValidUpdatePreviousQualificationsDto(
       reference = request.reference!!,
+      prisonId = prisonId,
+      prisonNumber = prisonNumber,
       educationLevel = EducationLevelDomain.SECONDARY_SCHOOL_TOOK_EXAMS,
       qualifications = listOf(
         aValidCreateQualificationDto(
@@ -194,7 +198,11 @@ class QualificationsResourceMapperTest {
     )
 
     // When
-    val actual = mapper.toUpdatePreviousQualificationsDto(request, prisonId)
+    val actual = mapper.toUpdatePreviousQualificationsDto(
+      request = request,
+      prisonId = prisonId,
+      prisonNumber = prisonNumber,
+    )
 
     // Then
     assertThat(actual).isEqualTo(expected)
@@ -203,6 +211,7 @@ class QualificationsResourceMapperTest {
   @Test
   fun `should map to UpdatePreviousQualificationsDto given new qualification without a reference`() {
     // Given
+    val prisonNumber = aValidPrisonNumber()
     val prisonId = "BXI"
     val existingQualificationReference = UUID.randomUUID()
     val request = aValidUpdatePreviousQualificationsRequest(
@@ -214,6 +223,8 @@ class QualificationsResourceMapperTest {
 
     val expected = aValidUpdatePreviousQualificationsDto(
       reference = request.reference!!,
+      prisonId = prisonId,
+      prisonNumber = prisonNumber,
       educationLevel = EducationLevelDomain.SECONDARY_SCHOOL_TOOK_EXAMS,
       qualifications = listOf(
         aValidUpdateQualificationDto(
@@ -231,7 +242,11 @@ class QualificationsResourceMapperTest {
     )
 
     // When
-    val actual = mapper.toUpdatePreviousQualificationsDto(request, prisonId)
+    val actual = mapper.toUpdatePreviousQualificationsDto(
+      request = request,
+      prisonId = prisonId,
+      prisonNumber = prisonNumber,
+    )
 
     // Then
     assertThat(actual).isEqualTo(expected)


### PR DESCRIPTION
This PR adds the prisoner's `prisonNumber` to `UpdatePreviousQualificationsDto` and the associated changes to the mappers etc. This change (adding `prisonNumber`) is necessary to support updating a prisoner's qualifications outside of the context of updating the Induction (so it was a case of either do it here in a smaller PR, or include it in the PR that allows qualifications to be edited 🤷‍♂️  )