### PR TITLE
Delete goal note when update note is blank

### DIFF
--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalNotesService.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalNotesService.kt
@@ -9,5 +9,7 @@ interface GoalNotesService {
 
   fun getNotes(entityReference: UUID): String?
 
+  fun deleteNote(entityReference: UUID)
+
   fun updateNotes(entityReference: UUID, lastUpdatedAtPrison: String, updatedText: String?)
 }

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalService.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalService.kt
@@ -118,7 +118,11 @@ class GoalService(
         goalNotesService.createNotes(prisonNumber, listOf(goal))
       }
       existingNote != updatedNote && updatedNote != null -> {
-        goalNotesService.updateNotes(goal.reference, goal.lastUpdatedAtPrison, updatedNote)
+        if (updatedNote.isEmpty()) {
+          goalNotesService.deleteNote(goal.reference)
+        } else {
+          goalNotesService.updateNotes(goal.reference, goal.lastUpdatedAtPrison, updatedNote)
+        }
       }
       // No action if the note hasn't changed or both are null
     }

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalService.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalService.kt
@@ -117,8 +117,8 @@ class GoalService(
       existingNote == null && updatedNote != null -> {
         goalNotesService.createNotes(prisonNumber, listOf(goal))
       }
-      existingNote != updatedNote && updatedNote != null -> {
-        if (updatedNote.isEmpty()) {
+      existingNote != updatedNote -> {
+        if (updatedNote.isNullOrEmpty()) {
           goalNotesService.deleteNote(goal.reference)
         } else {
           goalNotesService.updateNotes(goal.reference, goal.lastUpdatedAtPrison, updatedNote)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalNoteService.kt
@@ -27,6 +27,10 @@ class GoalNoteService(
     return noteService.getNotes(entityReference, EntityType.GOAL, NoteType.GOAL).firstOrNull()?.content
   }
 
+  override fun deleteNote(entityReference: UUID) {
+    noteService.deleteNote(entityReference, EntityType.GOAL, NoteType.GOAL)
+  }
+
   override fun updateNotes(entityReference: UUID, lastUpdatedAtPrison: String, updatedText: String?) {
     val note = noteService.getNotes(entityReference, EntityType.GOAL, NoteType.GOAL).firstOrNull()
     // If no note exists, return early


### PR DESCRIPTION
When the the goal note is set to be a blank string or null and there is an existing goal note - then delete it.