### PR TITLE
RR-1004 - Dont lookup userDetails for "system" user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/timeline/TimelineEventResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/timeline/TimelineEventResourceMapper.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEvent
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventContext
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ManageUserService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.PrisonerApiTimelineService.Companion.SYSTEM_USER
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventResponse
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventType as TimelineEventTypeDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType as TimelineEventTypeApi
@@ -25,9 +26,7 @@ class TimelineEventResourceMapper(
         contextualInfo = buildContextualInfo(contextualInfo),
         actionedBy = actionedBy,
         timestamp = instantMapper.toOffsetDateTime(timestamp)!!,
-        actionedByDisplayName = userService.getUserDetails(actionedBy).let {
-          if (it.active) it.name else null
-        },
+        actionedByDisplayName = if (actionedBy !== SYSTEM_USER) userService.getUserDetails(actionedBy).name else null,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineService.kt
@@ -16,6 +16,10 @@ class PrisonerApiTimelineService(
   private val prisonMovementEventsMapper: PrisonMovementEventsMapper,
 ) : PrisonTimelineService {
 
+  companion object {
+    const val SYSTEM_USER = "system"
+  }
+
   override fun getPrisonTimelineEvents(prisonNumber: String): List<TimelineEvent> {
     return try {
       val prisonMovementEvents = prisonApiClient.getPrisonMovementEvents(prisonNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/mapper/PrisonMovementEventsMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/mapper/PrisonMovementEventsMapperTest.kt
@@ -22,7 +22,7 @@ import java.time.ZoneOffset
 @ExtendWith(MockitoExtension::class)
 class PrisonMovementEventsMapperTest {
   @InjectMocks
-  private lateinit var prisonMovementEventsMapper: PrisonMovementEventsMapperImpl
+  private lateinit var prisonMovementEventsMapper: PrisonMovementEventsMapper
 
   @Spy
   private lateinit var instantMapper: InstantMapper


### PR DESCRIPTION
This PR fixes a bug with the user details (display name) lookup for the timeline.

## Context
The timeline is a list of events that have happened. Some of those events are instigated by a DPS user (eg: PLP events such as updating a goal etc), but other events are "system" events and dont have an associated user (eg: prisoner movement events)

On the timeline UI prison movement events are rendered without the name of who performed the action, and PLP events show the user who performed the action:
![Screenshot 2024-10-15 at 10 51 35](https://github.com/user-attachments/assets/9d943bde-7751-4d88-9900-b8941ada4e91)
and
![Screenshot 2024-10-15 at 10 51 45](https://github.com/user-attachments/assets/503b7de8-2778-467b-96a1-725085ce76c5)

## Bug
The change made in my last PR was this:
```
        actionedByDisplayName = userService.getUserDetails(actionedBy).let {
          if (it.active) it.name else null
        },
```
This did the user lookup (even for the system user) and if the returned UserDetails was `active` then it returned the name, else it returned null.
This has resulted in the following UI bug where the original user who performed the action has left and no longer has an active DPS account:
![Screenshot 2024-10-15 at 11 20 46](https://github.com/user-attachments/assets/92d6d14b-ecb2-44c3-87ae-c9f414e1bdb4)

## Changes
The changes in this PR change the lookup to:
```
actionedByDisplayName = if (actionedBy !== SYSTEM_USER) userService.getUserDetails(actionedBy).name else null,
```
IE. If the event was actioned by the "system" user then dont even bother doing the user lookup, else do the lookup and return the `name` property, delegating to whatever the service returns in the case of non resolved/non-active users. This will allow the UI to display something of use (which currently it doesnt do! 🤣 )

Other changes to support the above are the introduction of a constant for the system user (rather than having "system" as a magic string littered across the codebase) and converting the mapper from a mapstruct mapper to a regular class.

With the changes in this PR, the above timeline (with the missing names) is now correctly shown as follows:
![Screenshot 2024-10-15 at 11 33 58](https://github.com/user-attachments/assets/b3826a94-7ef2-4f98-9ae1-f1a248089e64)
