### PR TITLE
store history for review schedule changes

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.rep
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.NoteRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.PreviousQualificationsRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ReviewRepository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ReviewScheduleHistoryRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ReviewScheduleRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.TimelineRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventPublisher.HmppsDomainEvent
@@ -150,6 +151,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var reviewScheduleRepository: ReviewScheduleRepository
+
+  @Autowired
+  lateinit var reviewScheduleHistoryRepository: ReviewScheduleHistoryRepository
 
   @SpyBean
   lateinit var telemetryClient: TelemetryClient

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusHistoryTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusHistoryTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType.APPLICATION_JSON
+import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.aValidUpdateActionPlanReviewStatusRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
+import java.time.LocalDate
+
+class UpdateActionPlanReviewStatusHistoryTest : IntegrationTestBase() {
+  companion object {
+    private const val URI_TEMPLATE = "/action-plans/{prisonNumber}/reviews/schedule-status"
+  }
+
+  private val prisonNumber = aValidPrisonNumber()
+
+  @Test
+  fun `Test that review schedule history records are written when a schedule is exempted`() {
+    // Given
+    createReviewScheduleRecord(
+      prisonNumber,
+      status = ReviewScheduleStatus.SCHEDULED.name,
+      earliestDate = LocalDate.now().minusDays(5),
+      latestDate = LocalDate.now(),
+    )
+
+    // When
+    webTestClient.put()
+      .uri(URI_TEMPLATE, prisonNumber)
+      .withBody(
+        aValidUpdateActionPlanReviewStatusRequest(
+          prisonId = "MDI",
+          status = ReviewScheduleStatus.EXEMPT_SYSTEM_TECHNICAL_ISSUE,
+        ),
+      )
+      .bearerToken(aValidTokenWithAuthority(REVIEWS_RW, username = "auser_gen", privateKey = keyPair.private))
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    // Then
+    val reviewSchedule = reviewScheduleRepository.getAllByPrisonNumber(prisonNumber)
+    val histories = reviewScheduleHistoryRepository.findAllByReference(reviewSchedule[0].reference)
+    assertThat(histories.size).isEqualTo(2)
+    assertThat(histories[0].scheduleStatus).isEqualTo(uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleStatus.EXEMPT_SYSTEM_TECHNICAL_ISSUE)
+    assertThat(histories[1].scheduleStatus).isEqualTo(uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleStatus.SCHEDULED)
+  }
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusTest.kt
@@ -410,9 +410,9 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     }
 
     // test that outbound event is also created:
-    val reviewScheduleEvent = reviewScheduleEventQueue.receiveEvent(QueueType.REVIEW)
-    assertThat(reviewScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
-    assertThat(reviewScheduleEvent.detailUrl)
+    val reviewScheduleEvents = reviewScheduleEventQueue.receiveEventsOnQueue(QueueType.REVIEW)
+    assertThat(reviewScheduleEvents[0].personReference.identifiers[0].value).isEqualTo(prisonNumber)
+    assertThat(reviewScheduleEvents[0].detailUrl)
       .isEqualTo("http://localhost:8080/reviews/$prisonNumber/review-schedule")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapter.kt
@@ -11,7 +11,10 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.Cr
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.UpdateReviewScheduleDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.UpdateReviewScheduleStatusDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewSchedulePersistenceAdapter
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleHistoryEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.review.ReviewScheduleEntityMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ReviewScheduleHistoryRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ReviewScheduleRepository
 
 private val log = KotlinLogging.logger {}
@@ -19,6 +22,7 @@ private val log = KotlinLogging.logger {}
 @Component
 class JpaReviewSchedulePersistenceAdapter(
   private val reviewScheduleRepository: ReviewScheduleRepository,
+  private val reviewScheduleHistoryRepository: ReviewScheduleHistoryRepository,
   private val reviewScheduleEntityMapper: ReviewScheduleEntityMapper,
 ) : ReviewSchedulePersistenceAdapter {
 
@@ -28,10 +32,10 @@ class JpaReviewSchedulePersistenceAdapter(
       if (getActiveReviewSchedule(prisonNumber) != null) {
         throw ActiveReviewScheduleAlreadyExistsException(prisonNumber)
       }
-
       val persistedEntity = reviewScheduleRepository.saveAndFlush(
         reviewScheduleEntityMapper.fromDomainToEntity(this),
       )
+      saveReviewScheduleHistory(persistedEntity)
       reviewScheduleEntityMapper.fromEntityToDomain(persistedEntity)
     }
 
@@ -41,7 +45,9 @@ class JpaReviewSchedulePersistenceAdapter(
 
     return reviewScheduleEntity?.let {
       reviewScheduleEntityMapper.updateExistingEntityFromDto(it, updateReviewScheduleDto)
-      reviewScheduleEntityMapper.fromEntityToDomain(reviewScheduleRepository.saveAndFlush(it))
+      val saved = reviewScheduleRepository.saveAndFlush(it)
+      saveReviewScheduleHistory(saved)
+      reviewScheduleEntityMapper.fromEntityToDomain(saved)
     }
   }
 
@@ -71,6 +77,30 @@ class JpaReviewSchedulePersistenceAdapter(
       updatedAtPrison = updateReviewScheduleStatusDto.prisonId
     }
 
-    return reviewScheduleEntityMapper.fromEntityToDomain(reviewScheduleRepository.save(reviewScheduleEntity))
+    val savedReviewScheduleEntity = reviewScheduleRepository.save(reviewScheduleEntity)
+    saveReviewScheduleHistory(savedReviewScheduleEntity)
+    return reviewScheduleEntityMapper.fromEntityToDomain(savedReviewScheduleEntity)
+  }
+
+  fun saveReviewScheduleHistory(reviewScheduleEntity: ReviewScheduleEntity) {
+    with(reviewScheduleEntity) {
+      val historyEntry = ReviewScheduleHistoryEntity(
+        version = reviewScheduleHistoryRepository.findMaxVersionByReviewScheduleReference(reference)
+          ?.plus(1) ?: 1,
+        reference = reference,
+        prisonNumber = prisonNumber,
+        createdAtPrison = createdAtPrison,
+        updatedAtPrison = updatedAtPrison,
+        updatedAt = updatedAt,
+        createdAt = createdAt,
+        updatedBy = updatedBy,
+        createdBy = createdBy,
+        scheduleStatus = scheduleStatus,
+        earliestReviewDate = earliestReviewDate,
+        latestReviewDate = latestReviewDate,
+        scheduleCalculationRule = scheduleCalculationRule,
+      )
+      reviewScheduleHistoryRepository.save(historyEntry)
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapter.kt
@@ -82,7 +82,7 @@ class JpaReviewSchedulePersistenceAdapter(
     return reviewScheduleEntityMapper.fromEntityToDomain(savedReviewScheduleEntity)
   }
 
-  fun saveReviewScheduleHistory(reviewScheduleEntity: ReviewScheduleEntity) {
+  private fun saveReviewScheduleHistory(reviewScheduleEntity: ReviewScheduleEntity) {
     with(reviewScheduleEntity) {
       val historyEntry = ReviewScheduleHistoryEntity(
         version = reviewScheduleHistoryRepository.findMaxVersionByReviewScheduleReference(reference)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/review/ReviewScheduleHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/review/ReviewScheduleHistoryEntity.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.UuidGenerator
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+@Table(name = "review_schedule_history")
+@Entity
+data class ReviewScheduleHistoryEntity(
+
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null,
+
+  val version: Int,
+
+  @Column(updatable = false)
+  val reference: UUID,
+
+  @Column(updatable = false)
+  val prisonNumber: String,
+
+  @Column
+  var earliestReviewDate: LocalDate,
+
+  @Column
+  var latestReviewDate: LocalDate,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  var scheduleCalculationRule: ReviewScheduleCalculationRule,
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  var scheduleStatus: ReviewScheduleStatus,
+
+  @Column(updatable = false)
+  val createdAtPrison: String,
+
+  @Column
+  var updatedAtPrison: String,
+
+  @Column(updatable = false)
+  var createdBy: String? = null,
+
+  @Column(updatable = false)
+  var createdAt: Instant? = null,
+
+  @Column
+  var updatedBy: String? = null,
+
+  @Column
+  var updatedAt: Instant? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/ReviewScheduleHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/ReviewScheduleHistoryRepository.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleHistoryEntity
+import java.util.UUID
+
+@Repository
+interface ReviewScheduleHistoryRepository : JpaRepository<ReviewScheduleHistoryEntity, Long> {
+  @Query("SELECT MAX(h.version) FROM ReviewScheduleHistoryEntity h WHERE h.reference = :reviewScheduleReference")
+  fun findMaxVersionByReviewScheduleReference(reviewScheduleReference: UUID): Int?
+
+  fun findAllByReference(reviewScheduleReference: UUID): List<ReviewScheduleHistoryEntity>
+}

--- a/src/main/resources/db/migration/common/V2024.12.10.0001__add_review_schedule_history_table.sql
+++ b/src/main/resources/db/migration/common/V2024.12.10.0001__add_review_schedule_history_table.sql
@@ -1,0 +1,23 @@
+--- Add the table review schedule history
+
+--- review_schedule table
+CREATE TABLE review_schedule_history
+(
+    id                         UUID PRIMARY KEY,
+    reference                  UUID                        NOT NULL,
+    version                    INT                         NOT NULL,
+    prison_number              VARCHAR(10)                 NOT NULL,
+    earliest_review_date       DATE                        NOT NULL,
+    latest_review_date         DATE                        NOT NULL,
+    schedule_calculation_rule  VARCHAR(50)                 NOT NULL,
+    schedule_status            VARCHAR(50)                 NOT NULL,
+    created_at                 TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    created_by                 VARCHAR(50)                 NOT NULL,
+    created_at_prison          VARCHAR(3)                  NOT NULL,
+    updated_at                 TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    updated_by                 VARCHAR(50)                 NOT NULL,
+    updated_at_prison          VARCHAR(3)                  NOT NULL
+);
+
+CREATE INDEX idx_review_schedule_history_prison_number
+    ON review_schedule_history (prison_number);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaReviewSchedulePersistenceAdapterTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.aV
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.aValidReviewScheduleEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.review.ReviewScheduleEntityMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ReviewScheduleHistoryRepository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.ReviewScheduleRepository
 import java.time.Instant
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus as ReviewScheduleStatusDomain
@@ -36,6 +37,9 @@ class JpaReviewSchedulePersistenceAdapterTest {
 
   @Mock
   private lateinit var reviewScheduleRepository: ReviewScheduleRepository
+
+  @Mock
+  private lateinit var reviewScheduleHistoryRepository: ReviewScheduleHistoryRepository
 
   @Mock
   private lateinit var reviewScheduleEntityMapper: ReviewScheduleEntityMapper
@@ -170,10 +174,12 @@ class JpaReviewSchedulePersistenceAdapterTest {
 
       // Then
       assertThat(actual).isEqualTo(expectedReviewSchedule)
+      verify(reviewScheduleHistoryRepository).findMaxVersionByReviewScheduleReference(reviewScheduleEntity.reference)
       verify(reviewScheduleRepository).findActiveReviewSchedule(prisonNumber)
       verify(reviewScheduleEntityMapper).fromDomainToEntity(createReviewScheduleDto)
       verify(reviewScheduleRepository).saveAndFlush(reviewScheduleEntity)
       verify(reviewScheduleEntityMapper).fromEntityToDomain(reviewScheduleEntity)
+      verify(reviewScheduleHistoryRepository).save(any())
     }
   }
 
@@ -205,6 +211,7 @@ class JpaReviewSchedulePersistenceAdapterTest {
     verify(reviewScheduleRepository).findActiveReviewSchedule(prisonNumber)
     verify(reviewScheduleEntityMapper).fromEntityToDomain(reviewScheduleEntity)
     verifyNoMoreInteractions(reviewScheduleRepository)
+    verifyNoInteractions(reviewScheduleHistoryRepository)
   }
 
   @Nested
@@ -236,6 +243,7 @@ class JpaReviewSchedulePersistenceAdapterTest {
       verify(reviewScheduleEntityMapper).updateExistingEntityFromDto(reviewScheduleEntity, updateReviewScheduleDto)
       verify(reviewScheduleRepository).saveAndFlush(reviewScheduleEntity)
       verify(reviewScheduleEntityMapper).fromEntityToDomain(reviewScheduleEntity)
+      verify(reviewScheduleHistoryRepository).save(any())
     }
 
     @Test
@@ -257,6 +265,7 @@ class JpaReviewSchedulePersistenceAdapterTest {
       verify(reviewScheduleRepository).findByReference(reference)
       verifyNoMoreInteractions(reviewScheduleRepository)
       verifyNoInteractions(reviewScheduleEntityMapper)
+      verifyNoInteractions(reviewScheduleHistoryRepository)
     }
   }
 }


### PR DESCRIPTION
Pretty straightforward method of storing history for review schedule entities. 

Whenever we call save just call the saveReviewScheduleHistory method after and the history will be recorded, subsequent saves will increment the version number on the history entity. 

I did attempt to do this with a Jpa listener but burned too much time on it and I think may have been [impossible](https://stackoverflow.com/questions/71348249/spring-jpa-calling-repository-method-inside-entitys-life-cycle-method) 