### PR TITLE
RR-962 - Only create the Note db entity if the request to create the goal has a populated note

### DIFF
--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/dto/CreateNoteDtoAssert.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/dto/CreateNoteDtoAssert.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto
+
+import org.assertj.core.api.AbstractObjectAssert
+import java.util.UUID
+
+fun assertThat(actual: CreateNoteDto?) = CreateNoteDtoAssert(actual)
+
+/**
+ * AssertJ custom assertion for [CreateNoteDto].
+ */
+class CreateNoteDtoAssert(actual: CreateNoteDto?) :
+  AbstractObjectAssert<CreateNoteDtoAssert, CreateNoteDto?>(actual, CreateNoteDtoAssert::class.java) {
+
+  fun hasPrisonNumber(expected: String): CreateNoteDtoAssert {
+    isNotNull
+    with(actual!!) {
+      if (prisonNumber != expected) {
+        failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  fun hasContent(expected: String): CreateNoteDtoAssert {
+    isNotNull
+    with(actual!!) {
+      if (content != expected) {
+        failWithMessage("Expected note content to be $expected, but was $content")
+      }
+    }
+    return this
+  }
+
+  fun hasEntityReference(expected: UUID): CreateNoteDtoAssert {
+    isNotNull
+    with(actual!!) {
+      if (entityReference != expected) {
+        failWithMessage("Expected note entityReference to be $expected, but was $entityReference")
+      }
+    }
+    return this
+  }
+
+  fun hasEntityType(expected: EntityType): CreateNoteDtoAssert {
+    isNotNull
+    with(actual!!) {
+      if (entityType != expected) {
+        failWithMessage("Expected note entityType to be $expected, but was $entityType")
+      }
+    }
+    return this
+  }
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalsTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalsTest.kt
@@ -302,4 +302,66 @@ class CreateGoalsTest : IntegrationTestBase() {
         .containsKey("correlationId")
     }
   }
+
+  @Test
+  fun `should add goal with no notes`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+
+    val createGoalRequest = aValidCreateGoalRequest(
+      notes = null,
+    )
+    val createGoalsRequest = aValidCreateGoalsRequest(goals = listOf(createGoalRequest))
+
+    // When
+    webTestClient.post()
+      .uri(CREATE_GOALS_URI_TEMPLATE, prisonNumber)
+      .withBody(createGoalsRequest)
+      .bearerToken(aValidTokenWithAuthority(GOALS_RW, privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
+
+    // Then
+    val actual = getActionPlan(prisonNumber)
+    assertThat(actual)
+      .isForPrisonNumber(prisonNumber)
+      .hasNumberOfGoals(1)
+      .goal(1) { goal ->
+        goal
+          .hasNoGoalNote()
+          .hasNoNotes()
+      }
+  }
+
+  @Test
+  fun `should add goal with notes`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+
+    val createGoalRequest = aValidCreateGoalRequest(
+      notes = "This feels like an appropriate and achievable goal for Chris",
+    )
+    val createGoalsRequest = aValidCreateGoalsRequest(goals = listOf(createGoalRequest))
+
+    // When
+    webTestClient.post()
+      .uri(CREATE_GOALS_URI_TEMPLATE, prisonNumber)
+      .withBody(createGoalsRequest)
+      .bearerToken(aValidTokenWithAuthority(GOALS_RW, privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isCreated()
+
+    // Then
+    val actual = getActionPlan(prisonNumber)
+    assertThat(actual)
+      .isForPrisonNumber(prisonNumber)
+      .hasNumberOfGoals(1)
+      .goal(1) { goal ->
+        goal.hasGoalNote("This feels like an appropriate and achievable goal for Chris")
+      }
+  }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -105,9 +105,8 @@ class GetActionPlanTest : IntegrationTestBase() {
           .wasUpdatedAtPrison("BXI")
           .wasUpdatedBy("auser_gen")
           .hasUpdatedByDisplayName("Albert User")
-          .hasNotes("Chris would like to improve his listening skills, not just his verbal communication")
           .hasGoalNote("Chris would like to improve his listening skills, not just his verbal communication")
-          .hasArchiveNote(null)
+          .hasNoArchiveNote()
       }
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetGoalTest.kt
@@ -144,8 +144,8 @@ class GetGoalTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .hasReference(goalReference)
-    // archive note should be null.
-    assertThat(actual).hasArchiveNote(null)
+      // archive note should be null.
+      .hasNoArchiveNote()
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
@@ -155,7 +155,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
           .hasStatus(GoalStatus.ACTIVE)
           .hasArchiveReason(null)
           .hasArchiveReasonOther(null)
-          .hasArchiveNote(null) // previous archive note will be removed
+          .hasNoArchiveNote() // previous archive note will be removed
       }
 
     await.untilAsserted {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalNoteService.kt
@@ -16,9 +16,8 @@ class GoalNoteService(
 ) : GoalNotesService {
 
   override fun createNotes(prisonNumber: String, createdGoals: List<Goal>) {
-    val goalsCopy = ArrayList(createdGoals)
-    goalsCopy.forEach { createdGoal ->
-      createdGoal.notes?.let {
+    createdGoals.forEach { createdGoal ->
+      if (!createdGoal.notes.isNullOrEmpty()) {
         noteService.createNote(createdGoal.mapToNotesDTO(prisonNumber))
       }
     }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GoalResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GoalResponseAssert.kt
@@ -131,18 +131,30 @@ class GoalResponseAssert(actual: GoalResponse?) :
   fun hasNoNotes(): GoalResponseAssert {
     isNotNull
     with(actual!!) {
-      if (notes != null) {
-        failWithMessage("Expected goal to have no notes, but was $notes")
+      if (goalNotes.isNotEmpty()) {
+        failWithMessage("Expected goal to have no notes, but there were ${goalNotes.size}")
       }
     }
     return this
   }
 
-  fun hasNotes(expected: String): GoalResponseAssert {
+  fun hasNoGoalNote(): GoalResponseAssert {
     isNotNull
     with(actual!!) {
-      if (notes != expected) {
-        failWithMessage("Expected goal to have notes '$expected', but was $notes")
+      val goalNotesCount = goalNotes.count { it.type == NoteType.GOAL }
+      if (goalNotesCount > 0) {
+        failWithMessage("Expected goal to have no goal notes, but there were $goalNotesCount")
+      }
+    }
+    return this
+  }
+
+  fun hasNoArchiveNote(): GoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val archiveNotesCount = goalNotes.count { it.type == NoteType.GOAL_ARCHIVAL }
+      if (archiveNotesCount > 0) {
+        failWithMessage("Expected goal to have no archive notes, but there were $archiveNotesCount")
       }
     }
     return this
@@ -158,27 +170,24 @@ class GoalResponseAssert(actual: GoalResponse?) :
     return this
   }
 
-  fun hasArchiveNote(expected: String?): GoalResponseAssert {
+  fun hasArchiveNote(expected: String): GoalResponseAssert {
     return hasNoteOfType(NoteType.GOAL_ARCHIVAL, expected, "archive")
   }
 
-  fun hasGoalNote(expected: String?): GoalResponseAssert {
+  fun hasGoalNote(expected: String): GoalResponseAssert {
     return hasNoteOfType(NoteType.GOAL, expected, "goal")
   }
 
-  private fun hasNoteOfType(noteType: NoteType, expected: String?, noteLabel: String): GoalResponseAssert {
+  private fun hasNoteOfType(noteType: NoteType, expected: String, noteLabel: String): GoalResponseAssert {
     isNotNull
     with(actual!!) {
       val note = goalNotes.firstOrNull { it.type == noteType }
       when {
-        note == null && expected != null ->
+        note == null ->
           failWithMessage("Expected $noteLabel note to be $expected, but was null")
 
-        note != null && note.content != expected ->
+        note.content != expected ->
           failWithMessage("Expected $noteLabel note to be $expected, but was ${note.content}")
-
-        expected == null && note != null ->
-          failWithMessage("Expected no $noteLabel note, but was ${note.content}")
       }
     }
     return this


### PR DESCRIPTION
This PR fixes the problem where empty Notes entities were being created when creating a goal with no notes.

The Notes DB entity is now only created when the request to create the goal has a populated notes field