### PR TITLE
RR-1088 - Persistence adapter etc for persisting a new Completed Review

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/SentenceType.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/SentenceType.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review
+
+enum class SentenceType {
+  RECALL,
+  DEAD,
+  INDETERMINATE_SENTENCE,
+  SENTENCED,
+  CONVICTED_UNSENTENCED,
+  CIVIL_PRISONER,
+  IMMIGRATION_DETAINEE,
+  REMAND,
+  UNKNOWN,
+  OTHER,
+}

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/CreateCompletedReviewDto.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/CreateCompletedReviewDto.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto
+
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.SentenceType
+import java.time.LocalDate
+
+data class CreateCompletedReviewDto(
+  val prisonNumber: String,
+  val prisonId: String,
+  val note: String,
+  val conductedAt: LocalDate,
+  val conductedBy: String?,
+  val conductedByRole: String?,
+  val prisonerReleaseDate: LocalDate,
+  val prisonerSentenceType: SentenceType,
+)

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewPersistenceAdapter.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewPersistenceAdapter.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service
 
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.CompletedReview
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.CreateCompletedReviewDto
+import java.time.LocalDate
 
 interface ReviewPersistenceAdapter {
   /**
@@ -8,4 +10,9 @@ interface ReviewPersistenceAdapter {
    * for the prisoner.
    */
   fun getCompletedReviews(prisonNumber: String): List<CompletedReview>
+
+  /**
+   * Creates and returns a new [CompletedReview] using the specified [CreateCompletedReviewDto] and deadlineDate.
+   */
+  fun createCompletedReview(createCompletedReviewDto: CreateCompletedReviewDto, deadlineDate: LocalDate): CompletedReview
 }

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewService.kt
@@ -4,6 +4,8 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.Comple
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewSchedule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNotFoundException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.SentenceType
 import java.time.LocalDate
 import java.time.Period
 
@@ -73,31 +75,5 @@ class ReviewService(
       monthsLeft < 60 || isExactMonths(60) -> ReviewScheduleCalculationRule.BETWEEN_12_AND_60_MONTHS_TO_SERVE
       else -> ReviewScheduleCalculationRule.MORE_THAN_60_MONTHS_TO_SERVE
     }
-  }
-}
-
-enum class SentenceType {
-  RECALL,
-  DEAD,
-  INDETERMINATE_SENTENCE,
-  SENTENCED,
-  CONVICTED_UNSENTENCED,
-  CIVIL_PRISONER,
-  IMMIGRATION_DETAINEE,
-  REMAND,
-  UNKNOWN,
-  OTHER,
-}
-
-data class ReviewScheduleWindow(
-  val dateFrom: LocalDate,
-  val dateTo: LocalDate,
-) {
-  companion object {
-    fun fromTodayToTenDays(): ReviewScheduleWindow = with(LocalDate.now()) { ReviewScheduleWindow(this, this.plusDays(10)) }
-    fun fromOneToThreeMonths(): ReviewScheduleWindow = with(LocalDate.now()) { ReviewScheduleWindow(this.plusMonths(1), this.plusMonths(3)) }
-    fun fromTwoToThreeMonths(): ReviewScheduleWindow = with(LocalDate.now()) { ReviewScheduleWindow(this.plusMonths(2), this.plusMonths(3)) }
-    fun fromFourToSixMonths(): ReviewScheduleWindow = with(LocalDate.now()) { ReviewScheduleWindow(this.plusMonths(4), this.plusMonths(6)) }
-    fun fromTenToTwelveMonths(): ReviewScheduleWindow = with(LocalDate.now()) { ReviewScheduleWindow(this.plusMonths(10), this.plusMonths(12)) }
   }
 }

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceCalculateReviewWindowTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceCalculateReviewWindowTest.kt
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
 import java.time.LocalDate
 
 @ExtendWith(MockitoExtension::class)

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceDetermineReviewScheduleCalculationRuleTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceDetermineReviewScheduleCalculationRuleTest.kt
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.SentenceType
 import java.time.LocalDate
 import java.util.stream.Stream
 

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNotFoundException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidCompletedReview
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidReviewSchedule
 import java.time.LocalDate

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/CreateCompletedReviewDtoBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/CreateCompletedReviewDtoBuilder.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto
+
+import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.SentenceType
+import java.time.LocalDate
+
+fun aValidCreateCompletedReviewDto(
+  prisonNumber: String = aValidPrisonNumber(),
+  prisonId: String = "BXI",
+  note: String = "Note content",
+  conductedAt: LocalDate = LocalDate.now(),
+  conductedBy: String? = "Barnie Jones",
+  conductedByRole: String? = "Peer mentor",
+  prisonerReleaseDate: LocalDate = LocalDate.now().plusYears(1),
+  prisonerSentenceType: SentenceType = SentenceType.SENTENCED,
+): CreateCompletedReviewDto =
+  CreateCompletedReviewDto(
+    prisonNumber = prisonNumber,
+    prisonId = prisonId,
+    note = note,
+    conductedAt = conductedAt,
+    conductedBy = conductedBy,
+    conductedByRole = conductedByRole,
+    prisonerReleaseDate = prisonerReleaseDate,
+    prisonerSentenceType = prisonerSentenceType,
+  )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewPersistenceAdapter.kt
@@ -3,11 +3,16 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.CompletedReview
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.CreateCompletedReviewDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewPersistenceAdapter
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.NoteEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.NoteType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.review.ReviewEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.NoteRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ReviewRepository
+import java.time.LocalDate
+import java.util.UUID
 
 @Component
 class JpaReviewPersistenceAdapter(
@@ -24,5 +29,27 @@ class JpaReviewPersistenceAdapter(
         entityType = EntityType.REVIEW,
       ).first()
       reviewEntityMapper.fromEntityToDomain(it, reviewNoteEntity)
+    }
+
+  @Transactional
+  override fun createCompletedReview(createCompletedReviewDto: CreateCompletedReviewDto, deadlineDate: LocalDate): CompletedReview =
+    with(createCompletedReviewDto) {
+      val completedReviewEntity = reviewRepository.saveAndFlush(
+        reviewEntityMapper.fromDomainToEntity(this, deadlineDate),
+      )
+      val noteEntity = noteRepository.saveAndFlush(
+        NoteEntity(
+          reference = UUID.randomUUID(),
+          prisonNumber = prisonNumber,
+          content = note,
+          noteType = NoteType.REVIEW,
+          entityType = EntityType.REVIEW,
+          entityReference = completedReviewEntity.reference,
+          createdAtPrison = prisonId,
+          updatedAtPrison = prisonId,
+        ),
+      )
+
+      reviewEntityMapper.fromEntityToDomain(completedReviewEntity, noteEntity)
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/note/NoteMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/note/NoteMapper.kt
@@ -26,17 +26,17 @@ object NoteMapper {
 
   fun fromEntityToDomain(noteEntity: NoteEntity): NoteDto {
     return NoteDto(
-      reference = noteEntity.reference!!,
-      content = noteEntity.content.orEmpty(),
+      reference = noteEntity.reference,
+      content = noteEntity.content,
       createdBy = noteEntity.createdBy,
       createdAt = noteEntity.createdAt,
-      createdAtPrison = noteEntity.createdAtPrison.orEmpty(),
+      createdAtPrison = noteEntity.createdAtPrison,
       lastUpdatedBy = noteEntity.updatedBy,
       lastUpdatedAt = noteEntity.updatedAt,
-      lastUpdatedAtPrison = noteEntity.updatedAtPrison.orEmpty(),
-      noteType = toNoteType(noteEntity.noteType!!),
-      entityType = toEntityType(noteEntity.entityType!!),
-      entityReference = noteEntity.reference!!,
+      lastUpdatedAtPrison = noteEntity.updatedAtPrison,
+      noteType = toNoteType(noteEntity.noteType),
+      entityType = toEntityType(noteEntity.entityType),
+      entityReference = noteEntity.entityReference,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/review/ReviewEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/review/ReviewEntityMapper.kt
@@ -3,9 +3,12 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.CompletedReview
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewConductedBy
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.CreateCompletedReviewDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.NoteEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.note.NoteMapper
+import java.time.LocalDate
+import java.util.UUID
 
 @Component
 class ReviewEntityMapper {
@@ -22,6 +25,20 @@ class ReviewEntityMapper {
         createdAt = createdAt!!,
         createdAtPrison = createdAtPrison,
         conductedBy = toReviewConductedBy(this),
+      )
+    }
+
+  fun fromDomainToEntity(createCompletedReviewDto: CreateCompletedReviewDto, deadlineDate: LocalDate): ReviewEntity =
+    with(createCompletedReviewDto) {
+      ReviewEntity(
+        reference = UUID.randomUUID(),
+        prisonNumber = prisonNumber,
+        deadlineDate = deadlineDate,
+        completedDate = conductedAt,
+        createdAtPrison = prisonId,
+        updatedAtPrison = prisonId,
+        conductedBy = conductedBy,
+        conductedByRole = conductedByRole,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/review/ReviewEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/review/ReviewEntityMapperTest.kt
@@ -2,14 +2,16 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ma
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.aValidNoteDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewConductedBy
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidCompletedReview
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.aValidNoteEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.aValidReviewEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.note.NoteMapper
 import java.time.Instant
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.EntityType as EntityTypeDomain
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType as EntityTypeEntity
 
 class ReviewEntityMapperTest {
   private val mapper = ReviewEntityMapper()
@@ -28,7 +30,7 @@ class ReviewEntityMapperTest {
     )
     val reviewNoteEntity = aValidNoteEntity(
       entityReference = reference,
-      entityType = EntityType.REVIEW,
+      entityType = EntityTypeEntity.REVIEW,
     )
 
     val expectedNote = NoteMapper.fromEntityToDomain(reviewNoteEntity)
@@ -60,7 +62,7 @@ class ReviewEntityMapperTest {
     )
     val reviewNoteEntity = aValidNoteEntity(
       entityReference = reference,
-      entityType = EntityType.REVIEW,
+      entityType = EntityTypeEntity.REVIEW,
     )
 
     val expectedNote = NoteMapper.fromEntityToDomain(reviewNoteEntity)
@@ -69,6 +71,64 @@ class ReviewEntityMapperTest {
       note = expectedNote,
       conductedBy = null,
       createdAt = createdAt,
+    )
+
+    // When
+    val actual = mapper.fromEntityToDomain(reviewEntity, reviewNoteEntity)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map entity to completed review`() {
+    // Given
+    val reviewReference = UUID.randomUUID()
+    val reviewCreatedBy = "asmith_gen"
+    val reviewCreatedAt = Instant.now()
+    val reviewCreatedAtPrison = "BXI"
+    val reviewEntity = aValidReviewEntity(
+      reference = reviewReference,
+      createdBy = reviewCreatedBy,
+      createdAt = reviewCreatedAt,
+      createdAtPrison = reviewCreatedAtPrison,
+    )
+
+    val noteReference = UUID.randomUUID()
+    val noteCreatedBy = "asmith_gen"
+    val noteCreatedAt = Instant.now()
+    val noteCreatedAtPrison = "BXI"
+    val noteUpdatedBy = "asmith_gen"
+    val noteUpdatedAt = Instant.now()
+    val noteUpdatedAtPrison = "BXI"
+    val reviewNoteEntity = aValidNoteEntity(
+      reference = noteReference,
+      entityType = EntityTypeEntity.REVIEW,
+      entityReference = reviewReference,
+      createdBy = noteCreatedBy,
+      createdAtPrison = noteCreatedAtPrison,
+      createdAt = noteCreatedAt,
+      updatedBy = noteUpdatedBy,
+      updatedAtPrison = noteUpdatedAtPrison,
+      updatedAt = noteUpdatedAt,
+    )
+
+    val expected = aValidCompletedReview(
+      reference = reviewReference,
+      createdBy = reviewCreatedBy,
+      createdAt = reviewCreatedAt,
+      createdAtPrison = reviewCreatedAtPrison,
+      note = aValidNoteDto(
+        reference = noteReference,
+        entityType = EntityTypeDomain.REVIEW,
+        entityReference = reviewReference,
+        createdBy = noteCreatedBy,
+        createdAtPrison = noteCreatedAtPrison,
+        createdAt = noteCreatedAt,
+        lastUpdatedBy = noteUpdatedBy,
+        lastUpdatedAtPrison = noteUpdatedAtPrison,
+        lastUpdatedAt = noteUpdatedAt,
+      ),
     )
 
     // When


### PR DESCRIPTION
Once this PR is approved and merged I should be able to create a service method to create a completed review, whose implementation will use all the stuff that these recent PRs have been adding (ie. it will need to check a ReviewSchedule exists, create the new Completed Review, call the methods to work out the calculation rule and next schedule, and then update the ReviewSchedule with the next schedule etc.
And once we've got the service method in place then it will be an easy job to create the controller method which will call it 👍 