### PR TITLE
RR-918 - Updated sequence diagram for KPI 1

### DIFF
--- a/docs/ciag-kpis/CIAG KPI1 - PEF Apr 25 to Oct 25.mermaid
+++ b/docs/ciag-kpis/CIAG KPI1 - PEF Apr 25 to Oct 25.mermaid
@@ -7,21 +7,18 @@ sequenceDiagram
 
   actor Prisoner as Prisoner
   actor CIAG as CIAG
-  participant NOMIS as NOMIS/HMPPS Domain Events
-  participant Curious as Curious
   participant PLP as PLP
   participant PLPDB as PLP DB
+  participant NOMIS as NOMIS/HMPPS Domain Events
+  participant Integration as HMPPS Integration API
+  participant IntegrationDB as HMPPS Integration DB
+  participant Curious as Curious
 
   rect rgba(0, 200, 255, 0.4)
     Prisoner ->> NOMIS: Prisoner enters prison
     note over Prisoner, NOMIS: New or re-offending prisoner
     activate NOMIS
     deactivate NOMIS
-
-    activate Curious
-      note left of Curious: Curious processes<br/>prisoner.received event<br/>reason: admission
-      NOMIS -) Curious: prison-offender-events.prisoner.received event
-    deactivate Curious
 
     activate PLP
       note left of PLP: PLP API processes<br/>prisoner.received event<br/>reason: admission
@@ -31,7 +28,7 @@ sequenceDiagram
           PLP ->> PLPDB: Create new Induction Schedule record
           note right of PLPDB: Induction deadline date<br/>set to today + 30 days (TBD)
         deactivate PLPDB
-        PLP -) NOMIS: induction.deadline.set event
+        PLP -) NOMIS: prisoner.induction.updated event
       else Prisoner already has a PLP<br/>eg. re-offending prisoner
         note over PLP: TODO - This is essentially the "review" process from KPI2
       end
@@ -44,11 +41,6 @@ sequenceDiagram
     activate NOMIS
     deactivate NOMIS
 
-    activate Curious
-      note left of Curious: Curious processes<br/>prisoner.received event<br/>reason: transferred
-      NOMIS -) Curious: prison-offender-events.prisoner.received event
-    deactivate Curious
-
     activate PLP
       note left of PLP: PLP API processes<br/>prisoner.received event<br/>reason: transferred
       NOMIS -) PLP: prison-offender-events.prisoner.received event
@@ -57,7 +49,7 @@ sequenceDiagram
           PLP ->> PLPDB: Create new Induction Schedule record
           note right of PLPDB: Induction deadline date<br/>set to today + 30 days (TBD)
         deactivate PLPDB
-        PLP -) NOMIS: induction.deadline.set event
+        PLP -) NOMIS: prisoner.induction.updated event
       else Prisoner already has a PLP<br/>eg. PLP was done in previous prison
         note over PLP: TODO - This is essentially the "review" process from KPI2
       end
@@ -69,17 +61,12 @@ sequenceDiagram
     activate NOMIS
     deactivate NOMIS
 
-    activate Curious
-      note left of Curious: Curious processes<br/>prisoner.released event
-      NOMIS -) Curious: prison-offender-events.prisoner.released event
-    deactivate Curious
-
     activate PLP
       note left of PLP: PLP API processes<br/>prisoner.released event
       NOMIS -) PLP: prison-offender-events.prisoner.released event
       opt Prisoner has a PLP
         PLP ->> PLPDB: Record exemption reason
-        PLP -) NOMIS: induction.exempt event
+        PLP -) NOMIS: prisoner.induction.updated event
       end
     deactivate PLP
   end
@@ -89,17 +76,12 @@ sequenceDiagram
     activate NOMIS
     deactivate NOMIS
 
-    activate Curious
-      note left of Curious: Curious processes<br/>prisoner.released event<br/>nomisMovementReasonCode: DEC
-      NOMIS -) Curious: prison-offender-events.prisoner.released event
-    deactivate Curious
-
     activate PLP
       note left of PLP: PLP API processes<br/>prisoner.released event<br/>nomisMovementReasonCode: DEC
       NOMIS -) PLP: prison-offender-events.prisoner.released event
       opt Prisoner has a PLP
         PLP ->> PLPDB: Record exemption reason
-        PLP -) NOMIS: induction.exempt event
+        PLP -) NOMIS: prisoner.induction.updated event
       end
     deactivate PLP
   end
@@ -110,19 +92,12 @@ sequenceDiagram
         CIAG ->> PLP: Do prisoner's Induction
         alt Prisoners Induction could not be completed due to exemptions
           PLP ->> PLPDB: Record exemption reason
-          PLP -) NOMIS: induction.exempt event
         else
-          PLP -) NOMIS: induction.complete event
+          PLP ->> PLPDB: Record prisoner's induction
         end
+        PLP -) NOMIS: prisoner.induction.updated event
       deactivate PLP
     deactivate CIAG
-  end
-
-  rect rgba(0, 200, 255, 0.4)
-    activate PLP
-      note left of PLP: PLP API processes<br/>prisoner.released event
-      NOMIS -) PLP: prisoner.released event
-    deactivate PLP
   end
 
   rect rgba(0, 200, 255, 0.4)
@@ -130,38 +105,39 @@ sequenceDiagram
       activate PLP
         CIAG ->> PLP: Clear prisoner's Induction exemption
         PLP ->> PLPDB: Clear exemption reason
-        PLP -) NOMIS: induction.exempt.cleared event
         PLP ->> PLPDB: Update Induction Schedule record
         note right of PLPDB: Induction deadline date<br/>set to today + 5 days
-        PLP -) NOMIS: induction.deadline.set event
+        PLP -) NOMIS: prisoner.induction.updated event
       deactivate PLP
     deactivate CIAG
   end
 
-  rect rgba(0, 200, 255, 0.4)
+  rect rgba(0, 255, 200, 0.4)
+    activate Integration
+      note left of Integration: HMPPS Integration API processes<br/>prisoner.induction.updated event
+      NOMIS -) Integration: prisoner.induction.updated event
+      Integration ->> PLP: get prisoner's induction meta data
+      activate PLP
+        PLP ->> PLPDB: get prisoner's induction meta data
+        PLPDB ->> PLP: prisoner's induction meta data
+        PLP ->> Integration: prisoner's induction meta data
+      deactivate PLP
+      Integration ->> IntegrationDB: Store prisoner's induction meta data
+      Integration -) NOMIS: prisoner.induction.metadata.available event
+    deactivate Integration
+  end
+
+  rect rgba(255, 100, 100, 0.4)
     activate Curious
-    note left of Curious: Curious processes<br/>induction.deadline.set event
-    NOMIS -) Curious: induction.deadline.set event
+      note left of Curious: Curious processes<br/>prisoner.induction.metadata.available event
+      NOMIS -) Curious: prisoner.induction.metadata.available event
+      Curious ->> Integration: get prisoner's induction meta data
+      activate Integration
+        Integration ->> IntegrationDB: get prisoner's induction meta data
+        IntegrationDB ->> Integration: prisoner's induction meta data
+        Integration ->> Curious: prisoner's induction meta data
+      deactivate Integration
+      note left of Curious: Curious processes prisoner's induction meta data<br/>in order to produce reports
     deactivate Curious
   end
 
-  rect rgba(0, 200, 255, 0.4)
-    activate Curious
-      note left of Curious: Curious processes<br/>induction.complete event
-      NOMIS -) Curious: induction.complete event
-    deactivate Curious
-  end
-
-  rect rgba(0, 200, 255, 0.4)
-    activate Curious
-      note left of Curious: Curious processes<br/>induction.exempt event
-      NOMIS -) Curious: induction.exempt event
-    deactivate Curious
-  end
-
-  rect rgba(0, 200, 255, 0.4)
-    activate Curious
-      note left of Curious: Curious processes<br/>induction.exempt event
-      NOMIS -) Curious: induction.exempt.cleared event
-    deactivate Curious
-  end

--- a/docs/ciag-kpis/README.md
+++ b/docs/ciag-kpis/README.md
@@ -49,9 +49,11 @@ but TBC); without any regard for when screenings and assessments might or might 
 This folder contains 2 sequence diagrams that cover KPI 1, one for PEF April 2025 to October 2025, and one for
 PES October 2025 onwards.
 
-**Please note** - In the sequence diagrams the blue boxes do not mean anything. They are there simply to differentiate 
-different parts or processes of the system. Without the boxes it is hard to see where one process ends and another 
-starts.
+**Please note** - In the sequence diagrams coloured boxes are used to group together and designate higher level
+processes. Without the boxes it is hard to see where one process ends and another starts.
+* Blue boxes represent PLP based processing
+* Green boxes represent the HMPPS Integration API
+* Red boxes represent Curious based processes
 
 ## CIAG KPI 2
 TODO ....


### PR DESCRIPTION
This PR documents the new proposed flow in for KPI1 as discussed with Matt Ryall and Stephen Mcallister.

The basic idea is that we do not try to use lots of backwards & forwards granular events to try to co-ordinate / orchestrate processes within 2 otherwise unconnected systems (PLP and Curious)
Instead PLP does it's thing and manages its own state/process. But every time that the Induction Schedule is updated for any reason, it publishes an SNS message (the detail of which is not defined in this PR/spec). 
HMPPS Integration API processes this event via a subscription and queue to the message and calls PLP's REST API to get the details of the Induction Schedule (again, the detail of which is not the scope of this PR)
HMPPS Integration API then publishes an SNS message which is received and processed by Curious.
Curious then calls HMPPS Integration API's REST API in order to get the current state of the Induction Schedule.
Curious can then process the current Induction Schedule to determine metrics to produce reports etc to faciliate CIAG KPI reporting.

---

For the purpose of making it easier to review this PR, this is the rendered proposed sequence diagram:
https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/blob/feature/RR-918-updated-KPI1-sequence-diagram/docs/ciag-kpis/CIAG%20KPI1%20-%20PEF%20Apr%2025%20to%20Oct%2025.mermaid
