### PR TITLE
allow all on dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -22,11 +22,8 @@ generic-service:
     CIAG_KPI_PROCESSING_RULE: PEF
     SERVICE_BASE_URL: "https://learningandworkprogress-api-dev.hmpps.service.justice.gov.uk"
 
-  allowlist:
-    groups:
-      - internal
-      - prisons
-      - circleci
+  allowlist: null
+
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
Disable the ingress allowlist for the API **on `dev` only**
This is to allow the Integration API to consume the API's swagger spec

As per the following conversation with Matt Ryall this is not ideal but we dont have other options in the short term:
![image](https://github.com/user-attachments/assets/143cf39f-00fb-4273-8924-9fc07f6becc0)
