### PR TITLE
RR-227 - Address TODOs

### DIFF
--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/ActionPlan.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/ActionPlan.kt
@@ -18,10 +18,9 @@ class ActionPlan(
     get() = field.also { goals -> goals.sortByDescending { it.createdAt } }
 
   init {
-    // TODO - RR-227 enable once we are returning a 404, rather than a "dummy" Action Plan
-    // if (goals.isEmpty()) {
-    //  throw InvalidActionPlanException("Cannot create ActionPlan with reference [$reference]. At least one Goal is required.")
-    // }
+    if (goals.isEmpty()) {
+      throw InvalidActionPlanException("Cannot create ActionPlan with reference [$reference]. At least one Goal is required.")
+    }
     this.goals = goals.toMutableList()
   }
 

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/Exceptions.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/Exceptions.kt
@@ -9,14 +9,21 @@ import java.util.UUID
 class InvalidGoalException(message: String) : RuntimeException(message)
 
 /**
+ * Thrown when an Action Plan cannot be created, for example because it is missing mandatory data.
+ */
+class InvalidActionPlanException(message: String) : RuntimeException(message)
+
+/**
  * Thrown when an ActionPlan cannot be found.
  */
-class ActionPlanNotFoundException(message: String) : RuntimeException(message)
+class ActionPlanNotFoundException(prisonNumber: String) :
+  RuntimeException("ActionPlan for prisoner [$prisonNumber] not found")
 
 /**
  * Thrown when an Attempt is made to create an ActionPlan for a prisoner who already has one.
  */
-class ActionPlanAlreadyExistsException(message: String) : RuntimeException(message)
+class ActionPlanAlreadyExistsException(prisonNumber: String) :
+  RuntimeException("An Action Plan already exists for prisoner $prisonNumber.")
 
 /**
  * Thrown when a specified Goal cannot be found.

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/ActionPlanService.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/ActionPlanService.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.domain.personallearningplan.service
 import mu.KotlinLogging
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlan
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanAlreadyExistsException
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanSummary
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.CreateActionPlanDto
-import java.util.UUID
 
 private val log = KotlinLogging.logger {}
 
@@ -32,7 +32,7 @@ class ActionPlanService(
       log.info { "Creating ActionPlan for prisoner [$prisonNumber]" }
 
       if (persistenceAdapter.getActionPlan(prisonNumber) != null) {
-        throw ActionPlanAlreadyExistsException("An Action Plan already exists for prisoner $prisonNumber.")
+        throw ActionPlanAlreadyExistsException(prisonNumber)
       }
 
       return persistenceAdapter.createActionPlan(createActionPlanDto)
@@ -47,15 +47,11 @@ class ActionPlanService(
    */
   fun getActionPlan(prisonNumber: String): ActionPlan {
     log.debug { "Retrieving Action Plan for prisoner [$prisonNumber]" }
-    // TODO RR-227 - return 404 if not found
-    val actionPlan = persistenceAdapter.getActionPlan(prisonNumber)
-      ?: ActionPlan(
-        reference = UUID.randomUUID(),
-        prisonNumber = prisonNumber,
-        goals = emptyList(),
-      )
-    actionPlan.goals.onEach { it.notes = goalNotesService.getNotes(it.reference) }
-    return actionPlan
+    return persistenceAdapter.getActionPlan(prisonNumber)
+      ?.apply {
+        goals.onEach { it.notes = goalNotesService.getNotes(it.reference) }
+      }
+      ?: throw ActionPlanNotFoundException(prisonNumber)
   }
 
   fun getActionPlanSummaries(prisonNumbers: List<String>): List<ActionPlanSummary> {

--- a/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/ActionPlanServiceTest.kt
+++ b/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/ActionPlanServiceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.anotherValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanAlreadyExistsException
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanSummary
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidActionPlan
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidActionPlanSummary
@@ -104,11 +105,13 @@ class ActionPlanServiceTest {
       given(persistenceAdapter.getActionPlan(any())).willReturn(null)
 
       // When
-      val retrievedActionPlan = service.getActionPlan(prisonNumber)
+      val exception = catchThrowableOfType(ActionPlanNotFoundException::class.java) {
+        service.getActionPlan(prisonNumber)
+      }
 
       // Then
-      assertThat(retrievedActionPlan.prisonNumber).isEqualTo(prisonNumber)
-      assertThat(retrievedActionPlan.goals).isEmpty()
+      assertThat(exception)
+        .hasMessage("ActionPlan for prisoner [$prisonNumber] not found")
       verify(persistenceAdapter).getActionPlan(prisonNumber)
     }
   }

--- a/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalServiceTest.kt
+++ b/domain/personallearningplan/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/service/GoalServiceTest.kt
@@ -18,8 +18,10 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.aValidReference
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalNotFoundException
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.InvalidGoalStateException
@@ -30,7 +32,6 @@ import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidGoal
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.GetGoalsDto
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.ReasonToArchiveGoal
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.aValidArchiveGoalDto
-import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.aValidCreateActionPlanDto
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.aValidCreateGoalDto
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.aValidUnarchiveGoalDto
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.aValidUpdateGoalDto
@@ -48,9 +49,6 @@ class GoalServiceTest {
 
   @Mock
   private lateinit var actionPlanPersistenceAdapter: ActionPlanPersistenceAdapter
-
-  @Mock
-  private lateinit var actionPlanEventService: ActionPlanEventService
 
   @Mock
   private lateinit var goalNotesService: GoalNotesService
@@ -76,29 +74,25 @@ class GoalServiceTest {
       verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
       verify(goalPersistenceAdapter).createGoals(prisonNumber, listOf(createGoalDto))
       verify(goalEventService).goalsCreated(prisonNumber, createdGoals)
-      verifyNoInteractions(actionPlanEventService)
     }
 
     @Test
-    fun `should add goal to new action plan given prisoner does not have an action plan`() {
+    fun `should not add goal to action plan given prisoner does not have an action plan`() {
       // Given
       val prisonNumber = aValidPrisonNumber()
-      val goal = aValidGoal()
-      val actionPlan = aValidActionPlan(prisonNumber = prisonNumber, goals = listOf(goal))
       given(actionPlanPersistenceAdapter.getActionPlan(any())).willReturn(null)
-      given(actionPlanPersistenceAdapter.createActionPlan(any())).willReturn(actionPlan)
       val createGoalDto = aValidCreateGoalDto()
-      val expectedCreateActionPlanDto =
-        aValidCreateActionPlanDto(prisonNumber = prisonNumber, goals = listOf(createGoalDto))
 
       // When
-      val actual = service.createGoal(prisonNumber, createGoalDto)
+      val exception = catchThrowableOfType(ActionPlanNotFoundException::class.java) {
+        service.createGoal(prisonNumber, createGoalDto)
+      }
 
       // Then
-      assertThat(actual).isEqualTo(goal)
+      assertThat(exception)
+        .hasMessage("ActionPlan for prisoner [$prisonNumber] not found")
       verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
-      verify(actionPlanPersistenceAdapter).createActionPlan(expectedCreateActionPlanDto)
-      verify(actionPlanEventService).actionPlanCreated(actionPlan)
+      verifyNoMoreInteractions(actionPlanPersistenceAdapter)
       verifyNoInteractions(goalPersistenceAdapter)
       verifyNoInteractions(goalEventService)
     }
@@ -129,34 +123,28 @@ class GoalServiceTest {
       verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
       verify(goalPersistenceAdapter).createGoals(prisonNumber, createGoalDtos)
       verify(goalEventService).goalsCreated(prisonNumber, createdGoals)
-      verifyNoInteractions(actionPlanEventService)
     }
 
     @Test
     fun `should add goals to new action plan given prisoner does not have an action plan`() {
       // Given
       val prisonNumber = aValidPrisonNumber()
-      val goal1 = aValidGoal(title = "Goal 1")
-      val goal2 = aValidGoal(title = "Goal 2")
-      val actionPlan = aValidActionPlan(prisonNumber = prisonNumber, goals = listOf(goal1, goal2))
       given(actionPlanPersistenceAdapter.getActionPlan(any())).willReturn(null)
-      given(actionPlanPersistenceAdapter.createActionPlan(any())).willReturn(actionPlan)
 
       val createGoalDto1 = aValidCreateGoalDto(title = "Goal 1")
       val createGoalDto2 = aValidCreateGoalDto(title = "Goal 2")
       val createGoalDtos = listOf(createGoalDto1, createGoalDto2)
 
-      val expectedCreateActionPlanDto =
-        aValidCreateActionPlanDto(prisonNumber = prisonNumber, goals = createGoalDtos)
-
       // When
-      val actual = service.createGoals(prisonNumber, createGoalDtos)
+      val exception = catchThrowableOfType(ActionPlanNotFoundException::class.java) {
+        service.createGoals(prisonNumber, createGoalDtos)
+      }
 
       // Then
-      assertThat(actual).containsExactlyInAnyOrder(goal1, goal2)
+      assertThat(exception)
+        .hasMessage("ActionPlan for prisoner [$prisonNumber] not found")
       verify(actionPlanPersistenceAdapter).getActionPlan(prisonNumber)
-      verify(actionPlanPersistenceAdapter).createActionPlan(expectedCreateActionPlanDto)
-      verify(actionPlanEventService).actionPlanCreated(actionPlan)
+      verifyNoMoreInteractions(actionPlanPersistenceAdapter)
       verifyNoInteractions(goalPersistenceAdapter)
       verifyNoInteractions(goalEventService)
     }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -62,13 +62,11 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Archi
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateConversationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateEducationRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.conversation.aValidCreateConversationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.aValidCreateEducationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
@@ -235,11 +233,20 @@ abstract class IntegrationTestBase {
   fun createActionPlan(
     prisonNumber: String,
     createActionPlanRequest: CreateActionPlanRequest = aValidCreateActionPlanRequest(),
+    username: String = "auser_gen",
+    displayName: String = "Albert User",
   ) {
     webTestClient.post()
       .uri(CREATE_ACTION_PLAN_URI_TEMPLATE, prisonNumber)
       .withBody(createActionPlanRequest)
-      .bearerToken(aValidTokenWithAuthority(ACTIONPLANS_RW, privateKey = keyPair.private))
+      .bearerToken(
+        aValidTokenWithAuthority(
+          ACTIONPLANS_RW,
+          privateKey = keyPair.private,
+          username = username,
+          displayName = displayName,
+        ),
+      )
       .contentType(MediaType.APPLICATION_JSON)
       .exchange()
   }
@@ -300,25 +307,6 @@ abstract class IntegrationTestBase {
       .returnResult(InductionResponse::class.java)
       .responseBody.blockFirst()!!
 
-  fun createGoal(
-    prisonNumber: String,
-    createGoalRequest: CreateGoalRequest,
-    username: String = "auser_gen",
-    displayName: String = "Albert User",
-  ) {
-    val createGoalsRequest = aValidCreateGoalsRequest(goals = listOf(createGoalRequest))
-    webTestClient.post()
-      .uri("/action-plans/{prisonNumber}/goals", prisonNumber)
-      .withBody(createGoalsRequest)
-      .bearerToken(
-        aValidTokenWithAuthority(GOALS_RW, privateKey = keyPair.private),
-      )
-      .contentType(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus()
-      .isCreated()
-  }
-
   fun archiveGoal(
     prisonNumber: String,
     archiveGoalRequest: ArchiveGoalRequest,
@@ -329,7 +317,12 @@ abstract class IntegrationTestBase {
       .uri("/action-plans/{prisonNumber}/goals/{goalReference}/archive", prisonNumber, archiveGoalRequest.goalReference)
       .withBody(archiveGoalRequest)
       .bearerToken(
-        aValidTokenWithAuthority(GOALS_RW, privateKey = keyPair.private),
+        aValidTokenWithAuthority(
+          GOALS_RW,
+          privateKey = keyPair.private,
+          username = username,
+          displayName = displayName,
+        ),
       )
       .contentType(MediaType.APPLICATION_JSON)
       .exchange()
@@ -347,7 +340,12 @@ abstract class IntegrationTestBase {
       .uri("/conversations/{prisonNumber}", prisonNumber)
       .withBody(createConversationRequest)
       .bearerToken(
-        aValidTokenWithAuthority(CONVERSATIONS_RW, privateKey = keyPair.private),
+        aValidTokenWithAuthority(
+          CONVERSATIONS_RW,
+          privateKey = keyPair.private,
+          username = username,
+          displayName = displayName,
+        ),
       )
       .contentType(MediaType.APPLICATION_JSON)
       .exchange()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
@@ -24,13 +24,14 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalS
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonToArchiveGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidArchiveGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
-import java.util.*
+import java.util.UUID
 
 class ArchiveGoalTest : IntegrationTestBase() {
 
@@ -65,7 +66,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 204 and archive a goal and record the reason and other text `() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val reasonOther = "Because it's Monday"
     val archiveGoalRequest = aValidArchiveGoalRequest(
       goalReference = goalReference,
@@ -115,7 +116,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 204 and archive a goal and record the reason and other text and create an archive note`() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val reasonOther = "Because it's Monday"
     val noteText = "no longer relevant"
     val archiveGoalRequest = aValidArchiveGoalRequest(
@@ -189,7 +190,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 404 if the goal is for a different prisoner`() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val archiveGoalRequest = aValidArchiveGoalRequest(goalReference)
     val aDifferentPrisonNumber = "Z9876YX"
 
@@ -237,7 +238,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 400 if other reason without description`() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val archiveGoalRequest = aValidArchiveGoalRequest(
       goalReference = goalReference,
       reason = ReasonToArchiveGoal.OTHER,
@@ -260,7 +261,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 409 if goal is already archived`() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val archiveGoalRequest = aValidArchiveGoalRequest(goalReference = goalReference)
     archiveAGoal(prisonNumber, goalReference, archiveGoalRequest)
       .expectStatus()
@@ -297,23 +298,27 @@ class ArchiveGoalTest : IntegrationTestBase() {
     .contentType(APPLICATION_JSON)
     .exchange()
 
-  private fun createAGoalAndGetTheReference(prisonNumber: String): UUID {
-    val createGoalRequest = aValidCreateGoalRequest(
-      title = "Learn French",
-      steps = listOf(
-        aValidCreateStepRequest(
-          title = "Book course",
-        ),
-        aValidCreateStepRequest(
-          title = "Attend course",
+  private fun createAnActionPlanAndGetTheGoalReference(prisonNumber: String): UUID {
+    val createActionPlanRequest = aValidCreateActionPlanRequest(
+      goals = listOf(
+        aValidCreateGoalRequest(
+          title = "Learn French",
+          steps = listOf(
+            aValidCreateStepRequest(
+              title = "Book course",
+            ),
+            aValidCreateStepRequest(
+              title = "Attend course",
+            ),
+          ),
         ),
       ),
     )
-    createGoal(
+    createActionPlan(
       username = "auser_gen",
       displayName = "Albert User",
       prisonNumber = prisonNumber,
-      createGoalRequest = createGoalRequest,
+      createActionPlanRequest = createActionPlanRequest,
     )
     val actionPlan = getActionPlan(prisonNumber)
     val goal = actionPlan.goals[0]

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CompleteGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CompleteGoalTest.kt
@@ -25,13 +25,14 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalS
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidArchiveGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCompleteGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
-import java.util.*
+import java.util.UUID
 
 class CompleteGoalTest : IntegrationTestBase() {
 
@@ -66,7 +67,7 @@ class CompleteGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 204 and complete a goal`() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val completeGoalRequest = aValidCompleteGoalRequest(
       goalReference = goalReference,
     )
@@ -112,7 +113,7 @@ class CompleteGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 204 and complete a goal and create an completion note`() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val noteText = "Completed the goal! "
     val completeGoalRequest = aValidCompleteGoalRequest(
       goalReference = goalReference,
@@ -185,7 +186,7 @@ class CompleteGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 404 if the goal is for a different prisoner`() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val completeGoalRequest = aValidCompleteGoalRequest(goalReference)
     val aDifferentPrisonNumber = "Z9876YX"
 
@@ -233,7 +234,7 @@ class CompleteGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 409 if goal is already completed`() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val completeGoalRequest = aValidCompleteGoalRequest(goalReference = goalReference)
     completeAGoal(prisonNumber, goalReference, completeGoalRequest)
       .expectStatus()
@@ -270,23 +271,27 @@ class CompleteGoalTest : IntegrationTestBase() {
     .contentType(APPLICATION_JSON)
     .exchange()
 
-  private fun createAGoalAndGetTheReference(prisonNumber: String): UUID {
-    val createGoalRequest = aValidCreateGoalRequest(
-      title = "Learn French",
-      steps = listOf(
-        aValidCreateStepRequest(
-          title = "Book course",
-        ),
-        aValidCreateStepRequest(
-          title = "Attend course",
+  private fun createAnActionPlanAndGetTheGoalReference(prisonNumber: String): UUID {
+    val createActionPlanRequest = aValidCreateActionPlanRequest(
+      goals = listOf(
+        aValidCreateGoalRequest(
+          title = "Learn French",
+          steps = listOf(
+            aValidCreateStepRequest(
+              title = "Book course",
+            ),
+            aValidCreateStepRequest(
+              title = "Attend course",
+            ),
+          ),
         ),
       ),
     )
-    createGoal(
+    createActionPlan(
       username = "auser_gen",
       displayName = "Albert User",
       prisonNumber = prisonNumber,
-      createGoalRequest = createGoalRequest,
+      createActionPlanRequest = createActionPlanRequest,
     )
     val actionPlan = getActionPlan(prisonNumber)
     val goal = actionPlan.goals[0]

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
@@ -66,14 +67,14 @@ class GetActionPlanTest : IntegrationTestBase() {
       .bearerToken(aValidTokenWithAuthority(ACTIONPLANS_RW, privateKey = keyPair.private))
       .exchange()
       .expectStatus()
-      .isOk
-      .returnResult(ActionPlanResponse::class.java)
+      .isNotFound
+      .returnResult(ErrorResponse::class.java)
 
     // Then
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
-      .isForPrisonNumber(prisonNumber)
-      .hasNoGoalsSet()
+      .hasStatus(NOT_FOUND.value())
+      .hasUserMessage("ActionPlan for prisoner [$prisonNumber] not found")
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetGoalTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Error
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonToArchiveGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidArchiveGoalRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 
@@ -86,9 +86,9 @@ class GetGoalTest : IntegrationTestBase() {
   fun `should return not found given goal exists but for a different prisoner`() {
     // Given
     val someOtherPrisonNumber = anotherValidPrisonNumber()
-    createGoal(
+    createActionPlan(
       prisonNumber = someOtherPrisonNumber,
-      createGoalRequest = aValidCreateGoalRequest(),
+      createActionPlanRequest = aValidCreateActionPlanRequest(),
     )
     val actionPlan = getActionPlan(someOtherPrisonNumber)
     val goal = actionPlan.goals[0]
@@ -118,9 +118,9 @@ class GetGoalTest : IntegrationTestBase() {
   @Test
   fun `should return goal given prison number and goal reference`() {
     // Given
-    createGoal(
+    createActionPlan(
       prisonNumber = prisonNumber,
-      createGoalRequest = aValidCreateGoalRequest(),
+      createActionPlanRequest = aValidCreateActionPlanRequest(),
     )
     val actionPlan = getActionPlan(prisonNumber)
     val goal = actionPlan.goals[0]
@@ -151,9 +151,9 @@ class GetGoalTest : IntegrationTestBase() {
   @Test
   fun `should return goal given prison number with archive note`() {
     // Given a goal is created and archived.
-    createGoal(
+    createActionPlan(
       prisonNumber = prisonNumber,
-      createGoalRequest = aValidCreateGoalRequest(),
+      createActionPlanRequest = aValidCreateActionPlanRequest(),
     )
     val actionPlan = getActionPlan(prisonNumber)
     val goal = actionPlan.goals[0]

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetGoalsTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetGoalsTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GetGoalsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidArchiveGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateStepRequest
 
@@ -247,8 +248,8 @@ class GetGoalsTest : IntegrationTestBase() {
   }
 
   private fun anActionPlanExistsWithAnArchivedGoal(): ActionPlanResponse {
-    prisonerGoals.forEach { title ->
-      val createGoalRequest = aValidCreateGoalRequest(
+    val createGoalsRequests = prisonerGoals.map { title ->
+      aValidCreateGoalRequest(
         title = title,
         steps = listOf(
           aValidCreateStepRequest(
@@ -259,13 +260,15 @@ class GetGoalsTest : IntegrationTestBase() {
           ),
         ),
       )
-      createGoal(
-        username = "auser_gen",
-        displayName = "Albert User",
-        prisonNumber = prisonNumber,
-        createGoalRequest = createGoalRequest,
-      )
     }
+    createActionPlan(
+      username = "auser_gen",
+      displayName = "Albert User",
+      prisonNumber = prisonNumber,
+      createActionPlanRequest = aValidCreateActionPlanRequest(
+        goals = createGoalsRequests,
+      ),
+    )
     val actionPlan = getActionPlan(prisonNumber)
     val goalToArchive = actionPlan.goals.first { it.title == archivedGoal }
     archiveGoal(prisonNumber, aValidArchiveGoalRequest(goalToArchive.goalReference))

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Reaso
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UnarchiveGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidArchiveGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidUnarchiveGoalRequest
@@ -32,7 +33,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actio
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
-import java.util.*
+import java.util.UUID
 
 class UnarchiveGoalTest : IntegrationTestBase() {
 
@@ -73,7 +74,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 204 and unarchive a goal and reset the reason and other text `() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val reasonOther = "Because it's Monday"
     val archiveRequestWithOtherReason = aValidArchiveGoalRequest(
       goalReference = goalReference,
@@ -124,7 +125,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 204 and unarchive a goal and reset the reason and other text and archive note is deleted `() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val reasonOther = "Because it's Monday"
     val archiveNote = "an archive note"
     val archiveRequestWithOtherReason = aValidArchiveGoalRequest(
@@ -207,7 +208,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 404 if the goal is for a different prisoner`() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val unarchiveGoalRequest = aValidUnarchiveGoalRequest(goalReference)
     val aDifferentPrisonNumber = "Z9876YX"
 
@@ -260,7 +261,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 409 if goal is not archived`() {
     // given
-    val goalReference = createAGoalAndGetTheReference(prisonNumber)
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val archiveGoalRequest = aValidUnarchiveGoalRequest(goalReference)
 
     // when
@@ -314,23 +315,27 @@ class UnarchiveGoalTest : IntegrationTestBase() {
     .expectStatus()
     .isNoContent()
 
-  private fun createAGoalAndGetTheReference(prisonNumber: String): UUID {
-    val createGoalRequest = aValidCreateGoalRequest(
-      title = "Learn French",
-      steps = listOf(
-        aValidCreateStepRequest(
-          title = "Book course",
-        ),
-        aValidCreateStepRequest(
-          title = "Attend course",
+  private fun createAnActionPlanAndGetTheGoalReference(prisonNumber: String): UUID {
+    val createActionPlanRequest = aValidCreateActionPlanRequest(
+      goals = listOf(
+        aValidCreateGoalRequest(
+          title = "Learn French",
+          steps = listOf(
+            aValidCreateStepRequest(
+              title = "Book course",
+            ),
+            aValidCreateStepRequest(
+              title = "Attend course",
+            ),
+          ),
         ),
       ),
     )
-    createGoal(
+    createActionPlan(
       username = "auser_gen",
       displayName = "Albert User",
       prisonNumber = prisonNumber,
-      createGoalRequest = createGoalRequest,
+      createActionPlanRequest = createActionPlanRequest,
     )
     val actionPlan = getActionPlan(prisonNumber)
     val goal = actionPlan.goals[0]

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateStepRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidUpdateGoalRequest
@@ -195,22 +196,25 @@ class UpdateGoalTest : IntegrationTestBase() {
   fun `should update goal`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val createGoalRequest = aValidCreateGoalRequest(
-      title = "Learn French",
-      steps = listOf(
-        aValidCreateStepRequest(
-          title = "Book course",
-        ),
-        aValidCreateStepRequest(
-          title = "Attend course",
-        ),
-      ),
-    )
-    createGoal(
+    createActionPlan(
       username = "auser_gen",
       displayName = "Albert User",
       prisonNumber = prisonNumber,
-      createGoalRequest = createGoalRequest,
+      createActionPlanRequest = aValidCreateActionPlanRequest(
+        goals = listOf(
+          aValidCreateGoalRequest(
+            title = "Learn French",
+            steps = listOf(
+              aValidCreateStepRequest(
+                title = "Book course",
+              ),
+              aValidCreateStepRequest(
+                title = "Attend course",
+              ),
+            ),
+          ),
+        ),
+      ),
     )
 
     val actionPlan = getActionPlan(prisonNumber)
@@ -315,22 +319,25 @@ class UpdateGoalTest : IntegrationTestBase() {
   fun `should update goal and delete goal note`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val createGoalRequest = aValidCreateGoalRequest(
-      title = "Learn French",
-      steps = listOf(
-        aValidCreateStepRequest(
-          title = "Book course",
-        ),
-        aValidCreateStepRequest(
-          title = "Attend course",
-        ),
-      ),
-    )
-    createGoal(
+    createActionPlan(
       username = "auser_gen",
       displayName = "Albert User",
       prisonNumber = prisonNumber,
-      createGoalRequest = createGoalRequest,
+      createActionPlanRequest = aValidCreateActionPlanRequest(
+        goals = listOf(
+          aValidCreateGoalRequest(
+            title = "Learn French",
+            steps = listOf(
+              aValidCreateStepRequest(
+                title = "Book course",
+              ),
+              aValidCreateStepRequest(
+                title = "Attend course",
+              ),
+            ),
+          ),
+        ),
+      ),
     )
 
     val actionPlan = getActionPlan(prisonNumber)
@@ -435,16 +442,19 @@ class UpdateGoalTest : IntegrationTestBase() {
   fun `should update goal given the goal fields are unchanged and the only change is to add a step`() {
     // Given
     val prisonNumber = aValidPrisonNumber()
-    val createGoalRequest = aValidCreateGoalRequest(
-      steps = listOf(
-        aValidCreateStepRequest(title = "Book course"),
-      ),
-    )
-    createGoal(
+    createActionPlan(
       username = "auser_gen",
       displayName = "Albert User",
       prisonNumber = prisonNumber,
-      createGoalRequest = createGoalRequest,
+      createActionPlanRequest = aValidCreateActionPlanRequest(
+        goals = listOf(
+          aValidCreateGoalRequest(
+            steps = listOf(
+              aValidCreateStepRequest(title = "Book course"),
+            ),
+          ),
+        ),
+      ),
     )
 
     val actionPlan = getActionPlan(prisonNumber)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -50,14 +50,12 @@ class DomainConfiguration {
     goalPersistenceAdapter: GoalPersistenceAdapter,
     goalEventService: GoalEventService,
     actionPlanPersistenceAdapter: ActionPlanPersistenceAdapter,
-    actionPlanEventService: ActionPlanEventService,
     goalNotesService: GoalNotesService,
   ): GoalService =
     GoalService(
       goalPersistenceAdapter,
       goalEventService,
       actionPlanPersistenceAdapter,
-      actionPlanEventService,
       goalNotesService,
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
@@ -32,7 +32,7 @@ class JpaGoalPersistenceAdapter(
   @Transactional
   override fun createGoals(prisonNumber: String, createGoalDtos: List<CreateGoalDto>): List<Goal> {
     val actionPlanEntity = actionPlanRepository.findByPrisonNumber(prisonNumber)
-      ?: throw ActionPlanNotFoundException("Unable to find ActionPlan for prisoner [$prisonNumber]")
+      ?: throw ActionPlanNotFoundException(prisonNumber)
 
     val goalEntities = createGoalDtos.map { goalMapper.fromDtoToEntity(it) }
     with(actionPlanEntity) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionNotFoundException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionService
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.service.ActionPlanService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.GoalResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.InductionResourceMapper
@@ -27,9 +28,13 @@ class SubjectAccessRequestService(
     val fromDateInstance = fromDate?.atStartOfDay()?.toInstant(ZoneOffset.UTC)
     val toDateInstance = toDate?.atStartOfDay()?.toInstant(ZoneOffset.UTC)
 
-    val goals = actionPlanService.getActionPlan(prisonNumber).goals
-      .filter { fromDateInstance == null || it.createdAt?.isAfter(fromDateInstance) ?: true }
-      .filter { toDateInstance == null || it.createdAt?.isBefore(toDateInstance) ?: true }
+    val goals = try {
+      actionPlanService.getActionPlan(prisonNumber).goals
+        .filter { fromDateInstance == null || it.createdAt?.isAfter(fromDateInstance) ?: true }
+        .filter { toDateInstance == null || it.createdAt?.isBefore(toDateInstance) ?: true }
+    } catch (e: ActionPlanNotFoundException) {
+      emptyList()
+    }
 
     val induction = try {
       inductionService.getInductionForPrisoner(prisonNumber)

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.17.9'
+  version: '1.18.0'
   description: Education and Work Plan API
   contact:
     name: Learning and Work Progress team
@@ -154,8 +154,9 @@ paths:
     get:
       summary: Return a Prisoner's Action Plan
       description: | 
-        Return a Prisoner's Action Plan with the goals ordered in chronological order (oldest first). If the prisoner does not yet have any goals set, then an Action Plan with no goals (empty array) is returned.
-        **Role Requirements:**
+        Return a Prisoner's Action Plan with the goals ordered in chronological order (oldest first). If the prisoner does not yet have any goals set, a 404 is returned.
+
+        **Role Requirements:**  
         Access to this endpoint requires one of the following roles:
           - `ROLE_EDUCATION_AND_WORK_PLAN__ACTIONPLANS__RO` (Read-Only)
           - `ROLE_EDUCATION_AND_WORK_PLAN__ACTIONPLANS__RW` (Read-Write)
@@ -164,6 +165,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ActionPlan'
+        '404':
+          $ref: '#/components/responses/404ErrorResponse'
       operationId: get-action-plan-by-prison-number
 
   #
@@ -301,7 +304,7 @@ paths:
     post:
       summary: Creates one or more Goals.
       description: |
-        Creates one or more Goals and saves them to the Prisoner's Action Plan (the latter will be created if it doesn't already exist).
+        Creates one or more Goals and saves them to the Prisoner's Action Plan. Returns a 404 if the Prisoner does not have an Action Plan.
         
         **Role Requirements:**
         Access to this endpoint requires one of the following roles:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
@@ -65,7 +65,7 @@ class JpaGoalPersistenceAdapterTest {
       }
 
       // Then
-      assertThat(exception).hasMessage("Unable to find ActionPlan for prisoner [$prisonNumber]")
+      assertThat(exception).hasMessage("ActionPlan for prisoner [$prisonNumber] not found")
       verifyNoInteractions(goalMapper)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestServiceTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.Induction
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aFullyPopulatedInduction
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionService
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.Goal
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidActionPlan
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidGoal
@@ -221,8 +222,7 @@ class SubjectAccessRequestServiceTest {
     // Given
     val prisonNumber = aValidPrisonNumber()
     given(inductionService.getInductionForPrisoner(prisonNumber)).willReturn(null)
-    val emptyActionPlan = aValidActionPlan(prisonNumber = prisonNumber, goals = emptyList())
-    given(actionPlanService.getActionPlan(prisonNumber)).willReturn(emptyActionPlan)
+    given(actionPlanService.getActionPlan(prisonNumber)).willThrow(ActionPlanNotFoundException(prisonNumber))
 
     // When
     val sarResponse = subjectAccessRequestService.getPrisonContentFor(prisonNumber, null, null)


### PR DESCRIPTION
This PR completes RR-227 by addressing the TODO now that the UI has been changed to call the `createActionPlan` API endpoint.

Basically there were 3 TODO's to address:
1. Enable the code to throw an exception when a Action Plan is created with no goals
2. Throw an exception (which results in a 404) when attempting to get an Action Plan that does not exist (previously it returned a "dummy" Action Plan with no goals
3. Throw an exception (which results in a 404) when attempted to create goals but for an Action Plan that does not exist (previously it created an Action Plan)

Pretty much all of the other changes in this PR are changes to the tests to reflect the new behaviour.

