### PR TITLE
RR-998 - Added displayName fields to NotesResource and related mappers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/manageusers/ManageUsersApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/manageusers/ManageUsersApiClient.kt
@@ -7,14 +7,14 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 @Component
 class ManageUsersApiClient(@Qualifier("manageUsersApiWebClient") private val manageUsersApiClient: WebClient) {
-  fun getUserDetails(username: String): UserDetailsDto? {
+  fun getUserDetails(username: String): UserDetailsDto {
     return try {
       manageUsersApiClient
         .get()
         .uri("/users/{username}", username)
         .retrieve()
         .bodyToMono(UserDetailsDto::class.java)
-        .block()
+        .block()!!
     } catch (e: WebClientResponseException.NotFound) {
       UserDetailsDto(username, false, "$username not found")
     } catch (e: Exception) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/note/NoteMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/note/NoteMapper.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.Enti
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteType as DomainNoteType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType as EntityEntityType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.NoteType as EntityNoteType
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.NoteType as ResourceNoteType
 
 object NoteMapper {
 
@@ -53,13 +52,6 @@ object NoteMapper {
       EntityNoteType.GOAL -> DomainNoteType.GOAL
       EntityNoteType.GOAL_ARCHIVAL -> DomainNoteType.GOAL_ARCHIVAL
       EntityNoteType.GOAL_COMPLETION -> DomainNoteType.GOAL_COMPLETION
-    }
-
-  fun toResourceModel(noteType: DomainNoteType) =
-    when (noteType) {
-      DomainNoteType.GOAL -> ResourceNoteType.GOAL
-      DomainNoteType.GOAL_ARCHIVAL -> ResourceNoteType.GOAL_ARCHIVAL
-      DomainNoteType.GOAL_COMPLETION -> ResourceNoteType.GOAL_COMPLETION
     }
 
   fun toEntity(entityType: DomainEntityType) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ActionPlanController.kt
@@ -17,14 +17,13 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.EntityType
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.service.NoteService
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.service.ActionPlanService
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.note.NoteMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.ActionPlanResourceMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.note.NoteResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.PRISON_NUMBER_FORMAT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanSummaryListResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GetActionPlanSummariesRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Note
 
 @RestController
 @Validated
@@ -33,6 +32,7 @@ class ActionPlanController(
   private val actionPlanService: ActionPlanService,
   private val actionPlanMapper: ActionPlanResourceMapper,
   private val noteService: NoteService,
+  private val noteResourceMapper: NoteResourceMapper,
 ) {
 
   @PostMapping("/{prisonNumber}")
@@ -59,13 +59,7 @@ class ActionPlanController(
       val notes = noteService.getNotes(goalResponse.goalReference, EntityType.GOAL)
 
       // Map the notes into their respective models
-      val mappedNotes = notes.map { note ->
-        Note(
-          reference = note.reference,
-          content = note.content,
-          type = NoteMapper.toResourceModel(note.noteType),
-        )
-      }
+      val mappedNotes = notes.map { noteResourceMapper.fromDomainToModel(it) }
 
       // Return a new goal response with the updated notes
       goalResponse.copy(goalNotes = mappedNotes)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -100,7 +100,7 @@ class GoalController(
     @Valid @RequestBody archiveGoalRequest: ArchiveGoalRequest,
     @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
     @PathVariable goalReference: UUID,
-  ): Goal {
+  ) {
     val goal = goalService.archiveGoal(
       prisonNumber = prisonNumber,
       archiveGoalDto = goalResourceMapper.fromModelToDto(archiveGoalRequest),
@@ -108,7 +108,6 @@ class GoalController(
     archiveGoalRequest.note?.let {
       createGoalNote(prisonNumber, goal, it, NoteType.GOAL_ARCHIVAL)
     }
-    return goal
   }
 
   private fun createGoalNote(prisonNumber: String, goal: Goal, noteText: String, noteType: NoteType) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -23,8 +23,8 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.service.
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.Goal
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.GetGoalsDto
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.service.GoalService
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.note.NoteMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.GoalResourceMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.note.NoteResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.GoalReferenceMatchesReferenceInUpdateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.PRISON_NUMBER_FORMAT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ArchiveGoalRequest
@@ -32,7 +32,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Creat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GetGoalsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Note
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UnarchiveGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
 import java.util.UUID
@@ -44,6 +43,7 @@ class GoalController(
   private val goalService: GoalService,
   private val goalResourceMapper: GoalResourceMapper,
   private val noteService: NoteService,
+  private val noteResourceMapper: NoteResourceMapper,
 ) {
 
   @PostMapping
@@ -70,7 +70,7 @@ class GoalController(
     val response = goalResourceMapper.fromDomainToModel(goalService.getGoal(prisonNumber, goalReference))
     // Get the archive note and update the response if present
     val notes = noteService.getNotes(response.goalReference, EntityType.GOAL)
-    return response.copy(goalNotes = notes.map { Note(it.reference, it.content, NoteMapper.toResourceModel(it.noteType)) })
+    return response.copy(goalNotes = notes.map { noteResourceMapper.fromDomainToModel(it) })
   }
 
   @PutMapping("{goalReference}")
@@ -133,16 +133,14 @@ class GoalController(
     @Valid @RequestBody archiveGoalRequest: UnarchiveGoalRequest,
     @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
     @PathVariable goalReference: UUID,
-  ): Goal {
-    val goal = goalService.unarchiveGoal(
+  ) {
+    goalService.unarchiveGoal(
       prisonNumber = prisonNumber,
       unarchiveGoalDto = goalResourceMapper.fromModelToDto(archiveGoalRequest),
     )
 
     // delete any goal notes
     noteService.deleteNote(archiveGoalRequest.goalReference, EntityType.GOAL, NoteType.GOAL_ARCHIVAL)
-
-    return goal
   }
 
   @GetMapping

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalResourceMapper.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalS
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UnarchiveGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
 import java.time.Instant
+import java.util.Collections
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus as GoalStatusDto
 
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus as Go
   imports = [
     Instant::class,
     UUID::class,
+    Collections::class,
   ],
 )
 interface GoalResourceMapper {
@@ -41,6 +43,7 @@ interface GoalResourceMapper {
   @Mapping(target = "updatedAt", source = "lastUpdatedAt")
   @Mapping(target = "createdAtPrison", source = "createdAtPrison")
   @Mapping(target = "updatedAtPrison", source = "lastUpdatedAtPrison")
+  @Mapping(target = "goalNotes", expression = "java( Collections.emptyList() )")
   fun fromDomainToModel(goalDomain: Goal): GoalResponse
 
   @Mapping(target = "reference", source = "goalReference")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/conversation/ConversationsResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/conversation/ConversationsResourceMapper.kt
@@ -28,13 +28,13 @@ class ConversationsResourceMapper(
       note = conversation.note.content,
       createdBy = conversation.note.createdBy!!,
       createdByDisplayName = conversation.note.createdBy?.let {
-        userService.getUserDetails(it)?.name
+        userService.getUserDetails(it).name
       } ?: "Unknown",
       createdAt = instantMapper.toOffsetDateTime(conversation.note.createdAt)!!,
       createdAtPrison = conversation.note.createdAtPrison,
       updatedBy = conversation.note.lastUpdatedBy!!,
       updatedByDisplayName = conversation.note.lastUpdatedBy?.let {
-        userService.getUserDetails(it)?.name
+        userService.getUserDetails(it).name
       } ?: "Unknown",
       updatedAt = instantMapper.toOffsetDateTime(conversation.note.lastUpdatedAt)!!,
       updatedAtPrison = conversation.note.lastUpdatedAtPrison,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/note/NoteResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/note/NoteResourceMapper.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.note
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ManageUserService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.NoteResponse
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteType as DomainNoteType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.NoteType as ApiNoteType
+
+@Component
+class NoteResourceMapper(
+  private val instantMapper: InstantMapper,
+  private val userService: ManageUserService,
+) {
+
+  fun fromDomainToModel(note: NoteDto): NoteResponse =
+    NoteResponse(
+      reference = note.reference,
+      content = note.content,
+      type = toNoteType(note.noteType),
+      createdBy = note.createdBy!!,
+      createdByDisplayName = userService.getUserDetails(note.createdBy!!).name,
+      createdAt = instantMapper.toOffsetDateTime(note.createdAt)!!,
+      createdAtPrison = note.createdAtPrison,
+      updatedBy = note.lastUpdatedBy!!,
+      updatedByDisplayName = userService.getUserDetails(note.lastUpdatedBy!!).name,
+      updatedAt = instantMapper.toOffsetDateTime(note.lastUpdatedAt)!!,
+      updatedAtPrison = note.lastUpdatedAtPrison,
+    )
+
+  private fun toNoteType(noteType: DomainNoteType): ApiNoteType =
+    when (noteType) {
+      DomainNoteType.GOAL -> ApiNoteType.GOAL
+      DomainNoteType.GOAL_ARCHIVAL -> ApiNoteType.GOAL_ARCHIVAL
+      DomainNoteType.GOAL_COMPLETION -> ApiNoteType.GOAL_COMPLETION
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/ManageUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/ManageUserService.kt
@@ -2,11 +2,12 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.manageusers.ManageUsersApiClient
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.manageusers.UserDetailsDto
 
 @Component
 class ManageUserService(
   private val manageUsersApiClient: ManageUsersApiClient,
 ) {
-  fun getUserDetails(username: String) =
+  fun getUserDetails(username: String): UserDetailsDto =
     manageUsersApiClient.getUserDetails(username)
 }

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.16.2'
+  version: '1.16.3'
   description: Education and Work Plan API
   contact:
     name: Learning and Work Progress team
@@ -780,7 +780,7 @@ components:
             $ref: '#/components/schemas/StepResponse'
         notes:
           type: string
-          description: Some additional notes related to the Goal. This is deprecated - use the GoalNotes list instead
+          description: Some additional notes related to the Goal. This is deprecated - use the`goalNotes` list instead
           example: Pay close attention to Peter's behaviour.
           deprecated: true
         createdBy:
@@ -824,9 +824,9 @@ components:
           description: Describes the reason for archiving if 'OTHER' is selected, it is mandatory in this scenario.
         goalNotes:
           type: array
-          description: A List of at Notes associated with the Goal.
+          description: A List of at Notes associated with the Goal. Will be an empty array if the goal has no Notes
           items:
-            $ref: '#/components/schemas/Note'
+            $ref: '#/components/schemas/NoteResponse'
       required:
         - goalReference
         - title
@@ -841,6 +841,7 @@ components:
         - updatedByDisplayName
         - updatedAt
         - updatedAtPrison
+        - goalNotes
     StepResponse:
       title: StepResponse
       type: object
@@ -1788,8 +1789,8 @@ components:
         - goalReference
         - reason
 
-    Note:
-      title: Note
+    NoteResponse:
+      title: NoteResponse
       type: object
       description: An object representing a note.
       properties:
@@ -1803,6 +1804,52 @@ components:
           description: The content of the note.
         type:
           $ref: '#/components/schemas/NoteType'
+        createdBy:
+          type: string
+          description: The DPS username of the person who created the Note.
+          example: 'asmith_gen'
+        createdByDisplayName:
+          type: string
+          description: The display name of the person who created the Note.
+          example: 'Alex Smith'
+        createdAt:
+          type: string
+          format: date-time
+          description: An ISO-8601 timestamp representing when the Note was created.
+          example: '2023-06-19T09:39:44Z'
+        createdAtPrison:
+          type: string
+          description: The identifier of the prison that the prisoner was resident at when the Note was created.
+          example: 'BXI'
+        updatedBy:
+          type: string
+          description: The DPS username of the person who last updated the Note.
+          example: 'asmith_gen'
+        updatedByDisplayName:
+          type: string
+          description: The display name of the person who last updated the Note.
+          example: 'Alex Smith'
+        updatedAt:
+          type: string
+          format: date-time
+          description: An ISO-8601 timestamp representing when the Note was last updated. This will be the same as the created date if it has not yet been updated.
+          example: '2023-06-19T09:39:44Z'
+        updatedAtPrison:
+          type: string
+          description: The identifier of the prison that the prisoner was resident at when the Note was updated.
+          example: 'BXI'
+      required:
+        - reference
+        - content
+        - type
+        - createdAt
+        - createdBy
+        - createdByDisplayName
+        - createdAtPrison
+        - updatedAt
+        - updatedBy
+        - updatedByDisplayName
+        - updatedAtPrison
 
     NoteType:
       title: NoteType

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalResourceMapperTest.kt
@@ -133,6 +133,7 @@ internal class GoalResourceMapperTest {
       updatedAtPrison = "MDI",
       updatedBy = "bjones_gen",
       updatedByDisplayName = "Barry Jones",
+      goalNotes = emptyList(),
     )
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/note/NoteResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/note/NoteResourceMapperTest.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.note
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.aValidNoteDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.manageusers.UserDetailsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ManageUserService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.note.aValidNoteResponse
+import java.time.Instant
+import java.time.ZoneOffset.UTC
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteType as DomainNoteType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.NoteType as ApiNoteType
+
+@ExtendWith(MockitoExtension::class)
+class NoteResourceMapperTest {
+  @InjectMocks
+  private lateinit var mapper: NoteResourceMapper
+
+  @Mock
+  private lateinit var instantMapper: InstantMapper
+
+  @Mock
+  private lateinit var userService: ManageUserService
+
+  @Test
+  fun `should map domain Note to NoteResponse`() {
+    // Given
+    val noteReference = UUID.randomUUID()
+    val createdAt = Instant.now().minus(1, ChronoUnit.HOURS)
+    val updatedAt = Instant.now()
+
+    val note = aValidNoteDto(
+      reference = noteReference,
+      content = "Note content",
+      noteType = DomainNoteType.GOAL,
+      createdBy = "ASMITH_GEN",
+      createdAt = createdAt,
+      createdAtPrison = "BXI",
+      lastUpdatedBy = "BJONES_GEN",
+      lastUpdatedAt = updatedAt,
+      lastUpdatedAtPrison = "MDI",
+    )
+
+    val expectedCreatedAt = createdAt.atOffset(UTC)
+    val expectedUpdatedAt = updatedAt.atOffset(UTC)
+    given(instantMapper.toOffsetDateTime(any())).willReturn(expectedCreatedAt, expectedUpdatedAt)
+
+    given(userService.getUserDetails(any())).willReturn(
+      UserDetailsDto("ASMITH_GEN", true, "Alex Smith"),
+      UserDetailsDto("BJONES_GEN", true, "Barry Jones"),
+    )
+
+    val expectedNoteResponse = aValidNoteResponse(
+      reference = noteReference,
+      content = "Note content",
+      type = ApiNoteType.GOAL,
+      createdBy = "ASMITH_GEN",
+      createdByDisplayName = "Alex Smith",
+      createdAt = expectedCreatedAt,
+      createdAtPrison = "BXI",
+      updatedBy = "BJONES_GEN",
+      updatedByDisplayName = "Barry Jones",
+      updatedAt = expectedUpdatedAt,
+      updatedAtPrison = "MDI",
+    )
+
+    // When
+    val actual = mapper.fromDomainToModel(note)
+
+    // Then
+    assertThat(actual).isEqualTo(expectedNoteResponse)
+    verify(userService).getUserDetails("ASMITH_GEN")
+    verify(userService).getUserDetails("BJONES_GEN")
+    verify(instantMapper).toOffsetDateTime(createdAt)
+    verify(instantMapper).toOffsetDateTime(updatedAt)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/UpdateGoalRequestReferenceConstraintValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/UpdateGoalRequestReferenceConstraintValidatorTest.kt
@@ -15,7 +15,7 @@ class UpdateGoalRequestReferenceConstraintValidatorTest {
   private val validatorFactory = Validation.buildDefaultValidatorFactory()
   private val validator = validatorFactory.validator.forExecutables()
 
-  private val goalController = GoalController(mock(), mock(), mock())
+  private val goalController = GoalController(mock(), mock(), mock(), mock())
   private val updateGoalMethod = GoalController::class.java.getMethod(
     "updateGoal",
     UpdateGoalRequest::class.java,

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GoalResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GoalResponseAssert.kt
@@ -169,7 +169,7 @@ class GoalResponseAssert(actual: GoalResponse?) :
   private fun hasNoteOfType(noteType: NoteType, expected: String?, noteLabel: String): GoalResponseAssert {
     isNotNull
     with(actual!!) {
-      val note = goalNotes?.firstOrNull { it.type == noteType }
+      val note = goalNotes.firstOrNull { it.type == noteType }
       when {
         note == null && expected != null ->
           failWithMessage("Expected $noteLabel note to be $expected, but was null")

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GoalResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GoalResponseBuilder.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.acti
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.NoteResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonToArchiveGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.StepResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.note.aValidNoteResponse
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -25,6 +27,7 @@ fun aValidGoalResponse(
   updatedAtPrison: String = "BXI",
   archiveReason: ReasonToArchiveGoal? = null,
   archiveReasonOther: String? = null,
+  goalNotes: List<NoteResponse> = listOf(aValidNoteResponse()),
 ): GoalResponse =
   GoalResponse(
     goalReference = reference,
@@ -43,6 +46,7 @@ fun aValidGoalResponse(
     updatedAtPrison = updatedAtPrison,
     archiveReason = archiveReason,
     archiveReasonOther = archiveReasonOther,
+    goalNotes = goalNotes,
   )
 
 fun anotherValidGoalResponse(
@@ -60,6 +64,7 @@ fun anotherValidGoalResponse(
   updatedByDisplayName: String = "Barry Jones",
   updatedAt: OffsetDateTime = OffsetDateTime.now(),
   updatedAtPrison: String = "BXI",
+  goalNotes: List<NoteResponse> = listOf(aValidNoteResponse()),
 ): GoalResponse =
   GoalResponse(
     goalReference = reference,
@@ -76,4 +81,5 @@ fun anotherValidGoalResponse(
     updatedAt = updatedAt,
     updatedByDisplayName = updatedByDisplayName,
     updatedAtPrison = updatedAtPrison,
+    goalNotes = goalNotes,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/note/NoteResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/note/NoteResponseBuilder.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.note
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.NoteResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.NoteType
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aValidNoteResponse(
+  reference: UUID = UUID.randomUUID(),
+  content: String = "Some notes about the goal",
+  type: NoteType = NoteType.GOAL,
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
+): NoteResponse =
+  NoteResponse(
+    reference = reference,
+    content = content,
+    type = type,
+    createdBy = createdBy,
+    createdByDisplayName = createdByDisplayName,
+    createdAt = createdAt,
+    createdAtPrison = createdAtPrison,
+    updatedBy = updatedBy,
+    updatedByDisplayName = updatedByDisplayName,
+    updatedAt = updatedAt,
+    updatedAtPrison = updatedAtPrison,
+  )


### PR DESCRIPTION
This PR maps the createdByDisplayName and updatedByDisplayName fields in Note in the REST API responses to be mapped from the user service (ie. look them up from the API call)
We need to make this change on all REST API responses where the resource contains createdByDisplayName and updatedByDisplayName fields - this PR just does Notes

In order to do this change I have:
* Renamed Notes to NotesResponse (consistent with our other response model types)
* added the createdByDisplayName and updatedByDisplayName fields to NoteResponse
* added the other audit related fields to NoteResponse (not strictly necessary for this PR, but I was there anyway and it made sense to do them)
* created and used a new mapper to map NoteDto domain instances into NoteResource instances, including looking up the displayname fields from the user service
* 