### PR TITLE
RR-227 - Remove reviewDate from Action Plan

### DIFF
--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/ActionPlan.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/ActionPlan.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.domain.personallearningplan
 
-import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -9,7 +8,6 @@ import java.util.UUID
 class ActionPlan(
   val reference: UUID,
   val prisonNumber: String,
-  val reviewDate: LocalDate?,
   goals: List<Goal> = emptyList(),
 ) {
 
@@ -34,6 +32,6 @@ class ActionPlan(
     goals.add(goal)
 
   override fun toString(): String {
-    return "ActionPlan(reference=$reference, prisonNumber='$prisonNumber', reviewDate='$reviewDate', goals=$goals)"
+    return "ActionPlan(reference=$reference, prisonNumber='$prisonNumber', goals=$goals)"
   }
 }

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/ActionPlanSummary.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/ActionPlanSummary.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.domain.personallearningplan
 
-import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -10,5 +9,4 @@ import java.util.UUID
 data class ActionPlanSummary(
   val reference: UUID,
   val prisonNumber: String,
-  val reviewDate: LocalDate?,
 )

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/CreateActionPlanDto.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/CreateActionPlanDto.kt
@@ -1,12 +1,9 @@
 package uk.gov.justice.digital.hmpps.domain.personallearningplan.dto
 
-import java.time.LocalDate
-
 /**
  * A DTO class that contains the data required to create a new Action Plan domain object
  */
 data class CreateActionPlanDto(
   val prisonNumber: String,
-  val reviewDate: LocalDate?,
   val goals: List<CreateGoalDto>,
 )

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/ActionPlanService.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/ActionPlanService.kt
@@ -52,7 +52,6 @@ class ActionPlanService(
       ?: ActionPlan(
         reference = UUID.randomUUID(),
         prisonNumber = prisonNumber,
-        reviewDate = null,
         goals = emptyList(),
       )
     actionPlan.goals.onEach { it.notes = goalNotesService.getNotes(it.reference) }

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalService.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalService.kt
@@ -234,7 +234,6 @@ class GoalService(
   private fun newActionPlan(prisonNumber: String, createGoalDtos: List<CreateGoalDto>) =
     CreateActionPlanDto(
       prisonNumber = prisonNumber,
-      reviewDate = null,
       goals = createGoalDtos,
     )
 }

--- a/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalServiceTest.kt
+++ b/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalServiceTest.kt
@@ -89,7 +89,7 @@ class GoalServiceTest {
       given(actionPlanPersistenceAdapter.createActionPlan(any())).willReturn(actionPlan)
       val createGoalDto = aValidCreateGoalDto()
       val expectedCreateActionPlanDto =
-        aValidCreateActionPlanDto(prisonNumber = prisonNumber, reviewDate = null, goals = listOf(createGoalDto))
+        aValidCreateActionPlanDto(prisonNumber = prisonNumber, goals = listOf(createGoalDto))
 
       // When
       val actual = service.createGoal(prisonNumber, createGoalDto)
@@ -147,7 +147,7 @@ class GoalServiceTest {
       val createGoalDtos = listOf(createGoalDto1, createGoalDto2)
 
       val expectedCreateActionPlanDto =
-        aValidCreateActionPlanDto(prisonNumber = prisonNumber, reviewDate = null, goals = createGoalDtos)
+        aValidCreateActionPlanDto(prisonNumber = prisonNumber, goals = createGoalDtos)
 
       // When
       val actual = service.createGoals(prisonNumber, createGoalDtos)

--- a/domain/personallearningplan/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/ActionPlanBuilder.kt
+++ b/domain/personallearningplan/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/ActionPlanBuilder.kt
@@ -1,17 +1,14 @@
 package uk.gov.justice.digital.hmpps.domain.personallearningplan
 
-import java.time.LocalDate
 import java.util.UUID
 
 fun aValidActionPlan(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<Goal> = mutableListOf(aValidGoal()),
 ): ActionPlan =
   ActionPlan(
     reference = reference,
     prisonNumber = prisonNumber,
-    reviewDate = reviewDate,
     goals = goals,
   )

--- a/domain/personallearningplan/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/ActionPlanSummaryBuilder.kt
+++ b/domain/personallearningplan/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/ActionPlanSummaryBuilder.kt
@@ -1,15 +1,12 @@
 package uk.gov.justice.digital.hmpps.domain.personallearningplan
 
-import java.time.LocalDate
 import java.util.UUID
 
 fun aValidActionPlanSummary(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
 ): ActionPlanSummary =
   ActionPlanSummary(
     reference = reference,
     prisonNumber = prisonNumber,
-    reviewDate = reviewDate,
   )

--- a/domain/personallearningplan/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/CreateActionPlanDtoBuilder.kt
+++ b/domain/personallearningplan/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/CreateActionPlanDtoBuilder.kt
@@ -1,14 +1,10 @@
 package uk.gov.justice.digital.hmpps.domain.personallearningplan.dto
 
-import java.time.LocalDate
-
 fun aValidCreateActionPlanDto(
   prisonNumber: String = "A1234BC",
-  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<CreateGoalDto> = mutableListOf(aValidCreateGoalDto()),
 ): CreateActionPlanDto =
   CreateActionPlanDto(
     prisonNumber = prisonNumber,
-    reviewDate = reviewDate,
     goals = goals,
   )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanSummariesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanSummariesTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actio
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
-import java.time.LocalDate
 
 class GetActionPlanSummariesTest : IntegrationTestBase() {
 
@@ -83,14 +82,13 @@ class GetActionPlanSummariesTest : IntegrationTestBase() {
     // Given
     val prisonNumber1 = aValidPrisonNumber()
     val prisonNumber2 = anotherValidPrisonNumber()
-    val reviewDate = LocalDate.now().plusMonths(6)
-    createActionPlan(prisonNumber1, aValidCreateActionPlanRequest(reviewDate = reviewDate))
-    createActionPlan(prisonNumber2, aValidCreateActionPlanRequest(reviewDate = null))
+    createActionPlan(prisonNumber1, aValidCreateActionPlanRequest())
+    createActionPlan(prisonNumber2, aValidCreateActionPlanRequest())
     val request = aValidGetActionPlanSummariesRequest(listOf(prisonNumber1, prisonNumber2))
     val expectedResponse = ActionPlanSummaryListResponse(
       actionPlanSummaries = listOf(
-        aValidActionPlanSummaryResponse(prisonNumber = prisonNumber1, reviewDate = reviewDate),
-        aValidActionPlanSummaryResponse(prisonNumber = prisonNumber2, reviewDate = null),
+        aValidActionPlanSummaryResponse(prisonNumber = prisonNumber1),
+        aValidActionPlanSummaryResponse(prisonNumber = prisonNumber2),
       ),
     )
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actio
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
-import java.time.LocalDate
 
 class GetActionPlanTest : IntegrationTestBase() {
 
@@ -81,7 +80,7 @@ class GetActionPlanTest : IntegrationTestBase() {
   fun `should get action plan for prisoner`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val createActionPlanRequest = aValidCreateActionPlanRequest(reviewDate = null)
+    val createActionPlanRequest = aValidCreateActionPlanRequest()
     createActionPlan(prisonNumber, createActionPlanRequest)
 
     // When
@@ -97,7 +96,6 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
-      .hasNoReviewDate()
       .goal(1) {
         it.wasCreatedAtPrison("BXI")
           .wasCreatedBy("auser_gen")
@@ -115,13 +113,11 @@ class GetActionPlanTest : IntegrationTestBase() {
     // Given
     val prisonNumber = aValidPrisonNumber()
     val createActionPlanRequest = aValidCreateActionPlanRequest(
-      reviewDate = LocalDate.now(),
       goals = listOf(aValidCreateGoalRequest(title = "Learn German")),
     )
     createActionPlan(prisonNumber, createActionPlanRequest)
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn French"))
     createGoal(prisonNumber, aValidCreateGoalRequest(title = "Learn Spanish"))
-    val expectedReviewDate = LocalDate.now()
 
     // When
     val response = webTestClient.get()
@@ -136,7 +132,6 @@ class GetActionPlanTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .isForPrisonNumber(prisonNumber)
-      .hasReviewDate(expectedReviewDate)
       .goal(1) {
         it.hasTitle("Learn Spanish")
       }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt
@@ -29,7 +29,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.asser
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
-import java.time.LocalDate
 
 class GetTimelineTest : IntegrationTestBase() {
 
@@ -120,7 +119,6 @@ class GetTimelineTest : IntegrationTestBase() {
       ),
     )
     val createActionPlanRequest = aValidCreateActionPlanRequest(
-      reviewDate = LocalDate.now(),
       goals = listOf(aValidCreateGoalRequest(title = "Learn German")),
     )
     createActionPlan(prisonNumber, createActionPlanRequest)
@@ -208,7 +206,6 @@ class GetTimelineTest : IntegrationTestBase() {
     )
     createInduction(prisonNumber, aValidCreateInductionRequest())
     val createActionPlanRequest = aValidCreateActionPlanRequest(
-      reviewDate = LocalDate.now(),
       goals = listOf(aValidCreateGoalRequest(title = "Learn German")),
     )
     createActionPlan(prisonNumber, createActionPlanRequest)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanEntity.kt
@@ -20,7 +20,6 @@ import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
-import java.time.LocalDate
 import java.util.UUID
 
 @Table(name = "action_plan")
@@ -39,9 +38,6 @@ class ActionPlanEntity(
   @Column(updatable = false)
   @field:NotNull
   var prisonNumber: String? = null,
-
-  @Column
-  var reviewDate: LocalDate? = null,
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "action_plan_id", nullable = false)
@@ -71,11 +67,10 @@ class ActionPlanEntity(
     /**
      * Returns new un-persisted [ActionPlanEntity] for the specified prisoner with an empty collection of [GoalEntity]s
      */
-    fun newActionPlanForPrisoner(prisonNumber: String, reviewDate: LocalDate?): ActionPlanEntity =
+    fun newActionPlanForPrisoner(prisonNumber: String): ActionPlanEntity =
       ActionPlanEntity(
         reference = UUID.randomUUID(),
         prisonNumber = prisonNumber,
-        reviewDate = reviewDate,
         goals = mutableListOf(),
       )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanSummaryProjection.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanSummaryProjection.kt
@@ -1,10 +1,8 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan
 
-import java.time.LocalDate
 import java.util.UUID
 
 data class ActionPlanSummaryProjection(
   val reference: UUID,
   val prisonNumber: String,
-  val reviewDate: LocalDate?,
 )

--- a/src/main/resources/db/migration/common/V2024.12.06.0001__drop_review_date_column_from_action_plan.sql
+++ b/src/main/resources/db/migration/common/V2024.12.06.0001__drop_review_date_column_from_action_plan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE action_plan DROP COLUMN review_date;

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.17.7'
+  version: '1.17.8'
   description: Education and Work Plan API
   contact:
     name: Learning and Work Progress team
@@ -836,11 +836,6 @@ components:
           type: string
           description: The ID of the prisoner
           example: 'A1234BC'
-        reviewDate:
-          type: string
-          format: date
-          description: An optional ISO-8601 date representing when the Action Plan is up for review.
-          example: '2024-12-19'
       required:
         - reference
         - prisonNumber
@@ -858,11 +853,6 @@ components:
           type: string
           description: The ID of the prisoner
           example: 'A1234BC'
-        reviewDate:
-          type: string
-          format: date
-          description: An optional ISO-8601 date representing when the Action Plan is up for review.
-          example: '2024-12-19'
         goals:
           type: array
           description: A List of at least one or more Goals.
@@ -1839,13 +1829,6 @@ components:
       description: A request to create an Action Plan with at least one or more Goals that a Prisoner aims to complete.
       allOf:
         - $ref: '#/components/schemas/CreateGoalsRequest'
-      properties:
-        reviewDate:
-          type: string
-          format: date
-          x-constraints: 'NotInPast'
-          description: An optional ISO-8601 date representing when the Action Plan is up for review.
-          example: '2023-12-19'
 
     CreateGoalRequest:
       title: CreateGoalRequest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanEntityTest.kt
@@ -13,10 +13,7 @@ class ActionPlanEntityTest {
     val prisonNumber = aValidPrisonNumber()
 
     // When
-    val actual = ActionPlanEntity.newActionPlanForPrisoner(
-      prisonNumber = prisonNumber,
-      reviewDate = null,
-    )
+    val actual = ActionPlanEntity.newActionPlanForPrisoner(prisonNumber = prisonNumber)
 
     // Then
     assertThat(actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/ActionPlanEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/actionplan/ActionPlanEntityMapperTest.kt
@@ -40,7 +40,6 @@ class ActionPlanEntityMapperTest {
     val expected = aValidActionPlanEntity(
       reference = actionPlan.reference,
       prisonNumber = prisonNumber,
-      reviewDate = actionPlan.reviewDate,
       goals = mutableListOf(expectedGoalEntity),
       // JPA managed fields - expect these all to be null, implying a new db entity
       id = null,
@@ -72,7 +71,6 @@ class ActionPlanEntityMapperTest {
     val expected = aValidActionPlan(
       reference = actionPlanEntity.reference!!,
       prisonNumber = prisonNumber,
-      reviewDate = actionPlanEntity.reviewDate,
       goals = mutableListOf(goalDomain),
     )
 
@@ -93,12 +91,10 @@ class ActionPlanEntityMapperTest {
       aValidActionPlanSummary(
         prisonNumber = summaryProjection1.prisonNumber,
         reference = summaryProjection1.reference,
-        reviewDate = summaryProjection1.reviewDate,
       ),
       aValidActionPlanSummary(
         prisonNumber = summaryProjection2.prisonNumber,
         reference = summaryProjection2.reference,
-        reviewDate = summaryProjection2.reviewDate,
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/ActionPlanResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/ActionPlanResourceMapperTest.kt
@@ -38,7 +38,6 @@ internal class ActionPlanResourceMapperTest {
     val expectedCreateGoalDto = aValidCreateGoalDto()
     val expectedCreateActionPlanDto = aValidCreateActionPlanDto(
       prisonNumber = prisonNumber,
-      reviewDate = request.reviewDate,
       goals = listOf(expectedCreateGoalDto),
     )
     given(goalMapper.fromModelToDto(any<CreateGoalRequest>())).willReturn(expectedCreateGoalDto)
@@ -59,7 +58,6 @@ internal class ActionPlanResourceMapperTest {
     val expectedActionPlan = aValidActionPlanResponse(
       reference = actionPlan.reference,
       prisonNumber = actionPlan.prisonNumber,
-      reviewDate = actionPlan.reviewDate,
       goals = mutableListOf(expectedGoal),
     )
     given(goalMapper.fromDomainToModel(any<Goal>())).willReturn(expectedGoal)
@@ -81,12 +79,10 @@ internal class ActionPlanResourceMapperTest {
       aValidActionPlanSummaryResponse(
         prisonNumber = summary1.prisonNumber,
         reference = summary1.reference,
-        reviewDate = summary1.reviewDate,
       ),
       aValidActionPlanSummaryResponse(
         prisonNumber = summary2.prisonNumber,
         reference = summary2.reference,
-        reviewDate = summary2.reviewDate,
       ),
     )
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanEntityAssert.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.en
 
 import org.assertj.core.api.AbstractObjectAssert
 import java.time.Instant
-import java.time.LocalDate
 import java.util.UUID
 import java.util.function.Consumer
 
@@ -89,26 +88,6 @@ class ActionPlanEntityAssert(actual: ActionPlanEntity?) :
     with(actual!!) {
       if (prisonNumber != expected) {
         failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
-      }
-    }
-    return this
-  }
-
-  fun hasReviewDate(expected: LocalDate): ActionPlanEntityAssert {
-    isNotNull
-    with(actual!!) {
-      if (reviewDate != expected) {
-        failWithMessage("Expected reviewDate to be $expected, but was $reviewDate")
-      }
-    }
-    return this
-  }
-
-  fun hasNoReviewDate(): ActionPlanEntityAssert {
-    isNotNull
-    with(actual!!) {
-      if (reviewDate != null) {
-        failWithMessage("Expected reviewDate to be null, but was $reviewDate")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanEntityBuilder.kt
@@ -1,19 +1,16 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan
 
-import java.time.LocalDate
 import java.util.UUID
 
 fun aValidActionPlanEntity(
   id: UUID? = UUID.randomUUID(),
   reference: UUID? = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<GoalEntity> = listOf(aValidGoalEntity()),
 ): ActionPlanEntity =
   ActionPlanEntity(
     id = id,
     reference = reference,
     prisonNumber = prisonNumber,
-    reviewDate = reviewDate,
     goals = goals.toMutableList(),
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanSummaryProjectionBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/ActionPlanSummaryProjectionBuilder.kt
@@ -1,15 +1,12 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.actionplan
 
-import java.time.LocalDate
 import java.util.UUID
 
 fun aValidActionPlanSummaryProjection(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
 ): ActionPlanSummaryProjection =
   ActionPlanSummaryProjection(
     reference = reference,
     prisonNumber = prisonNumber,
-    reviewDate = reviewDate,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/ActionPlanResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/ActionPlanResponseAssert.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.acti
 
 import org.assertj.core.api.AbstractObjectAssert
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
-import java.time.LocalDate
 import java.util.function.Consumer
 
 fun assertThat(actual: ActionPlanResponse?) = ActionPlanResponseAssert(actual)
@@ -18,26 +17,6 @@ class ActionPlanResponseAssert(actual: ActionPlanResponse?) :
     with(actual!!) {
       if (prisonNumber != expected) {
         failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
-      }
-    }
-    return this
-  }
-
-  fun hasReviewDate(expected: LocalDate): ActionPlanResponseAssert {
-    isNotNull
-    with(actual!!) {
-      if (reviewDate != expected) {
-        failWithMessage("Expected reviewDate to be $expected, but was $reviewDate")
-      }
-    }
-    return this
-  }
-
-  fun hasNoReviewDate(): ActionPlanResponseAssert {
-    isNotNull
-    with(actual!!) {
-      if (reviewDate != null) {
-        failWithMessage("Expected reviewDate to be null, but was $reviewDate")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/ActionPlanResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/ActionPlanResponseBuilder.kt
@@ -2,18 +2,15 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.acti
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalResponse
-import java.time.LocalDate
 import java.util.UUID
 
 fun aValidActionPlanResponse(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<GoalResponse> = listOf(aValidGoalResponse(), anotherValidGoalResponse()),
 ): ActionPlanResponse =
   ActionPlanResponse(
     reference = reference,
     prisonNumber = prisonNumber,
-    reviewDate = reviewDate,
     goals = goals,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/ActionPlanSummaryResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/ActionPlanSummaryResponseBuilder.kt
@@ -1,16 +1,13 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanSummaryResponse
-import java.time.LocalDate
 import java.util.UUID
 
 fun aValidActionPlanSummaryResponse(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
 ): ActionPlanSummaryResponse =
   ActionPlanSummaryResponse(
     reference = reference,
     prisonNumber = prisonNumber,
-    reviewDate = reviewDate,
   )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/CreateActionPlanRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/CreateActionPlanRequestBuilder.kt
@@ -2,13 +2,10 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.acti
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
-import java.time.LocalDate
 
 fun aValidCreateActionPlanRequest(
-  reviewDate: LocalDate? = LocalDate.now().plusMonths(6),
   goals: List<CreateGoalRequest> = listOf(aValidCreateGoalRequest()),
 ): CreateActionPlanRequest =
   CreateActionPlanRequest(
-    reviewDate = reviewDate,
     goals = goals,
   )


### PR DESCRIPTION
This PR removes the `review_date` field from the `action_plan` table, and all the way up the stack (DB entity, domain, and on to the REST API; and all associated mappers, test data builders, assertion classes etc)
It's a lot of change to remove one field! 🤣 

### Why are we doing this?
Very early in the PLP development, the business spoke about the concept of "action plans being reviewed" (where an action plan is a prisoner's Induction and Goals). They've always had the idea that Action Plans would be reviewed; but their initial thought process and designs were unrelated to the work we are now doing with Reviews, Curious/MN, and KPI2.
At the time they didn't have final or tested screen designs, and hadn't thought through the process about how a review date might get set, and how a review would take place. All they knew is that Action Plans would get reviewed, and therefore needed the concept of a review date.
Very early in the project we added the database column and associated code (db column was added 2023-08-15) .... and then at some point afterwards we realised it was wrong, and that the business had not worked out what "reviews" were or how they were to work. Hence the ticket RR-227 to remove it all. (you can tell how long ago this was based on the low ticket number! 🤣 )

Given that we now know what Reviews are and how they work, we are well underway with our development of it .... and the design and implementation of "Reviews" looks nothing like what we had originally intended. And in some ways the "reviewDate" field/properties/etc that are still hanging around are kinda getting in the way now....

### And why are we doing it now?
As mentioned, the "reviewDate" field/properties/etc is kinda getting in the way now .... Specifically we have another change that we need to do next (still part of RR-227) that is to make the UI use the `createActionPlan` API endpoint (at the moment it doesn't because we didnt know what we were doing with "reviewDate" - ie should the UI be providing it?), so instead the UI calls the `createGoal` endpoint which in turn creates the initial Action Plan if necessary without a review date. 
There are TODO's all over this code to correct it via RR-227; and we now need to do it because when the action plan is created we need to create the first Review Schedule. But we can't do that at the moment because the UI doesnt call `createActionPlan` (it calls `createGoals`), so it is hard (not impossible) for us to tell if this is the creation of an action plan or just some additional goals. It will be easier all round if the UI calls `createActionPlan` as it was always intended to!
