### PR TITLE
return system as the display name

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/messaging/InboundEventsListenerTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/messaging/InboundEventsListenerTest.kt
@@ -100,9 +100,9 @@ class InboundEventsListenerTest : IntegrationTestBase() {
       .wasCreatedAfter(initialDateTime)
       .wasUpdatedAfter(initialDateTime)
       .wasCreatedBy("system")
-      .wasCreatedByDisplayName("system not found")
+      .wasCreatedByDisplayName("system")
       .wasUpdatedBy("system")
-      .wasUpdatedByDisplayName("system not found")
+      .wasUpdatedByDisplayName("system")
       .wasScheduleCalculationRule(InductionScheduleCalculationRuleResponse.NEW_PRISON_ADMISSION)
       .wasStatus(InductionScheduleStatusResponse.SCHEDULED)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/ManageUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/ManageUserService.kt
@@ -12,5 +12,9 @@ class ManageUserService(
 ) {
   @Cacheable(USER_DETAILS)
   fun getUserDetails(username: String): UserDetailsDto =
-    manageUsersApiClient.getUserDetails(username)
+    if (username == "system") {
+      UserDetailsDto(username, true, username)
+    } else {
+      manageUsersApiClient.getUserDetails(username)
+    }
 }


### PR DESCRIPTION
instead of system not found since system doesn't have a user account. 