### PR TITLE
RR-983 - Added prisoner-search-api client class and supporting code

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,17 @@ The following environment variables are required in order for the app to start:
 
 ### APIs
 
-| Name                   | Description                                                                                     |
-|------------------------|-------------------------------------------------------------------------------------------------|
-| CIAG_INDUCTION_API_URL | The URL of the CIAG Induction API, used as part of the ETL for the CIAG Induction API migration |
-| CIAG_API_CLIENT_ID     | hmpps-auth oauth2 client-id for connecting to the CIAG Induction API                            |
-| CIAG_API_CLIENT_SECRET | hmpps-auth oauth2 client-secret for connecting to the CIAG Induction API                        |
+| Name                              | Description                                                               |
+|-----------------------------------|---------------------------------------------------------------------------|
+| PRISON_API_URL                    | The URL of the Prison API                                                 |
+| PRISON_API_CLIENT_ID              | hmpps-auth oauth2 client-id for connecting to the Prison API              |
+| PRISON_API_CLIENT_SECRET          | hmpps-auth oauth2 client-secret for connecting to the Prison API          |
+| PRISONER_SEARCH_API_URL           | The URL of the Prisoner Search API                                        |
+| PRISONER_SEARCH_API_CLIENT_ID     | hmpps-auth oauth2 client-id for connecting to the Prisoner Search API     |
+| PRISONER_SEARCH_API_CLIENT_SECRET | hmpps-auth oauth2 client-secret for connecting to the Prisoner Search API |
+| MANAGE_USERS_API_URL              | The URL of the Manage Users API                                           |
+| MANAGE_USERS_API_CLIENT_ID        | hmpps-auth oauth2 client-id for connecting to the Manage Users API        |
+| MANAGE_USERS_API_CLIENT_SECRET    | hmpps-auth oauth2 client-secret for connecting to the Manage Users API    |
 
 ## Development and maintenance
 
@@ -198,6 +204,8 @@ This API consumes, and is therefore dependent on, data from the following APIs:
 * `hmpps-auth` - Standard HMPPS Digital configuration; used for Spring Security.
 * `application-insights` - Standard HMPPS Digital configuration; used for telemetry and event tracing.
 * `prison-api` - The Prison API; used for looking up a Prisoner's prison history.
+* `manage-users-api` - The Manage Users API; used for looking up the full name (display name) of DPS users.
+* `prisoner-search-api` - The Prisoner Search API; used for looking up Prisoner data in order to get their release date.
 
 ## API consumers
 The following are the known consumers of this API. Any changes to this API - especially breaking or potentially breaking
@@ -207,11 +215,11 @@ As is standard in HMPPS projects the term "service UI" specifically means the no
 UI running in the browser. UI's running in the browser do not make xhr/ajax style requests directly to the APIs.
 
 * `hmpps-eduction-and-work-plan-ui` - The Education and Work Plan service UI (aka PLP)  
-The REST API endpoints exposed by this API are consumed by the service UI. Roles required are `ROLE_EDUCATION_WORK_PLAN_EDITOR` or
-`ROLE_EDUCATION_WORK_PLAN_VIEWER` - see the individual controller methods and/or swagger spec for specific details.
-* `hmpps-ciag-careers-induction-ui` - The CIAG Induction service UI  
-The CIAG Induction service UI consumes the `GET` endpoint in order to retrieve action plan details for a list of prison
-numbers (prisoners). The role required is `ROLE_EDUCATION_WORK_PLAN_VIEWER`
+The REST API endpoints exposed by this API are consumed by the service UI. Roles required are dependent on the API 
+endpoint being consumed - see the individual controller methods and/or swagger spec for specific details.
+* `hmpps-prisoner-profile` - The DPS Prisoner Profile UI  
+The DPS Prisoner Profile UI consumes the `GET /action-plans/{prisonNumber}/goals` endpoint in order to retrieve the
+prisoner's active goals from their action plan. The role required is `ROLE_EDUCATION_AND_WORK_PLAN__GOALS__RO`
 
 ## Feature Toggles
 Features can be toggled by setting the relevant environment variable.
@@ -219,4 +227,3 @@ Features can be toggled by setting the relevant environment variable.
 | Name                                  | Default Value | Type    | Description                                                                                                          |
 |---------------------------------------|---------------|---------|----------------------------------------------------------------------------------------------------------------------|
 | SOME_TOGGLE_ENABLED                   | false         | Boolean | Example feature toggle, for demonstration purposes.                                                                  |
-| CIAG_INDUCTION_DATA_MIGRATION_ENABLED | false         | Boolean | Set to true to enable the components that perform an ETL migration of CIAG Inductions from the CIAG API to this API. |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -221,7 +221,7 @@ tasks.register<GenerateTask>("buildPrisonApiModel") {
   )
   globalProperties.set(
     mapOf(
-      "models" to "",
+      "models" to "PrisonerInPrisonSummary,PrisonPeriod,SignificantMovement,TransferDetail",
     ),
   )
 }

--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -33,6 +33,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api.prison.service.justice.gov.uk
     MANAGE_USERS_API_URL: https://manage-users-api.hmpps.service.justice.gov.uk
+    PRISONER_SEARCH_API_URL: https://prisoner-search.prison.service.justice.gov.uk
     HMPPS_SAR_ADDITIONALACCESSROLE: ROLE_EDUCATION_WORK_PLAN_VIEWER
     HMPPS_SQS_ENABLED: true
 
@@ -46,6 +47,10 @@ generic-service:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
       PRISON_API_CLIENT_ID: "PRISON_API_CLIENT_ID"
       PRISON_API_CLIENT_SECRET: "PRISON_API_CLIENT_SECRET"
+      PRISONER_SEARCH_API_CLIENT_ID: "PRISONER_SEARCH_API_CLIENT_ID"
+      PRISONER_SEARCH_API_CLIENT_SECRET: "PRISONER_SEARCH_API_CLIENT_SECRET"
+      MANAGE_USERS_API_CLIENT_ID: "MANAGE_USERS_API_CLIENT_ID"
+      MANAGE_USERS_API_CLIENT_SECRET: "MANAGE_USERS_API_CLIENT_SECRET"
     rds-postgresql-instance-output:
       DB_SERVER: "rds_instance_address"
       DB_NAME: "database_name"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,6 +17,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api-dev.prison.service.justice.gov.uk
     MANAGE_USERS_API_URL: https://manage-users-api-dev.hmpps.service.justice.gov.uk
+    PRISONER_SEARCH_API_URL: https://prisoner-search-dev.prison.service.justice.gov.uk
     SPRING_PROFILES_ACTIVE: dev
 
   allowlist:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,6 +17,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api-preprod.prison.service.justice.gov.uk
     MANAGE_USERS_API_URL: https://manage-users-api-preprod.hmpps.service.justice.gov.uk/
+    PRISONER_SEARCH_API_URL: https://prisoner-search-preprod.prison.service.justice.gov.uk
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/integrationTest/resources/application-integration-test.yml
+++ b/src/integrationTest/resources/application-integration-test.yml
@@ -45,10 +45,17 @@ manage-users-api:
     id: manage-users-api-client-id
     secret: client-secret
 
+prisoner-search-api:
+  client:
+    id: prisoner-search-api-client-id
+    secret: client-secret
+
 apis:
   prison-api:
     url: http://localhost:9093
   manage-users-api:
+    url: http://localhost:9093
+  prisoner-search-api:
     url: http://localhost:9093
 
 hmpps:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PagedPrisonerResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PagedPrisonerResponse.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch
+
+import java.time.LocalDate
+
+data class PagedPrisonerResponse(
+  val last: Boolean,
+  val content: List<Prisoner>,
+)
+
+data class Prisoner(
+  val prisonerNumber: String,
+  val legalStatus: LegalStatus,
+  val releaseDate: LocalDate?,
+)
+
+enum class LegalStatus {
+  RECALL,
+  DEAD,
+  INDETERMINATE_SENTENCE,
+  SENTENCED,
+  CONVICTED_UNSENTENCED,
+  CIVIL_PRISONER,
+  IMMIGRATION_DETAINEE,
+  REMAND,
+  UNKNOWN,
+  OTHER,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PrisonerSearchApiClient.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+@Component
+class PrisonerSearchApiClient(
+  @Qualifier("prisonerSearchApiWebClient")
+  private val prisonerSearchApiWebClient: WebClient,
+) {
+
+  companion object {
+    const val FIRST_PAGE = 0
+    const val DEFAULT_PAGE_SIZE = 9999
+  }
+
+  fun getPrisonersByPrisonId(prisonId: String, page: Int = FIRST_PAGE, pageSize: Int = DEFAULT_PAGE_SIZE): PagedPrisonerResponse =
+    prisonerSearchApiWebClient
+      .get()
+      .uri {
+        it.path("/prisoner-search/prison/$prisonId")
+          .queryParam("page", page)
+          .queryParam("size", pageSize)
+          .build()
+      }
+      .headers {
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .retrieve()
+      .bodyToMono(PagedPrisonerResponse::class.java)
+      .onErrorResume {
+        Mono.error(PrisonerSearchApiException("Error retrieving prisoners by prisonId $prisonId", it))
+      }
+      .block()!!
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PrisonerSearchApiException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PrisonerSearchApiException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch
+
+class PrisonerSearchApiException(message: String, throwable: Throwable) : RuntimeException(message, throwable)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/WebClientConfiguration.kt
@@ -32,6 +32,14 @@ class WebClientConfiguration {
   ): WebClient =
     builder.authorisedWebClient(authorizedClientManager, registrationId = "manage-users-api", url = manageUsersApiUri)
 
+  @Bean(name = ["prisonerSearchApiWebClient"])
+  fun prisonerSearchApiWebClient(
+    authorizedClientManager: OAuth2AuthorizedClientManager,
+    builder: WebClient.Builder,
+    @Value("\${apis.prisoner-search-api.url}") prisonerSearchApiUri: String,
+  ): WebClient =
+    builder.authorisedWebClient(authorizedClientManager, registrationId = "prisoner-search-api", url = prisonerSearchApiUri)
+
   @Bean
   fun authorizedClientManager(
     clientRegistrationRepository: ClientRegistrationRepository,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,10 +24,14 @@ spring:
             scope: read
           manage-users-api:
             provider: hmpps-auth
-#           Don't be alarmed this is deliberate manage users only requires a valid token, so reusing the prison-api one.
-#           Possibly create our own token for this in the future
-            client-id: ${prison-api.client.id}
-            client-secret: ${prison-api.client.secret}
+            client-id: ${manage-users-api.client.id}
+            client-secret: ${manage-users-api.client.secret}
+            authorization-grant-type: client_credentials
+            scope: read
+          prisoner-search-api:
+            provider: hmpps-auth
+            client-id: ${prisoner-search-api.client.id}
+            client-secret: ${prisoner-search-api.client.secret}
             authorization-grant-type: client_credentials
             scope: read
         provider:
@@ -115,4 +119,6 @@ apis:
     url: ${PRISON_API_URL}
   manage-users-api:
     url: ${MANAGE_USERS_API_URL}
+  prisoner-search-api:
+    url: ${PRISONER_SEARCH_API_URL}
 


### PR DESCRIPTION
This PR adds a client for calling `prisoner-search-api`
Currently nothing uses it - this PR just introduces the class, the basic wiring, and the config.

As part of this I've asked the HAAR team to create new client creds for us (in all 3 envs) with the appropriate role (ROLE_PRISONER_SEARCH)
Whilst I was talking to HAAR I also took the opportunity to ask them to create client creds for manage-users-api 👍 
Using the dev client creds they created, I have manually tested using them against the dev APIs, all works fine 👍 

Also updated the readme in a number of places.