### PR TITLE
RR-1088 - Persistence classes to create and update a ReviewScheduleEntity

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/Exceptions.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/Exceptions.kt
@@ -5,3 +5,9 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review
  */
 class ReviewScheduleNotFoundException(val prisonNumber: String) :
   RuntimeException("Review Schedule not found for prisoner [$prisonNumber]")
+
+/**
+ * Thrown when a Review Schedule already exists for a given Prisoner.
+ */
+class ReviewScheduleAlreadyExistsException(val prisonNumber: String) :
+  RuntimeException("Review Schedule already exists for prisoner [$prisonNumber]")

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/ReviewSchedule.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/ReviewSchedule.kt
@@ -10,8 +10,7 @@ import java.util.UUID
 data class ReviewSchedule(
   val reference: UUID,
   val prisonNumber: String,
-  val earliestReviewDate: LocalDate,
-  val latestReviewDate: LocalDate,
+  val reviewScheduleWindow: ReviewScheduleWindow,
   val scheduleCalculationRule: ReviewScheduleCalculationRule,
   val scheduleStatus: ReviewScheduleStatus,
   val createdBy: String,
@@ -49,4 +48,27 @@ enum class ReviewScheduleStatus(val inScope: Boolean) {
   EXEMPT_PRISONER_TRANSFER(false),
   EXEMPT_PRISONER_RELEASE(false),
   EXEMPT_PRISONER_DEATH(false),
+}
+
+data class ReviewScheduleWindow(
+  val dateFrom: LocalDate,
+  val dateTo: LocalDate,
+) {
+  companion object {
+    fun fromTodayToTenDays(): ReviewScheduleWindow = with(LocalDate.now()) {
+      ReviewScheduleWindow(this, plusDays(10))
+    }
+    fun fromOneToThreeMonths(): ReviewScheduleWindow = with(LocalDate.now()) {
+      ReviewScheduleWindow(plusMonths(1), plusMonths(3))
+    }
+    fun fromTwoToThreeMonths(): ReviewScheduleWindow = with(LocalDate.now()) {
+      ReviewScheduleWindow(plusMonths(2), plusMonths(3))
+    }
+    fun fromFourToSixMonths(): ReviewScheduleWindow = with(LocalDate.now()) {
+      ReviewScheduleWindow(plusMonths(4), plusMonths(6))
+    }
+    fun fromTenToTwelveMonths(): ReviewScheduleWindow = with(LocalDate.now()) {
+      ReviewScheduleWindow(plusMonths(10), plusMonths(12))
+    }
+  }
 }

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/CreateReviewScheduleDto.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/CreateReviewScheduleDto.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto
+
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
+
+data class CreateReviewScheduleDto(
+  val prisonNumber: String,
+  val reviewScheduleWindow: ReviewScheduleWindow,
+  val scheduleCalculationRule: ReviewScheduleCalculationRule,
+  val scheduleStatus: ReviewScheduleStatus,
+  val prisonId: String,
+)

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/UpdateReviewScheduleDto.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/UpdateReviewScheduleDto.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto
+
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
+import java.util.UUID
+
+data class UpdateReviewScheduleDto(
+  val reference: UUID,
+  val reviewScheduleWindow: ReviewScheduleWindow,
+  val scheduleCalculationRule: ReviewScheduleCalculationRule,
+  val scheduleStatus: ReviewScheduleStatus,
+  val prisonId: String,
+)

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewSchedulePersistenceAdapter.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewSchedulePersistenceAdapter.kt
@@ -1,8 +1,24 @@
 package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service
 
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleAlreadyExistsException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.CreateReviewScheduleDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.UpdateReviewScheduleDto
 
 interface ReviewSchedulePersistenceAdapter {
+
+  /**
+   * Persists a new [ReviewSchedule].
+   *
+   * Throws [ReviewScheduleAlreadyExistsException] if the prisoner already has a [ReviewSchedule].
+   */
+  fun createReviewSchedule(createReviewScheduleDto: CreateReviewScheduleDto): ReviewSchedule
+
+  /**
+   * Updates a [ReviewSchedule] identified by its `reference`.
+   */
+  fun updateReviewSchedule(updateReviewScheduleDto: UpdateReviewScheduleDto): ReviewSchedule?
+
   /**
    * Retrieves a [ReviewSchedule] for a given Prisoner. Returns `null` if the [ReviewSchedule] does not exist.
    */

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/ReviewScheduleBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/ReviewScheduleBuilder.kt
@@ -22,8 +22,7 @@ fun aValidReviewSchedule(
   ReviewSchedule(
     reference = reference,
     prisonNumber = prisonNumber,
-    earliestReviewDate = earliestReviewDate,
-    latestReviewDate = latestReviewDate,
+    reviewScheduleWindow = ReviewScheduleWindow(earliestReviewDate, latestReviewDate),
     scheduleCalculationRule = scheduleCalculationRule,
     scheduleStatus = scheduleStatus,
     createdBy = createdBy,

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/CreateReviewScheduleDtoBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/CreateReviewScheduleDtoBuilder.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto
+
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
+
+fun aValidCreateReviewScheduleDto(
+  prisonNumber: String = "A1234BC",
+  reviewScheduleWindow: ReviewScheduleWindow = ReviewScheduleWindow.fromFourToSixMonths(),
+  scheduleCalculationRule: ReviewScheduleCalculationRule = ReviewScheduleCalculationRule.MORE_THAN_60_MONTHS_TO_SERVE,
+  scheduleStatus: ReviewScheduleStatus = ReviewScheduleStatus.SCHEDULED,
+  prisonId: String = "BXI",
+): CreateReviewScheduleDto =
+  CreateReviewScheduleDto(
+    prisonNumber = prisonNumber,
+    reviewScheduleWindow = reviewScheduleWindow,
+    scheduleCalculationRule = scheduleCalculationRule,
+    scheduleStatus = scheduleStatus,
+    prisonId = prisonId,
+  )

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/UpdateReviewScheduleDtoBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/UpdateReviewScheduleDtoBuilder.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto
+
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
+import java.util.UUID
+
+fun aValidUpdateReviewScheduleDto(
+  reference: UUID = UUID.randomUUID(),
+  reviewScheduleWindow: ReviewScheduleWindow = ReviewScheduleWindow.fromTenToTwelveMonths(),
+  scheduleCalculationRule: ReviewScheduleCalculationRule = ReviewScheduleCalculationRule.MORE_THAN_60_MONTHS_TO_SERVE,
+  scheduleStatus: ReviewScheduleStatus = ReviewScheduleStatus.SCHEDULED,
+  prisonId: String = "BXI",
+): UpdateReviewScheduleDto =
+  UpdateReviewScheduleDto(
+    reference = reference,
+    reviewScheduleWindow = reviewScheduleWindow,
+    scheduleCalculationRule = scheduleCalculationRule,
+    scheduleStatus = scheduleStatus,
+    prisonId = prisonId,
+  )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapter.kt
@@ -3,6 +3,9 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleAlreadyExistsException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.CreateReviewScheduleDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.UpdateReviewScheduleDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewSchedulePersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.review.ReviewScheduleEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ReviewScheduleRepository
@@ -12,6 +15,32 @@ class JpaReviewSchedulePersistenceAdapter(
   private val reviewScheduleRepository: ReviewScheduleRepository,
   private val reviewScheduleEntityMapper: ReviewScheduleEntityMapper,
 ) : ReviewSchedulePersistenceAdapter {
+
+  @Transactional
+  override fun createReviewSchedule(createReviewScheduleDto: CreateReviewScheduleDto): ReviewSchedule =
+    with(createReviewScheduleDto) {
+      if (reviewScheduleRepository.findByPrisonNumber(prisonNumber) != null) {
+        throw ReviewScheduleAlreadyExistsException(prisonNumber)
+      }
+
+      val persistedEntity = reviewScheduleRepository.saveAndFlush(
+        reviewScheduleEntityMapper.fromDomainToEntity(this),
+      )
+      reviewScheduleEntityMapper.fromEntityToDomain(persistedEntity)
+    }
+
+  @Transactional
+  override fun updateReviewSchedule(updateReviewScheduleDto: UpdateReviewScheduleDto): ReviewSchedule? {
+    val reviewScheduleEntity = reviewScheduleRepository.findByReference(updateReviewScheduleDto.reference)
+
+    return if (reviewScheduleEntity != null) {
+      reviewScheduleEntityMapper.updateExistingEntityFromDto(reviewScheduleEntity, updateReviewScheduleDto)
+      val persistedEntity = reviewScheduleRepository.saveAndFlush(reviewScheduleEntity)
+      return reviewScheduleEntityMapper.fromEntityToDomain(persistedEntity)
+    } else {
+      null
+    }
+  }
 
   @Transactional(readOnly = true)
   override fun getReviewSchedule(prisonNumber: String): ReviewSchedule? =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapter.kt
@@ -33,12 +33,9 @@ class JpaReviewSchedulePersistenceAdapter(
   override fun updateReviewSchedule(updateReviewScheduleDto: UpdateReviewScheduleDto): ReviewSchedule? {
     val reviewScheduleEntity = reviewScheduleRepository.findByReference(updateReviewScheduleDto.reference)
 
-    return if (reviewScheduleEntity != null) {
-      reviewScheduleEntityMapper.updateExistingEntityFromDto(reviewScheduleEntity, updateReviewScheduleDto)
-      val persistedEntity = reviewScheduleRepository.saveAndFlush(reviewScheduleEntity)
-      return reviewScheduleEntityMapper.fromEntityToDomain(persistedEntity)
-    } else {
-      null
+    return reviewScheduleEntity?.let {
+      reviewScheduleEntityMapper.updateExistingEntityFromDto(it, updateReviewScheduleDto)
+      reviewScheduleEntityMapper.fromEntityToDomain(reviewScheduleRepository.saveAndFlush(it))
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/review/ReviewScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/review/ReviewScheduleEntity.kt
@@ -29,25 +29,25 @@ data class ReviewScheduleEntity(
   @Column(updatable = false)
   val prisonNumber: String,
 
-  @Column(updatable = false)
-  val earliestReviewDate: LocalDate,
+  @Column
+  var earliestReviewDate: LocalDate,
 
-  @Column(updatable = false)
-  val latestReviewDate: LocalDate,
+  @Column
+  var latestReviewDate: LocalDate,
 
-  @Column(updatable = false)
+  @Column
   @Enumerated(value = EnumType.STRING)
-  val scheduleCalculationRule: ReviewScheduleCalculationRule,
+  var scheduleCalculationRule: ReviewScheduleCalculationRule,
 
-  @Column(updatable = false)
+  @Column
   @Enumerated(value = EnumType.STRING)
-  val scheduleStatus: ReviewScheduleStatus,
+  var scheduleStatus: ReviewScheduleStatus,
 
   @Column(updatable = false)
   val createdAtPrison: String,
 
-  @Column(updatable = false)
-  val updatedAtPrison: String,
+  @Column
+  var updatedAtPrison: String,
 ) {
   @Id
   @GeneratedValue

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/review/ReviewScheduleEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/review/ReviewScheduleEntityMapper.kt
@@ -2,7 +2,11 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.CreateReviewScheduleDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.UpdateReviewScheduleDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleEntity
+import java.util.UUID
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule as ReviewScheduleCalculationRuleDomain
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus as ReviewScheduleStatusDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleCalculationRule as ReviewScheduleCalculationRuleEntity
@@ -16,8 +20,7 @@ class ReviewScheduleEntityMapper {
       ReviewSchedule(
         reference = reference,
         prisonNumber = prisonNumber,
-        earliestReviewDate = earliestReviewDate,
-        latestReviewDate = latestReviewDate,
+        reviewScheduleWindow = ReviewScheduleWindow(earliestReviewDate, latestReviewDate),
         scheduleCalculationRule = toReviewScheduleCalculationRule(scheduleCalculationRule),
         scheduleStatus = toReviewScheduleStatus(scheduleStatus),
         createdBy = createdBy!!,
@@ -27,6 +30,29 @@ class ReviewScheduleEntityMapper {
         lastUpdatedAt = updatedAt!!,
         lastUpdatedAtPrison = updatedAtPrison,
       )
+    }
+
+  fun fromDomainToEntity(createReviewScheduleDto: CreateReviewScheduleDto): ReviewScheduleEntity =
+    with(createReviewScheduleDto) {
+      ReviewScheduleEntity(
+        reference = UUID.randomUUID(),
+        prisonNumber = prisonNumber,
+        earliestReviewDate = reviewScheduleWindow.dateFrom,
+        latestReviewDate = reviewScheduleWindow.dateTo,
+        scheduleCalculationRule = toReviewScheduleCalculationRule(scheduleCalculationRule),
+        scheduleStatus = toReviewScheduleStatus(scheduleStatus),
+        createdAtPrison = prisonId,
+        updatedAtPrison = prisonId,
+      )
+    }
+
+  fun updateExistingEntityFromDto(entity: ReviewScheduleEntity, dto: UpdateReviewScheduleDto) =
+    with(entity) {
+      earliestReviewDate = dto.reviewScheduleWindow.dateFrom
+      latestReviewDate = dto.reviewScheduleWindow.dateTo
+      scheduleCalculationRule = toReviewScheduleCalculationRule(dto.scheduleCalculationRule)
+      scheduleStatus = toReviewScheduleStatus(dto.scheduleStatus)
+      updatedAtPrison = dto.prisonId
     }
 
   private fun toReviewScheduleCalculationRule(calculationRule: ReviewScheduleCalculationRuleEntity): ReviewScheduleCalculationRuleDomain =
@@ -40,6 +66,19 @@ class ReviewScheduleEntityMapper {
       ReviewScheduleCalculationRuleEntity.INDETERMINATE_SENTENCE -> ReviewScheduleCalculationRuleDomain.INDETERMINATE_SENTENCE
       ReviewScheduleCalculationRuleEntity.PRISONER_ON_REMAND -> ReviewScheduleCalculationRuleDomain.PRISONER_ON_REMAND
       ReviewScheduleCalculationRuleEntity.PRISONER_UN_SENTENCED -> ReviewScheduleCalculationRuleDomain.PRISONER_UN_SENTENCED
+    }
+
+  private fun toReviewScheduleCalculationRule(calculationRule: ReviewScheduleCalculationRuleDomain): ReviewScheduleCalculationRuleEntity =
+    when (calculationRule) {
+      ReviewScheduleCalculationRuleDomain.PRISONER_READMISSION -> ReviewScheduleCalculationRuleEntity.PRISONER_READMISSION
+      ReviewScheduleCalculationRuleDomain.PRISONER_TRANSFER -> ReviewScheduleCalculationRuleEntity.PRISONER_TRANSFER
+      ReviewScheduleCalculationRuleDomain.LESS_THAN_6_MONTHS_TO_SERVE -> ReviewScheduleCalculationRuleEntity.LESS_THAN_6_MONTHS_TO_SERVE
+      ReviewScheduleCalculationRuleDomain.BETWEEN_6_AND_12_MONTHS_TO_SERVE -> ReviewScheduleCalculationRuleEntity.BETWEEN_6_AND_12_MONTHS_TO_SERVE
+      ReviewScheduleCalculationRuleDomain.BETWEEN_12_AND_60_MONTHS_TO_SERVE -> ReviewScheduleCalculationRuleEntity.BETWEEN_12_AND_60_MONTHS_TO_SERVE
+      ReviewScheduleCalculationRuleDomain.MORE_THAN_60_MONTHS_TO_SERVE -> ReviewScheduleCalculationRuleEntity.MORE_THAN_60_MONTHS_TO_SERVE
+      ReviewScheduleCalculationRuleDomain.INDETERMINATE_SENTENCE -> ReviewScheduleCalculationRuleEntity.INDETERMINATE_SENTENCE
+      ReviewScheduleCalculationRuleDomain.PRISONER_ON_REMAND -> ReviewScheduleCalculationRuleEntity.PRISONER_ON_REMAND
+      ReviewScheduleCalculationRuleDomain.PRISONER_UN_SENTENCED -> ReviewScheduleCalculationRuleEntity.PRISONER_UN_SENTENCED
     }
 
   private fun toReviewScheduleStatus(reviewScheduleStatus: ReviewScheduleStatusEntity): ReviewScheduleStatusDomain =
@@ -58,5 +97,23 @@ class ReviewScheduleEntityMapper {
       ReviewScheduleStatusEntity.EXEMPT_PRISONER_TRANSFER -> ReviewScheduleStatusDomain.EXEMPT_PRISONER_TRANSFER
       ReviewScheduleStatusEntity.EXEMPT_PRISONER_RELEASE -> ReviewScheduleStatusDomain.EXEMPT_PRISONER_RELEASE
       ReviewScheduleStatusEntity.EXEMPT_PRISONER_DEATH -> ReviewScheduleStatusDomain.EXEMPT_PRISONER_DEATH
+    }
+
+  private fun toReviewScheduleStatus(reviewScheduleStatus: ReviewScheduleStatusDomain): ReviewScheduleStatusEntity =
+    when (reviewScheduleStatus) {
+      ReviewScheduleStatusDomain.SCHEDULED -> ReviewScheduleStatusEntity.SCHEDULED
+      ReviewScheduleStatusDomain.EXEMPT_PRISONER_DRUG_OR_ALCOHOL_DEPENDENCY -> ReviewScheduleStatusEntity.EXEMPT_PRISONER_DRUG_OR_ALCOHOL_DEPENDENCY
+      ReviewScheduleStatusDomain.EXEMPT_PRISONER_OTHER_HEALTH_ISSUES -> ReviewScheduleStatusEntity.EXEMPT_PRISONER_OTHER_HEALTH_ISSUES
+      ReviewScheduleStatusDomain.EXEMPT_PRISONER_FAILED_TO_ENGAGE -> ReviewScheduleStatusEntity.EXEMPT_PRISONER_FAILED_TO_ENGAGE
+      ReviewScheduleStatusDomain.EXEMPT_PRISONER_ESCAPED_OR_ABSCONDED -> ReviewScheduleStatusEntity.EXEMPT_PRISONER_ESCAPED_OR_ABSCONDED
+      ReviewScheduleStatusDomain.EXEMPT_PRISONER_SAFETY_ISSUES -> ReviewScheduleStatusEntity.EXEMPT_PRISONER_SAFETY_ISSUES
+      ReviewScheduleStatusDomain.EXEMPT_PRISON_REGIME_CIRCUMSTANCES -> ReviewScheduleStatusEntity.EXEMPT_PRISON_REGIME_CIRCUMSTANCES
+      ReviewScheduleStatusDomain.EXEMPT_PRISON_STAFF_REDEPLOYMENT -> ReviewScheduleStatusEntity.EXEMPT_PRISON_STAFF_REDEPLOYMENT
+      ReviewScheduleStatusDomain.EXEMPT_PRISON_OPERATION_OR_SECURITY_ISSUE -> ReviewScheduleStatusEntity.EXEMPT_PRISON_OPERATION_OR_SECURITY_ISSUE
+      ReviewScheduleStatusDomain.EXEMPT_SECURITY_ISSUE_RISK_TO_STAFF -> ReviewScheduleStatusEntity.EXEMPT_SECURITY_ISSUE_RISK_TO_STAFF
+      ReviewScheduleStatusDomain.EXEMPT_SYSTEM_TECHNICAL_ISSUE -> ReviewScheduleStatusEntity.EXEMPT_SYSTEM_TECHNICAL_ISSUE
+      ReviewScheduleStatusDomain.EXEMPT_PRISONER_TRANSFER -> ReviewScheduleStatusEntity.EXEMPT_PRISONER_TRANSFER
+      ReviewScheduleStatusDomain.EXEMPT_PRISONER_RELEASE -> ReviewScheduleStatusEntity.EXEMPT_PRISONER_RELEASE
+      ReviewScheduleStatusDomain.EXEMPT_PRISONER_DEATH -> ReviewScheduleStatusEntity.EXEMPT_PRISONER_DEATH
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/ReviewScheduleRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/ReviewScheduleRepository.kt
@@ -7,5 +7,7 @@ import java.util.UUID
 
 @Repository
 interface ReviewScheduleRepository : JpaRepository<ReviewScheduleEntity, UUID> {
+  fun findByReference(reference: UUID): ReviewScheduleEntity?
+
   fun findByPrisonNumber(prisonNumber: String): ReviewScheduleEntity?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/review/ScheduledActionPlanReviewResponseMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/review/ScheduledActionPlanReviewResponseMapper.kt
@@ -20,8 +20,8 @@ class ScheduledActionPlanReviewResponseMapper(
     with(reviewSchedule) {
       ScheduledActionPlanReviewResponse(
         reference = reference,
-        reviewDateFrom = earliestReviewDate,
-        reviewDateTo = latestReviewDate,
+        reviewDateFrom = reviewScheduleWindow.dateFrom,
+        reviewDateTo = reviewScheduleWindow.dateTo,
         status = toReviewScheduleStatus(scheduleStatus),
         calculationRule = toReviewScheduleCalculationRule(scheduleCalculationRule),
         createdBy = createdBy,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapterTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -11,8 +12,14 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.aValidReference
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleAlreadyExistsException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidReviewSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.aValidCreateReviewScheduleDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.aValidUpdateReviewScheduleDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.aValidReviewScheduleEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.review.ReviewScheduleEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ReviewScheduleRepository
@@ -64,6 +71,119 @@ class JpaReviewSchedulePersistenceAdapterTest {
       // Then
       assertThat(actual).isNull()
       verify(reviewScheduleRepository).findByPrisonNumber(prisonNumber)
+      verifyNoInteractions(reviewScheduleEntityMapper)
+    }
+  }
+
+  @Nested
+  inner class CreateReviewSchedule {
+    @Test
+    fun `should create review schedule given prisoner does not already have one`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+
+      val createReviewScheduleDto = aValidCreateReviewScheduleDto(
+        prisonNumber = prisonNumber,
+      )
+
+      given(reviewScheduleRepository.findByPrisonNumber(any())).willReturn(null)
+
+      val reviewScheduleEntity = aValidReviewScheduleEntity(
+        prisonNumber = prisonNumber,
+      )
+      given(reviewScheduleEntityMapper.fromDomainToEntity(any())).willReturn(reviewScheduleEntity)
+      given(reviewScheduleRepository.saveAndFlush(any<ReviewScheduleEntity>())).willReturn(reviewScheduleEntity)
+
+      val expectedReviewSchedule = aValidReviewSchedule()
+      given(reviewScheduleEntityMapper.fromEntityToDomain(any())).willReturn(expectedReviewSchedule)
+
+      // When
+      val actual = persistenceAdapter.createReviewSchedule(createReviewScheduleDto)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedReviewSchedule)
+      verify(reviewScheduleRepository).findByPrisonNumber(prisonNumber)
+      verify(reviewScheduleEntityMapper).fromDomainToEntity(createReviewScheduleDto)
+      verify(reviewScheduleRepository).saveAndFlush(reviewScheduleEntity)
+      verify(reviewScheduleEntityMapper).fromEntityToDomain(reviewScheduleEntity)
+    }
+  }
+
+  @Test
+  fun `should not create review schedule given prisoner already has one`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+
+    val createReviewScheduleDto = aValidCreateReviewScheduleDto(
+      prisonNumber = prisonNumber,
+    )
+
+    val reviewScheduleEntity = aValidReviewScheduleEntity(
+      prisonNumber = prisonNumber,
+    )
+    given(reviewScheduleRepository.findByPrisonNumber(any())).willReturn(reviewScheduleEntity)
+
+    // When
+    val exception = assertThrows(ReviewScheduleAlreadyExistsException::class.java) {
+      persistenceAdapter.createReviewSchedule(createReviewScheduleDto)
+    }
+
+    // Then
+    assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
+    verify(reviewScheduleRepository).findByPrisonNumber(prisonNumber)
+    verifyNoMoreInteractions(reviewScheduleRepository)
+    verifyNoInteractions(reviewScheduleEntityMapper)
+  }
+
+  @Nested
+  inner class UpdateReviewSchedule {
+    @Test
+    fun `should update review schedule`() {
+      // Given
+      val reference = aValidReference()
+
+      val reviewScheduleEntity = aValidReviewScheduleEntity(
+        reference = reference,
+      )
+      given(reviewScheduleRepository.findByReference(any())).willReturn(reviewScheduleEntity)
+      given(reviewScheduleRepository.saveAndFlush(any<ReviewScheduleEntity>())).willReturn(reviewScheduleEntity)
+
+      val expectedReviewSchedule = aValidReviewSchedule()
+      given(reviewScheduleEntityMapper.fromEntityToDomain(any())).willReturn(expectedReviewSchedule)
+
+      val updateReviewScheduleDto = aValidUpdateReviewScheduleDto(
+        reference = reference,
+      )
+
+      // When
+      val actual = persistenceAdapter.updateReviewSchedule(updateReviewScheduleDto)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedReviewSchedule)
+      verify(reviewScheduleRepository).findByReference(reference)
+      verify(reviewScheduleEntityMapper).updateExistingEntityFromDto(reviewScheduleEntity, updateReviewScheduleDto)
+      verify(reviewScheduleRepository).saveAndFlush(reviewScheduleEntity)
+      verify(reviewScheduleEntityMapper).fromEntityToDomain(reviewScheduleEntity)
+    }
+
+    @Test
+    fun `should not update review schedule given review does not exist by reference`() {
+      // Given
+      val reference = aValidReference()
+
+      given(reviewScheduleRepository.findByReference(any())).willReturn(null)
+
+      val updateReviewScheduleDto = aValidUpdateReviewScheduleDto(
+        reference = reference,
+      )
+
+      // When
+      val actual = persistenceAdapter.updateReviewSchedule(updateReviewScheduleDto)
+
+      // Then
+      assertThat(actual).isNull()
+      verify(reviewScheduleRepository).findByReference(reference)
+      verifyNoMoreInteractions(reviewScheduleRepository)
       verifyNoInteractions(reviewScheduleEntityMapper)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/review/ReviewScheduleEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/review/ReviewScheduleEntityMapperTest.kt
@@ -2,10 +2,19 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidReviewSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.aValidCreateReviewScheduleDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.aValidUpdateReviewScheduleDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.aValidReviewScheduleEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.aValidUnPersistedReviewScheduleEntity
 import java.time.Instant
+import java.time.LocalDate
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule as ReviewScheduleCalculationRuleDomain
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus as ReviewScheduleStatusDomain
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleCalculationRule as ReviewScheduleCalculationRuleEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleStatus as ReviewScheduleStatusEntity
 
 class ReviewScheduleEntityMapperTest {
   private val mapper = ReviewScheduleEntityMapper()
@@ -33,5 +42,62 @@ class ReviewScheduleEntityMapperTest {
 
     // Then
     assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map create review schedule domain DTO to review schedule entity`() {
+    // Given
+    val earliestReviewDate = LocalDate.now().plusMonths(1)
+    val latestReviewDate = LocalDate.now().plusMonths(3)
+    val createReviewScheduleDto = aValidCreateReviewScheduleDto(
+      scheduleCalculationRule = ReviewScheduleCalculationRuleDomain.MORE_THAN_60_MONTHS_TO_SERVE,
+      reviewScheduleWindow = ReviewScheduleWindow(earliestReviewDate, latestReviewDate),
+    )
+
+    val expected = aValidUnPersistedReviewScheduleEntity(
+      scheduleCalculationRule = ReviewScheduleCalculationRuleEntity.MORE_THAN_60_MONTHS_TO_SERVE,
+      earliestReviewDate = earliestReviewDate,
+      latestReviewDate = latestReviewDate,
+    )
+
+    // When
+    val actual = mapper.fromDomainToEntity(createReviewScheduleDto)
+
+    // Then
+    assertThat(actual)
+      .usingRecursiveComparison()
+      .ignoringFields("reference")
+      .isEqualTo(expected)
+  }
+
+  @Test
+  fun `should update review schedule entity from update review schedule domain DTO`() {
+    // Given
+    val reviewScheduleEntity = aValidReviewScheduleEntity(
+      earliestReviewDate = LocalDate.now().minusMonths(1),
+      latestReviewDate = LocalDate.now().plusDays(1),
+      scheduleCalculationRule = ReviewScheduleCalculationRuleEntity.PRISONER_TRANSFER,
+      scheduleStatus = ReviewScheduleStatusEntity.EXEMPT_PRISONER_OTHER_HEALTH_ISSUES,
+      updatedAtPrison = "BXI",
+    )
+
+    val updatedEarliestReviewDate = LocalDate.now().plusMonths(10)
+    val updatedLatestReviewDate = LocalDate.now().plusMonths(12)
+    val updateReviewScheduleDto = aValidUpdateReviewScheduleDto(
+      reviewScheduleWindow = ReviewScheduleWindow(updatedEarliestReviewDate, updatedLatestReviewDate),
+      scheduleCalculationRule = ReviewScheduleCalculationRuleDomain.BETWEEN_12_AND_60_MONTHS_TO_SERVE,
+      scheduleStatus = ReviewScheduleStatusDomain.SCHEDULED,
+      prisonId = "LFI",
+    )
+
+    // When
+    mapper.updateExistingEntityFromDto(reviewScheduleEntity, updateReviewScheduleDto)
+
+    // Then
+    assertThat(reviewScheduleEntity.earliestReviewDate).isEqualTo(updatedEarliestReviewDate)
+    assertThat(reviewScheduleEntity.latestReviewDate).isEqualTo(updatedLatestReviewDate)
+    assertThat(reviewScheduleEntity.scheduleStatus).isEqualTo(ReviewScheduleStatusEntity.SCHEDULED)
+    assertThat(reviewScheduleEntity.scheduleCalculationRule).isEqualTo(ReviewScheduleCalculationRuleEntity.BETWEEN_12_AND_60_MONTHS_TO_SERVE)
+    assertThat(reviewScheduleEntity.updatedAtPrison).isEqualTo("LFI")
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/review/ReviewScheduleEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/review/ReviewScheduleEntityBuilder.kt
@@ -6,18 +6,18 @@ import java.time.LocalDate
 import java.util.UUID
 
 fun aValidReviewScheduleEntity(
-  id: UUID = UUID.randomUUID(),
+  id: UUID? = UUID.randomUUID(),
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = aValidPrisonNumber(),
   earliestReviewDate: LocalDate = LocalDate.now().minusMonths(1),
   latestReviewDate: LocalDate = LocalDate.now().plusMonths(1),
   scheduleCalculationRule: ReviewScheduleCalculationRule = ReviewScheduleCalculationRule.BETWEEN_12_AND_60_MONTHS_TO_SERVE,
   scheduleStatus: ReviewScheduleStatus = ReviewScheduleStatus.SCHEDULED,
-  createdBy: String = "asmith_gen",
-  createdAt: Instant = Instant.now(),
+  createdBy: String? = "asmith_gen",
+  createdAt: Instant? = Instant.now(),
   createdAtPrison: String = "BXI",
-  updatedAt: Instant = Instant.now(),
-  updatedBy: String = "bjones_gen",
+  updatedAt: Instant? = Instant.now(),
+  updatedBy: String? = "bjones_gen",
   updatedAtPrison: String = "BXI",
 ): ReviewScheduleEntity =
   ReviewScheduleEntity(
@@ -36,3 +36,29 @@ fun aValidReviewScheduleEntity(
     this.updatedBy = updatedBy
     this.updatedAt = updatedAt
   }
+
+fun aValidUnPersistedReviewScheduleEntity(
+  reference: UUID = UUID.randomUUID(),
+  prisonNumber: String = aValidPrisonNumber(),
+  earliestReviewDate: LocalDate = LocalDate.now().minusMonths(1),
+  latestReviewDate: LocalDate = LocalDate.now().plusMonths(1),
+  scheduleCalculationRule: ReviewScheduleCalculationRule = ReviewScheduleCalculationRule.BETWEEN_12_AND_60_MONTHS_TO_SERVE,
+  scheduleStatus: ReviewScheduleStatus = ReviewScheduleStatus.SCHEDULED,
+  createdAtPrison: String = "BXI",
+  updatedAtPrison: String = "BXI",
+): ReviewScheduleEntity =
+  aValidReviewScheduleEntity(
+    id = null,
+    reference = reference,
+    prisonNumber = prisonNumber,
+    earliestReviewDate = earliestReviewDate,
+    latestReviewDate = latestReviewDate,
+    scheduleCalculationRule = scheduleCalculationRule,
+    scheduleStatus = scheduleStatus,
+    createdBy = null,
+    createdAt = null,
+    createdAtPrison = createdAtPrison,
+    updatedBy = null,
+    updatedAt = null,
+    updatedAtPrison = updatedAtPrison,
+  )


### PR DESCRIPTION
This PR creates the persistence adapter methods and supporting code to allow a `ReviewScheduleEntity` to be created, and to to be updated

Once we have this in place the Review service methods which will persist a Review and update the Review Schedule should be straightforward 🤞 