### PR TITLE
RR-918 - Remove unused `HMPPS Integration DB` participant from sequence diagrams

### DIFF
--- a/docs/ciag-kpis/CIAG KPI1 - PEF Apr 25 to Oct 25.mermaid
+++ b/docs/ciag-kpis/CIAG KPI1 - PEF Apr 25 to Oct 25.mermaid
@@ -11,7 +11,6 @@ sequenceDiagram
   participant PLPDB as PLP DB
   participant DomainEvents as HMPPS Domain Events
   participant Integration as HMPPS Integration API
-  participant IntegrationDB as HMPPS Integration DB
   participant Curious as Curious
 
   rect rgba(0, 200, 255, 0.4)

--- a/docs/ciag-kpis/CIAG KPI1 - PES post Oct 25.mermaid
+++ b/docs/ciag-kpis/CIAG KPI1 - PES post Oct 25.mermaid
@@ -7,7 +7,6 @@ sequenceDiagram
   participant PLPDB as PLP DB
   participant DomainEvents as HMPPS Domain Events
   participant Integration as HMPPS Integration API
-  participant IntegrationDB as HMPPS Integration DB
   participant Curious as Curious
 
   rect rgba(0, 200, 255, 0.4)


### PR DESCRIPTION
This PR removes the unused `HMPPS Integration DB` participant from the KPI1 sequence diagrams
(I forgot to remove them in my last PR)