### PR TITLE
RR-1088 - Refactor NoteEntity as a data class, make content field non-nullable

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/dto/UpdateNoteDto.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/dto/UpdateNoteDto.kt
@@ -4,6 +4,6 @@ import java.util.UUID
 
 data class UpdateNoteDto(
   val reference: UUID,
-  val content: String?,
+  val content: String,
   val lastUpdatedAtPrison: String,
 )

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalNotesService.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalNotesService.kt
@@ -11,5 +11,5 @@ interface GoalNotesService {
 
   fun deleteNote(entityReference: UUID)
 
-  fun updateNotes(entityReference: UUID, lastUpdatedAtPrison: String, updatedText: String?)
+  fun updateNotes(entityReference: UUID, lastUpdatedAtPrison: String, updatedText: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/note/NoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/note/NoteEntity.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import jakarta.validation.constraints.NotNull
 import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
@@ -22,60 +21,54 @@ import java.util.UUID
 @Table(name = "note")
 @Entity
 @EntityListeners(value = [AuditingEntityListener::class])
-class NoteEntity(
+data class NoteEntity(
+  @Column(updatable = false)
+  val prisonNumber: String,
+
+  @Column(updatable = false)
+  val reference: UUID,
+
+  @Column
+  var content: String,
+
+  @Column(updatable = false)
+  @Enumerated(value = EnumType.STRING)
+  val noteType: NoteType,
+
+  @Column(updatable = false)
+  @Enumerated(value = EnumType.STRING)
+  val entityType: EntityType,
+
+  @Column(updatable = false)
+  val entityReference: UUID,
+
+  @Column(updatable = false)
+  val createdAtPrison: String,
+
+  @Column
+  var updatedAtPrison: String,
+) {
   @Id
   @GeneratedValue
   @UuidGenerator
-  var id: UUID? = null,
-
-  @Column
-  var prisonNumber: String? = null,
-
-  @Column(updatable = false)
-  @field:NotNull
-  var reference: UUID? = null,
-
-  @Column
-  @field:NotNull
-  var content: String? = null,
-
-  @Column
-  @field:NotNull
-  @Enumerated(value = EnumType.STRING)
-  var noteType: NoteType? = null,
-
-  @Column
-  @field:NotNull
-  @Enumerated(value = EnumType.STRING)
-  var entityType: EntityType? = null,
-
-  @Column
-  var entityReference: UUID? = null,
-
-  @Column(updatable = false)
-  @CreationTimestamp
-  var createdAt: Instant? = null,
-
-  @Column
-  @field:NotNull
-  var createdAtPrison: String? = null,
+  var id: UUID? = null
 
   @Column(updatable = false)
   @CreatedBy
-  var createdBy: String? = null,
+  var createdBy: String? = null
 
-  @Column
-  @UpdateTimestamp
-  var updatedAt: Instant? = null,
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null
 
-  @Column
-  @field:NotNull
-  var updatedAtPrison: String? = null,
-
-  @Column
+  @Column(updatable = false)
   @LastModifiedBy
-  var updatedBy: String? = null,
-) {
+  var updatedBy: String? = null
+
+  @Column(updatable = false)
+  @UpdateTimestamp
+  var updatedAt: Instant? = null
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/GoalNoteService.kt
@@ -33,7 +33,7 @@ class GoalNoteService(
     noteService.deleteNote(entityReference, EntityType.GOAL, NoteType.GOAL)
   }
 
-  override fun updateNotes(entityReference: UUID, lastUpdatedAtPrison: String, updatedText: String?) {
+  override fun updateNotes(entityReference: UUID, lastUpdatedAtPrison: String, updatedText: String) {
     val note = noteService.getNotes(entityReference, EntityType.GOAL, NoteType.GOAL).firstOrNull()
     // If no note exists, return early
     note?.let {

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/note/NoteEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/note/NoteEntityBuilder.kt
@@ -1,21 +1,25 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import java.time.Instant
 import java.util.UUID
 
 fun aValidNoteEntity(
   id: UUID? = UUID.randomUUID(),
-  reference: UUID? = UUID.randomUUID(),
+  reference: UUID = UUID.randomUUID(),
   prisonNumber: String = aValidPrisonNumber(),
   content: String = "Note content",
   entityReference: UUID = UUID.randomUUID(),
   entityType: EntityType = EntityType.GOAL,
   noteType: NoteType = NoteType.GOAL,
+  createdBy: String = "asmith_gen",
+  createdAt: Instant = Instant.now(),
   createdAtPrison: String = "BXI",
-  updatedAtPrison: String = "MDI",
+  updatedAt: Instant = Instant.now(),
+  updatedBy: String = "bjones_gen",
+  updatedAtPrison: String = "BXI",
 ): NoteEntity =
   NoteEntity(
-    id = id,
     reference = reference,
     prisonNumber = prisonNumber,
     content = content,
@@ -24,4 +28,10 @@ fun aValidNoteEntity(
     noteType = noteType,
     createdAtPrison = createdAtPrison,
     updatedAtPrison = updatedAtPrison,
-  )
+  ).apply {
+    this.id = id
+    this.createdAt = createdAt
+    this.createdBy = createdBy
+    this.updatedAt = updatedAt
+    this.updatedBy = updatedBy
+  }


### PR DESCRIPTION
This PR makes a minor refactoring to the `NoteEntity` class to make it a data class, and to it's `content` field to make it non-nullable (and the same change in the DTO, mappers etc)

I've needed to make this change because it was biting me a little in respect of the "Submit Review" API endpoint I am implementing because it needs to persist a NoteEntity as part of submitting the Review
(To be fair, it wasn't strictly necessary, I could have coded around it, but it's neater this way)