### PR TITLE
archive note changes

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/service/NotePersistenceAdapter.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/service/NotePersistenceAdapter.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.service
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.CreateNoteDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.EntityType
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteType
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.UpdateNoteDto
 import java.util.*
 
@@ -24,10 +25,15 @@ interface NotePersistenceAdapter {
   /**
    * Gets the notes associated with this entity reference.
    */
-  fun getNotes(entityReference: UUID, entityType: EntityType): List<NoteDto>
+  fun getNotes(entityReference: UUID, entityType: EntityType, noteType: NoteType): List<NoteDto>
 
   /**
    * update a [Note].
    */
   fun updateNote(updateNoteDto: UpdateNoteDto): NoteDto
+
+  /**
+   * delete a [Note] by the entity reference.
+   */
+  fun deleteNoteByEntityReference(entityReference: UUID, entityType: EntityType, noteType: NoteType)
 }

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/service/NoteService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/service/NoteService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.service
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.CreateNoteDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.EntityType
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteType
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.UpdateNoteDto
 import java.util.UUID
 
@@ -11,11 +12,15 @@ class NoteService(private val notePersistenceAdapter: NotePersistenceAdapter) {
     return notePersistenceAdapter.createNote(createNoteDto)
   }
 
-  fun getNotes(entityReference: UUID, entityType: EntityType): List<NoteDto> {
-    return notePersistenceAdapter.getNotes(entityReference, entityType)
+  fun getNotes(entityReference: UUID, entityType: EntityType, noteType: NoteType): List<NoteDto> {
+    return notePersistenceAdapter.getNotes(entityReference, entityType, noteType)
   }
 
   fun updateNote(updateNoteDto: UpdateNoteDto): NoteDto {
     return notePersistenceAdapter.updateNote(updateNoteDto)
+  }
+
+  fun deleteNote(entityReference: UUID, entityType: EntityType, noteType: NoteType) {
+    notePersistenceAdapter.deleteNoteByEntityReference(entityReference, entityType, noteType)
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
@@ -15,6 +15,8 @@ import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.aValidReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.NoteType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ArchiveGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
@@ -33,7 +35,7 @@ import java.util.*
 class ArchiveGoalTest : IntegrationTestBase() {
 
   companion object {
-    private const val URI_TEMPLATE = "/action-plans/{prisonNumber}/goals/{goalReference}/archive"
+    const val URI_TEMPLATE = "/action-plans/{prisonNumber}/goals/{goalReference}/archive"
   }
 
   private val prisonNumber = aValidPrisonNumber()
@@ -107,6 +109,61 @@ class ArchiveGoalTest : IntegrationTestBase() {
       val goalArchivedEventProperties = eventPropertiesCaptor.firstValue
       assertThat(goalArchivedEventProperties)
         .containsEntry("reference", goalReference.toString())
+    }
+  }
+
+  @Test
+  fun `should return 204 and archive a goal and record the reason and other text and create an archive note`() {
+    // given
+    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val reasonOther = "Because it's Monday"
+    val noteText = "no longer relevant"
+    val archiveGoalRequest = aValidArchiveGoalRequest(
+      goalReference = goalReference,
+      ReasonToArchiveGoal.OTHER,
+      reasonOther,
+      note = noteText,
+    )
+
+    // when
+    archiveAGoal(prisonNumber, goalReference, archiveGoalRequest)
+      .expectStatus()
+      .isNoContent()
+
+    // then
+    assertThat(getActionPlan(prisonNumber))
+      .isForPrisonNumber(prisonNumber)
+      .hasNumberOfGoals(1)
+      .goal(1) { goal ->
+        goal
+          .hasStatus(GoalStatus.ARCHIVED)
+          .hasArchiveReason(ReasonToArchiveGoal.OTHER)
+          .hasArchiveReasonOther(reasonOther)
+      }
+
+    await.untilAsserted {
+      val timeline = getTimeline(prisonNumber)
+      assertThat(timeline)
+        .event(3) { // the 3rd Timeline event will be the GOAL_ARCHIVED event
+          it.hasEventType(TimelineEventType.GOAL_ARCHIVED)
+            .wasActionedBy("buser_gen")
+            .hasActionedByDisplayName("Bernie User")
+        }
+
+      val eventPropertiesCaptor = ArgumentCaptor.forClass(Map::class.java as Class<Map<String, String>>)
+
+      verify(telemetryClient).trackEvent(
+        eq("goal-archived"),
+        capture(eventPropertiesCaptor),
+        eq(null),
+      )
+
+      val goalArchivedEventProperties = eventPropertiesCaptor.firstValue
+      assertThat(goalArchivedEventProperties)
+        .containsEntry("reference", goalReference.toString())
+
+      val note = noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(goalReference, EntityType.GOAL, NoteType.GOAL_ARCHIVAL).firstOrNull()
+      assertThat(note!!.content).isEqualTo(noteText)
     }
   }
 
@@ -222,7 +279,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
       .hasUserMessageContaining("Could not archive goal with reference [$goalReference] for prisoner [$prisonNumber]: Goal was in state [ARCHIVED] that can't be archived")
   }
 
-  private fun archiveAGoal(
+  fun archiveAGoal(
     prisonNumber: String,
     goalReference: UUID,
     archiveGoalRequest: ArchiveGoalRequest,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
@@ -279,7 +279,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
       .hasUserMessageContaining("Could not archive goal with reference [$goalReference] for prisoner [$prisonNumber]: Goal was in state [ARCHIVED] that can't be archived")
   }
 
-  fun archiveAGoal(
+  private fun archiveAGoal(
     prisonNumber: String,
     goalReference: UUID,
     archiveGoalRequest: ArchiveGoalRequest,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestB
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.StepStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.NoteType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
@@ -229,7 +230,7 @@ class CreateActionPlanTest : IntegrationTestBase() {
       .hasStatus(StepStatus.NOT_STARTED)
       .wasCreatedBy(dpsUsername)
 
-    val notes = noteRepository.findAllByEntityReferenceAndEntityType(actionPlan.goals!![0].reference!!, EntityType.GOAL)
+    val notes = noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(actionPlan.goals!![0].reference!!, EntityType.GOAL, NoteType.GOAL)
     Assertions.assertThat(notes.size).isGreaterThan(0)
     Assertions.assertThat(notes[0].content).isEqualTo("Chris would like to improve his listening skills, not just his verbal communication")
   }
@@ -330,11 +331,11 @@ class CreateActionPlanTest : IntegrationTestBase() {
       .hasStatus(StepStatus.NOT_STARTED)
       .wasCreatedBy(dpsUsername)
 
-    val notesForGoal1 = noteRepository.findAllByEntityReferenceAndEntityType(actionPlan.goals!![0].reference!!, EntityType.GOAL)
+    val notesForGoal1 = noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(actionPlan.goals!![0].reference!!, EntityType.GOAL, NoteType.GOAL)
     Assertions.assertThat(notesForGoal1.size).isGreaterThan(0)
     Assertions.assertThat(notesForGoal1[0].content).isEqualTo("Chris would like to improve his listening skills, not just his verbal communication")
 
-    val notesForGoal2 = noteRepository.findAllByEntityReferenceAndEntityType(actionPlan.goals!![1].reference!!, EntityType.GOAL)
+    val notesForGoal2 = noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(actionPlan.goals!![1].reference!!, EntityType.GOAL, NoteType.GOAL)
     Assertions.assertThat(notesForGoal2.size).isGreaterThan(0)
     Assertions.assertThat(notesForGoal2[0].content).isEqualTo("Goal2 text")
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalsTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalsTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.NoteType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.StepStatus
@@ -238,11 +239,11 @@ class CreateGoalsTest : IntegrationTestBase() {
         .containsKey("correlationId")
     }
 
-    val notes1 = noteRepository.findAllByEntityReferenceAndEntityType(actual.goals[0].goalReference, EntityType.GOAL)
+    val notes1 = noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(actual.goals[0].goalReference, EntityType.GOAL, NoteType.GOAL)
     assertThat(notes1.size).isGreaterThan(0)
     assertThat(notes1[0].content).isEqualTo("a second note")
 
-    val notes2 = noteRepository.findAllByEntityReferenceAndEntityType(actual.goals[1].goalReference, EntityType.GOAL)
+    val notes2 = noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(actual.goals[1].goalReference, EntityType.GOAL, NoteType.GOAL)
     assertThat(notes2.size).isGreaterThan(0)
     assertThat(notes2[0].content).isEqualTo("Chris would like to improve his listening skills, not just his verbal communication")
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.domain.aValidReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.NoteType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
@@ -404,7 +405,7 @@ class UpdateGoalTest : IntegrationTestBase() {
           .hasActionedByDisplayName("Bernie User")
       }
 
-    val notes = noteRepository.findAllByEntityReferenceAndEntityType(actual.goals[0].goalReference, EntityType.GOAL)
+    val notes = noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(actual.goals[0].goalReference, EntityType.GOAL, NoteType.GOAL)
     assertThat(notes.size).isGreaterThan(0)
     assertThat(notes[0].content).isEqualTo("Updated goal text")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaNotePersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaNotePersistenceAdapter.kt
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.CreateNoteDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.EntityType
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteType
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.UpdateNoteDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.service.NotePersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.note.NoteMapper
@@ -22,8 +23,12 @@ class JpaNotePersistenceAdapter(
     return NoteMapper.toModel(noteEntity)
   }
 
-  override fun getNotes(entityReference: UUID, entityType: EntityType): List<NoteDto> {
-    return noteRepository.findAllByEntityReferenceAndEntityType(entityReference, NoteMapper.toEntity(entityType)).map { NoteMapper.toModel(it) }
+  override fun getNotes(entityReference: UUID, entityType: EntityType, noteType: NoteType): List<NoteDto> {
+    return noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(
+      entityReference,
+      NoteMapper.toEntity(entityType),
+      NoteMapper.toEntity(noteType),
+    ).map { NoteMapper.toModel(it) }
   }
 
   override fun updateNote(updateNoteDto: UpdateNoteDto): NoteDto {
@@ -32,5 +37,13 @@ class JpaNotePersistenceAdapter(
     noteEntity.updatedAtPrison = updateNoteDto.lastUpdatedAtPrison
     noteRepository.save(noteEntity)
     return NoteMapper.toModel(noteEntity)
+  }
+
+  override fun deleteNoteByEntityReference(entityReference: UUID, entityType: EntityType, noteType: NoteType) {
+    noteRepository.deleteNoteEntityByEntityReferenceAndEntityTypeAndNoteType(
+      entityReference,
+      NoteMapper.toEntity(entityType),
+      NoteMapper.toEntity(noteType),
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/NoteRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/NoteRepository.kt
@@ -1,16 +1,23 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.NoteEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.NoteType
 import java.util.UUID
 
 @Repository
 interface NoteRepository : JpaRepository<NoteEntity, UUID> {
   fun findAllByPrisonNumber(prisonNumber: String): List<NoteEntity>
 
-  fun findAllByEntityReferenceAndEntityType(entityReference: UUID, entityType: EntityType): List<NoteEntity>
+  fun findAllByEntityReferenceAndEntityTypeAndNoteType(entityReference: UUID, entityType: EntityType, noteType: NoteType): List<NoteEntity>
 
   fun findByReference(entityReference: UUID): NoteEntity
+
+  fun findAllByEntityReference(entityReference: UUID): NoteEntity
+
+  @Modifying
+  fun deleteNoteEntityByEntityReferenceAndEntityTypeAndNoteType(entityReference: UUID, entityType: EntityType, noteType: NoteType)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalNoteService.kt
@@ -25,11 +25,11 @@ class GoalNoteService(
   }
 
   override fun getNotes(entityReference: UUID): String? {
-    return noteService.getNotes(entityReference, EntityType.GOAL).firstOrNull()?.content
+    return noteService.getNotes(entityReference, EntityType.GOAL, NoteType.GOAL).firstOrNull()?.content
   }
 
   override fun updateNotes(entityReference: UUID, lastUpdatedAtPrison: String, updatedText: String?) {
-    val note = noteService.getNotes(entityReference, EntityType.GOAL).firstOrNull()
+    val note = noteService.getNotes(entityReference, EntityType.GOAL, NoteType.GOAL).firstOrNull()
     // If no note exists, return early
     note?.let {
       noteService.updateNote(

--- a/src/main/resources/db/migration/common/V2024.11.09.0006__update_note_column.sql
+++ b/src/main/resources/db/migration/common/V2024.11.09.0006__update_note_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE note
+    ALTER COLUMN note_type TYPE VARCHAR(50);

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -821,6 +821,10 @@ components:
         archiveReasonOther:
           type: string
           description: Describes the reason for archiving if 'OTHER' is selected, it is mandatory in this scenario.
+        archiveNote:
+          type: string
+          description: Note relating to the goal archival.
+          example: Goal no longer relevant.
       required:
         - goalReference
         - title
@@ -1775,6 +1779,9 @@ components:
         reasonOther:
           type: string
           description: Describes the reason for archiving if 'OTHER' is selected, it is mandatory in this scenario.
+        note:
+          type: string
+          description: An optional note to accompany the archive
       required:
         - goalReference
         - reason

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaNotePersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaNotePersistenceAdapterTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.EntityType
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteType
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.UpdateNoteDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.aValidCreateNoteDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.aValidNoteDto
@@ -51,26 +52,29 @@ class JpaNotePersistenceAdapterTest {
     // given
     val entityReference = UUID.randomUUID()
     val entityType = EntityType.GOAL
+    val noteType = NoteType.GOAL
     val noteDTO = aValidNoteDto()
     val noteEntity = aValidNoteEntity(content = noteDTO.content)
 
     given(
-      noteRepository.findAllByEntityReferenceAndEntityType(
+      noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(
         entityReference,
         NoteMapper.toEntity(entityType),
+        NoteMapper.toEntity(noteType),
       ),
     ).willReturn(
       listOf(noteEntity),
     )
 
     // when
-    val result = persistenceAdapter.getNotes(entityReference, entityType)
+    val result = persistenceAdapter.getNotes(entityReference, entityType, noteType)
 
     // then
     Assertions.assertThat(result[0].content).isEqualTo(noteDTO.content)
-    verify(noteRepository, times(1)).findAllByEntityReferenceAndEntityType(
+    verify(noteRepository, times(1)).findAllByEntityReferenceAndEntityTypeAndNoteType(
       entityReference,
       NoteMapper.toEntity(entityType),
+      NoteMapper.toEntity(noteType),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalControllerTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.service.NoteService
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.Goal
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidGoal
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.GetGoalsDto
@@ -21,8 +22,9 @@ import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus as Go
 class GoalControllerTest {
 
   private val goalService = mock<GoalService>()
+  private val noteService = mock<NoteService>()
   private val goalResourceMapper = mock<GoalResourceMapper>()
-  private val controller = GoalController(goalService, goalResourceMapper)
+  private val controller = GoalController(goalService, goalResourceMapper, noteService)
 
   private val prisonNumber = aValidPrisonNumber()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/UpdateGoalRequestReferenceConstraintValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/UpdateGoalRequestReferenceConstraintValidatorTest.kt
@@ -15,7 +15,7 @@ class UpdateGoalRequestReferenceConstraintValidatorTest {
   private val validatorFactory = Validation.buildDefaultValidatorFactory()
   private val validator = validatorFactory.validator.forExecutables()
 
-  private val goalController = GoalController(mock(), mock())
+  private val goalController = GoalController(mock(), mock(), mock())
   private val updateGoalMethod = GoalController::class.java.getMethod(
     "updateGoal",
     UpdateGoalRequest::class.java,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalNoteServiceTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.EntityType
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteType
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.UpdateNoteDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.aValidNoteDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.service.NoteService
@@ -51,14 +52,14 @@ class GoalNoteServiceTest {
       aValidNoteDto(reference = UUID.randomUUID(), content = "Second note"),
     )
 
-    given(noteService.getNotes(entityReference, EntityType.GOAL)).willReturn(notes)
+    given(noteService.getNotes(entityReference, EntityType.GOAL, NoteType.GOAL)).willReturn(notes)
 
     // When
     val result = goalNoteService.getNotes(entityReference)
 
     // Then
     assert(result == "First note")
-    verify(noteService, times(1)).getNotes(entityReference, EntityType.GOAL)
+    verify(noteService, times(1)).getNotes(entityReference, EntityType.GOAL, NoteType.GOAL)
   }
 
   @Test
@@ -69,7 +70,7 @@ class GoalNoteServiceTest {
     val updatedText = "Updated note content"
     val existingNote = aValidNoteDto(reference = UUID.randomUUID(), content = "Old content")
 
-    given(noteService.getNotes(entityReference, EntityType.GOAL)).willReturn(listOf(existingNote))
+    given(noteService.getNotes(entityReference, EntityType.GOAL, NoteType.GOAL)).willReturn(listOf(existingNote))
 
     // When
     goalNoteService.updateNotes(entityReference, lastUpdatedAtPrison, updatedText)
@@ -91,7 +92,7 @@ class GoalNoteServiceTest {
     val lastUpdatedAtPrison = "Prison A"
     val updatedText = "Updated note content"
 
-    given(noteService.getNotes(entityReference, EntityType.GOAL)).willReturn(emptyList())
+    given(noteService.getNotes(entityReference, EntityType.GOAL, NoteType.GOAL)).willReturn(emptyList())
 
     // When
     goalNoteService.updateNotes(entityReference, lastUpdatedAtPrison, updatedText)

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/ArchiveGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/ArchiveGoalRequestBuilder.kt
@@ -9,9 +9,11 @@ fun aValidArchiveGoalRequest(
   goalReference: UUID = aValidReference(),
   reason: ReasonToArchiveGoal = ReasonToArchiveGoal.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL,
   reasonOther: String? = null,
+  note: String? = null,
 ): ArchiveGoalRequest =
   ArchiveGoalRequest(
     goalReference = goalReference,
     reason = reason,
     reasonOther = reasonOther,
+    note = note,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GoalResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GoalResponseAssert.kt
@@ -157,6 +157,16 @@ class GoalResponseAssert(actual: GoalResponse?) :
     return this
   }
 
+  fun hasArchiveNote(expected: String?): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (archiveNote != expected) {
+        failWithMessage("Expected archive note to be $expected, but was $archiveNote")
+      }
+    }
+    return this
+  }
+
   /**
    * Allows for assertion chaining into the specified child [StepResponse]. Takes a lambda as the method argument
    * to call assertion methods provided by [StepResponseAssert].


### PR DESCRIPTION
Changes to Archive Goal such that there is an optional parameter of note - this will then create a Note linked to the goal and a note type of GOAL_ARCHIVAL. 

Reactivating will hard delete this note. 

Additional change to the getGoal endpoint to return this single note as an archiveNote String - although I think it would be better to return as a list of notes - together with note type... watch this space. 

