### PR TITLE
RR-997 - Mapped displayName fields in GoalResourceMapper via user lookup

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -176,5 +176,5 @@ class GoalController(
 
   // convert from the generated enum to the one we use in persistence
   private fun convertStatuses(statuses: Set<GoalStatus>?) =
-    statuses?.map { status -> goalResourceMapper.fromModelToDto(status) }?.toSet()
+    statuses?.map { status -> goalResourceMapper.toGoalStatus(status) }?.toSet()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalResourceMapper.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan
 
-import org.mapstruct.Mapper
-import org.mapstruct.Mapping
+import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.Goal
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.ArchiveGoalDto
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.CompleteGoalDto
@@ -9,53 +8,113 @@ import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.CreateGoalDt
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.UnarchiveGoalDto
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.UpdateGoalDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ManageUserService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ArchiveGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CompleteGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UnarchiveGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
-import java.time.Instant
-import java.util.Collections
-import java.util.UUID
-import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus as GoalStatusDto
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus as GoalStatusDomain
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.ReasonToArchiveGoal as ReasonToArchiveGoalDomain
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus as GoalStatusApi
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonToArchiveGoal as ReasonToArchiveGoalApi
 
-@Mapper(
-  uses = [
-    StepResourceMapper::class,
-    InstantMapper::class,
-  ],
-  imports = [
-    Instant::class,
-    UUID::class,
-    Collections::class,
-  ],
-)
-interface GoalResourceMapper {
-  @Mapping(target = "status", constant = "ACTIVE")
-  fun fromModelToDto(createGoalRequest: CreateGoalRequest): CreateGoalDto
+@Component
+class GoalResourceMapper(
+  private val stepResourceMapper: StepResourceMapper,
+  private val instantMapper: InstantMapper,
+  private val userService: ManageUserService,
+) {
+  fun fromModelToDto(createGoalRequest: CreateGoalRequest): CreateGoalDto =
+    with(createGoalRequest) {
+      CreateGoalDto(
+        title = title,
+        steps = steps.map { stepResourceMapper.fromModelToDto(it) },
+        prisonId = prisonId,
+        targetCompletionDate = targetCompletionDate,
+        notes = notes,
+        status = GoalStatusDomain.ACTIVE,
+      )
+    }
 
-  @Mapping(target = "reference", source = "goalReference")
-  fun fromModelToDto(updateGoalRequest: UpdateGoalRequest): UpdateGoalDto
+  fun fromModelToDto(updateGoalRequest: UpdateGoalRequest): UpdateGoalDto =
+    with(updateGoalRequest) {
+      UpdateGoalDto(
+        reference = goalReference,
+        steps = steps.map { stepResourceMapper.fromModelToDto(it) },
+        title = title,
+        prisonId = prisonId,
+        targetCompletionDate = targetCompletionDate,
+        notes = notes,
+      )
+    }
 
-  @Mapping(target = "goalReference", source = "reference")
-  @Mapping(target = "updatedBy", source = "lastUpdatedBy")
-  @Mapping(target = "updatedByDisplayName", source = "lastUpdatedByDisplayName")
-  @Mapping(target = "updatedAt", source = "lastUpdatedAt")
-  @Mapping(target = "createdAtPrison", source = "createdAtPrison")
-  @Mapping(target = "updatedAtPrison", source = "lastUpdatedAtPrison")
-  @Mapping(target = "goalNotes", expression = "java( Collections.emptyList() )")
-  fun fromDomainToModel(goalDomain: Goal): GoalResponse
+  fun fromDomainToModel(goalDomain: Goal): GoalResponse =
+    with(goalDomain) {
+      GoalResponse(
+        goalReference = reference,
+        title = title,
+        steps = steps.map { stepResourceMapper.fromDomainToModel(it) },
+        targetCompletionDate = targetCompletionDate,
+        status = toGoalStatus(status),
+        archiveReason = archiveReason?.let { toReasonToArchiveGoal(it) },
+        archiveReasonOther = archiveReasonOther,
+        createdBy = createdBy!!,
+        createdByDisplayName = userService.getUserDetails(createdBy!!).name,
+        createdAt = instantMapper.toOffsetDateTime(createdAt)!!,
+        createdAtPrison = createdAtPrison,
+        updatedBy = lastUpdatedBy!!,
+        updatedByDisplayName = userService.getUserDetails(lastUpdatedBy!!).name,
+        updatedAt = instantMapper.toOffsetDateTime(lastUpdatedAt)!!,
+        updatedAtPrison = lastUpdatedAtPrison,
+        notes = notes,
+        goalNotes = emptyList(),
+      )
+    }
 
-  @Mapping(target = "reference", source = "goalReference")
-  fun fromModelToDto(archiveGoalRequest: ArchiveGoalRequest): ArchiveGoalDto
+  fun fromModelToDto(archiveGoalRequest: ArchiveGoalRequest): ArchiveGoalDto =
+    with(archiveGoalRequest) {
+      ArchiveGoalDto(
+        reference = goalReference,
+        reason = toReasonToArchiveGoal(reason),
+        reasonOther = reasonOther,
+      )
+    }
 
-  @Mapping(target = "reference", source = "goalReference")
-  fun fromModelToDto(completeGoalRequest: CompleteGoalRequest): CompleteGoalDto
+  fun fromModelToDto(unarchiveGoalRequest: UnarchiveGoalRequest): UnarchiveGoalDto =
+    UnarchiveGoalDto(reference = unarchiveGoalRequest.goalReference)
 
-  @Mapping(target = "reference", source = "goalReference")
-  fun fromModelToDto(unarchiveGoalRequest: UnarchiveGoalRequest): UnarchiveGoalDto
+  fun fromModelToDto(completeGoalRequest: CompleteGoalRequest): CompleteGoalDto =
+    CompleteGoalDto(reference = completeGoalRequest.goalReference)
 
-  fun fromModelToDto(status: GoalStatus): GoalStatusDto
+  fun toGoalStatus(status: GoalStatusApi): GoalStatusDomain =
+    when (status) {
+      GoalStatusApi.ACTIVE -> GoalStatusDomain.ACTIVE
+      GoalStatusApi.COMPLETED -> GoalStatusDomain.COMPLETED
+      GoalStatusApi.ARCHIVED -> GoalStatusDomain.ARCHIVED
+    }
+
+  private fun toGoalStatus(status: GoalStatusDomain): GoalStatusApi =
+    when (status) {
+      GoalStatusDomain.ACTIVE -> GoalStatusApi.ACTIVE
+      GoalStatusDomain.COMPLETED -> GoalStatusApi.COMPLETED
+      GoalStatusDomain.ARCHIVED -> GoalStatusApi.ARCHIVED
+    }
+
+  private fun toReasonToArchiveGoal(reason: ReasonToArchiveGoalApi): ReasonToArchiveGoalDomain =
+    when (reason) {
+      ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL -> ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL
+      ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG -> ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG
+      ReasonToArchiveGoalApi.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON -> ReasonToArchiveGoalDomain.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON
+      ReasonToArchiveGoalApi.OTHER -> ReasonToArchiveGoalDomain.OTHER
+    }
+
+  private fun toReasonToArchiveGoal(reason: ReasonToArchiveGoalDomain): ReasonToArchiveGoalApi =
+    when (reason) {
+      ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL -> ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL
+      ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG -> ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG
+      ReasonToArchiveGoalDomain.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON -> ReasonToArchiveGoalApi.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON
+      ReasonToArchiveGoalDomain.OTHER -> ReasonToArchiveGoalApi.OTHER
+    }
 }


### PR DESCRIPTION
This PR maps the `displayName` fields for goal resources by looking up the user from the user service.

The mapper concerned is `GoalResourceMapper` and in making this change I have taken the opportunity to re-implement the mapper as a regular class, rather than a MapStruct mapper interface