### PR TITLE
adding notes to get action plan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,8 @@ jobs:
             domain/timeline/build/reports/jacoco
       - store_artifacts:
           path: build-reports.tar
+      - store_artifacts:
+          path: build/reports/tests
 
 workflows:
   version: 2

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/service/NotePersistenceAdapter.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/service/NotePersistenceAdapter.kt
@@ -25,6 +25,11 @@ interface NotePersistenceAdapter {
   /**
    * Gets the notes associated with this entity reference.
    */
+  fun getNotes(entityReference: UUID, entityType: EntityType): List<NoteDto>
+
+  /**
+   * Gets the notes associated with this entity reference and NoteType.
+   */
   fun getNotes(entityReference: UUID, entityType: EntityType, noteType: NoteType): List<NoteDto>
 
   /**

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/service/NoteService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/service/NoteService.kt
@@ -12,6 +12,10 @@ class NoteService(private val notePersistenceAdapter: NotePersistenceAdapter) {
     return notePersistenceAdapter.createNote(createNoteDto)
   }
 
+  fun getNotes(entityReference: UUID, entityType: EntityType): List<NoteDto> {
+    return notePersistenceAdapter.getNotes(entityReference, entityType)
+  }
+
   fun getNotes(entityReference: UUID, entityType: EntityType, noteType: NoteType): List<NoteDto> {
     return notePersistenceAdapter.getNotes(entityReference, entityType, noteType)
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -106,6 +106,8 @@ class GetActionPlanTest : IntegrationTestBase() {
           .wasUpdatedBy("auser_gen")
           .hasUpdatedByDisplayName("Albert User")
           .hasNotes("Chris would like to improve his listening skills, not just his verbal communication")
+          .hasGoalNote("Chris would like to improve his listening skills, not just his verbal communication")
+          .hasArchiveNote(null)
       }
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
@@ -130,7 +130,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
     val archiveRequestWithOtherReason = aValidArchiveGoalRequest(
       goalReference = goalReference,
       reason = ReasonToArchiveGoal.OTHER,
-      reasonOther = "Other reason",
+      reasonOther = reasonOther,
       note = archiveNote,
     )
     archiveAGoal(prisonNumber, goalReference, archiveRequestWithOtherReason)
@@ -155,6 +155,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
           .hasStatus(GoalStatus.ACTIVE)
           .hasArchiveReason(null)
           .hasArchiveReasonOther(null)
+          .hasArchiveNote(null) // previous archive note will be removed
       }
 
     await.untilAsserted {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -395,6 +395,7 @@ class UpdateGoalTest : IntegrationTestBase() {
           .wasUpdatedAtPrison("BXI")
           .wasCreatedBy("auser_gen")
           .wasUpdatedBy("buser_gen")
+          .hasGoalNote("Updated goal text")
       }
 
     val timeline = getTimeline(prisonNumber)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaNotePersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaNotePersistenceAdapter.kt
@@ -23,6 +23,13 @@ class JpaNotePersistenceAdapter(
     return NoteMapper.toModel(noteEntity)
   }
 
+  override fun getNotes(entityReference: UUID, entityType: EntityType): List<NoteDto> {
+    return noteRepository.findAllByEntityReferenceAndEntityType(
+      entityReference,
+      NoteMapper.toEntity(entityType),
+    ).map { NoteMapper.toModel(it) }
+  }
+
   override fun getNotes(entityReference: UUID, entityType: EntityType, noteType: NoteType): List<NoteDto> {
     return noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(
       entityReference,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/NoteRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/NoteRepository.kt
@@ -13,6 +13,11 @@ import java.util.UUID
 interface NoteRepository : JpaRepository<NoteEntity, UUID> {
   fun findAllByPrisonNumber(prisonNumber: String): List<NoteEntity>
 
+  fun findAllByEntityReferenceAndEntityType(
+    entityReference: UUID,
+    entityType: EntityType,
+  ): List<NoteEntity>
+
   fun findAllByEntityReferenceAndEntityTypeAndNoteType(
     entityReference: UUID,
     entityType: EntityType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -69,7 +69,7 @@ class GoalController(
   ): GoalResponse {
     val response = goalResourceMapper.fromDomainToModel(goalService.getGoal(prisonNumber, goalReference))
     // Get the archive note and update the response if present
-    val notes = noteService.getNotes(response.goalReference, EntityType.GOAL, NoteType.GOAL_ARCHIVAL)
+    val notes = noteService.getNotes(response.goalReference, EntityType.GOAL)
     return response.copy(goalNotes = notes.map { Note(it.reference, it.content, NoteMapper.toResourceModel(it.noteType)) })
   }
 

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1793,7 +1793,7 @@ components:
       type: object
       description: An object representing a note.
       properties:
-        noteReference:
+        reference:
           type: string
           format: uuid
           description: The Notes unique reference. This is used as an identifier to archive the required Note.

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GoalResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GoalResponseAssert.kt
@@ -159,14 +159,26 @@ class GoalResponseAssert(actual: GoalResponse?) :
   }
 
   fun hasArchiveNote(expected: String?): GoalResponseAssert {
+    return hasNoteOfType(NoteType.GOAL_ARCHIVAL, expected, "archive")
+  }
+
+  fun hasGoalNote(expected: String?): GoalResponseAssert {
+    return hasNoteOfType(NoteType.GOAL, expected, "goal")
+  }
+
+  private fun hasNoteOfType(noteType: NoteType, expected: String?, noteLabel: String): GoalResponseAssert {
     isNotNull
     with(actual!!) {
-      val archiveNote = goalNotes?.firstOrNull { it.type == NoteType.GOAL_ARCHIVAL }
-      if (archiveNote != null && archiveNote.content != expected) {
-        failWithMessage("Expected archive note to be $expected, but was ${archiveNote.content}")
-      }
-      if (expected == null && archiveNote != null) {
-        failWithMessage("Expected no archive note, but was ${archiveNote.content}")
+      val note = goalNotes?.firstOrNull { it.type == noteType }
+      when {
+        note == null && expected != null ->
+          failWithMessage("Expected $noteLabel note to be $expected, but was null")
+
+        note != null && note.content != expected ->
+          failWithMessage("Expected $noteLabel note to be $expected, but was ${note.content}")
+
+        expected == null && note != null ->
+          failWithMessage("Expected no $noteLabel note, but was ${note.content}")
       }
     }
     return this


### PR DESCRIPTION
Follow on work from the previous work to add (Archive) Goal notes. This PR returns a list of notes when a  goal is presented to the UI, Currently these are GOAL and ARCHIVE notes but in the future this will include GOAL_COMPLETE notes. 

The existing mechanism for getting goal notes has been retained.

Additionally, Circle CI config has been updated to display test results in the event of a test failure. 