### PR TITLE
RR-1049 - Renamed CreateReviewScheduleStatusRequest to UpdateReviewScheduleStatusRequest

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusHistoryTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusHistoryTest.kt
@@ -8,9 +8,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAutho
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleStatus
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.aValidUpdateActionPlanReviewStatusRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.aValidUpdateReviewScheduleStatusRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 import java.time.LocalDate
 
@@ -35,7 +33,7 @@ class UpdateActionPlanReviewStatusHistoryTest : IntegrationTestBase() {
     webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .withBody(
-        aValidUpdateActionPlanReviewStatusRequest(
+        aValidUpdateReviewScheduleStatusRequest(
           prisonId = "MDI",
           status = ReviewScheduleStatus.EXEMPT_SYSTEM_TECHNICAL_ISSUE,
         ),

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Revie
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.aValidCreateActionPlanReviewRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.aValidUpdateActionPlanReviewStatusRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.aValidUpdateReviewScheduleStatusRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
 import java.time.LocalDate
@@ -52,7 +52,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     val response = webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .contentType(APPLICATION_JSON)
-      .withBody(aValidUpdateActionPlanReviewStatusRequest())
+      .withBody(aValidUpdateReviewScheduleStatusRequest())
       .bearerToken(aValidTokenWithAuthority(REVIEWS_RO, privateKey = keyPair.private))
       .exchange()
       .expectStatus()
@@ -102,7 +102,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     // When
     val response = webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
-      .withBody(aValidUpdateActionPlanReviewStatusRequest())
+      .withBody(aValidUpdateReviewScheduleStatusRequest())
       .bearerToken(aValidTokenWithAuthority(REVIEWS_RW, privateKey = keyPair.private))
       .contentType(APPLICATION_JSON)
       .exchange()
@@ -126,7 +126,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .withBody(
-        aValidUpdateActionPlanReviewStatusRequest(
+        aValidUpdateReviewScheduleStatusRequest(
           prisonId = "MDI",
           status = ReviewScheduleStatus.EXEMPT_PRISONER_DRUG_OR_ALCOHOL_DEPENDENCY,
         ),
@@ -155,7 +155,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .withBody(
-        aValidUpdateActionPlanReviewStatusRequest(
+        aValidUpdateReviewScheduleStatusRequest(
           prisonId = "MDI",
           status = ReviewScheduleStatus.SCHEDULED,
         ),
@@ -184,7 +184,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     val response = webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .withBody(
-        aValidUpdateActionPlanReviewStatusRequest(
+        aValidUpdateReviewScheduleStatusRequest(
           prisonId = "MDI",
           status = ReviewScheduleStatus.EXEMPT_PRISONER_FAILED_TO_ENGAGE,
         ),
@@ -214,7 +214,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     val response = webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .withBody(
-        aValidUpdateActionPlanReviewStatusRequest(
+        aValidUpdateReviewScheduleStatusRequest(
           prisonId = "MDI",
           status = ReviewScheduleStatus.COMPLETED,
         ),
@@ -241,7 +241,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .withBody(
-        aValidUpdateActionPlanReviewStatusRequest(
+        aValidUpdateReviewScheduleStatusRequest(
           prisonId = "MDI",
           status = ReviewScheduleStatus.EXEMPT_SYSTEM_TECHNICAL_ISSUE,
         ),
@@ -272,7 +272,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .withBody(
-        aValidUpdateActionPlanReviewStatusRequest(
+        aValidUpdateReviewScheduleStatusRequest(
           prisonId = "MDI",
           status = ReviewScheduleStatus.EXEMPT_SYSTEM_TECHNICAL_ISSUE,
         ),
@@ -304,7 +304,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .withBody(
-        aValidUpdateActionPlanReviewStatusRequest(
+        aValidUpdateReviewScheduleStatusRequest(
           prisonId = "MDI",
           status = ReviewScheduleStatus.SCHEDULED,
         ),
@@ -336,7 +336,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .withBody(
-        aValidUpdateActionPlanReviewStatusRequest(
+        aValidUpdateReviewScheduleStatusRequest(
           prisonId = "MDI",
           status = ReviewScheduleStatus.SCHEDULED,
         ),
@@ -368,7 +368,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber)
       .withBody(
-        aValidUpdateActionPlanReviewStatusRequest(
+        aValidUpdateReviewScheduleStatusRequest(
           prisonId = "MDI",
           status = ReviewScheduleStatus.SCHEDULED,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ReviewController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ReviewController.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.Prisoner
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanReviewsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanReviewRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanReviewResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateReviewScheduleStatusRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateReviewScheduleStatusRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleStatus as ReviewScheduleStatusAPI
 
 @RestController
@@ -87,13 +87,13 @@ class ReviewController(
   @Transactional
   fun updateLatestReviewScheduleStatus(
     @Valid
-    @RequestBody createReviewScheduleStatusRequest: CreateReviewScheduleStatusRequest,
+    @RequestBody updateReviewScheduleStatusRequest: UpdateReviewScheduleStatusRequest,
     @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
   ) {
     reviewScheduleService.updateLatestReviewScheduleStatus(
       prisonNumber,
-      createReviewScheduleStatusRequest.prisonId,
-      toReviewScheduleStatus(createReviewScheduleStatusRequest.status),
+      updateReviewScheduleStatusRequest.prisonId,
+      toReviewScheduleStatus(updateReviewScheduleStatusRequest.status),
     )
   }
 

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.19.0'
+  version: '1.19.1'
   description: Education and Work Plan API
   contact:
     name: Learning and Work Progress team
@@ -251,9 +251,9 @@ paths:
           description: Invalid review schedule status change.
         '404':
           $ref: '#/components/responses/404ErrorResponse'
-      operationId: review-schedule-status
+      operationId: update-review-schedule-status
       requestBody:
-        $ref: '#/components/requestBodies/ReviewScheduleStatus'
+        $ref: '#/components/requestBodies/UpdateReviewScheduleStatus'
 
   #
   # Action Plan Review schedules
@@ -2898,8 +2898,8 @@ components:
         - conductedAt
 
     ### Action Plan Review Exemption ###
-    CreateReviewScheduleStatusRequest:
-      title: CreateReviewScheduleStatusRequest
+    UpdateReviewScheduleStatusRequest:
+      title: UpdateReviewScheduleStatusRequest
       description: A request to update the status of the current review schedule for example to set an exemption.
       type: object
       properties:
@@ -3537,12 +3537,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CreateActionPlanReviewRequest'
-    ReviewScheduleStatus:
+    UpdateReviewScheduleStatus:
       description: Request body to update a review schedule status.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CreateReviewScheduleStatusRequest'
+            $ref: '#/components/schemas/UpdateReviewScheduleStatusRequest'
   parameters:
     prisonNumberPathParameter:
       name: prisonNumber

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/review/UpdateReviewScheduleStatusRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/review/UpdateReviewScheduleStatusRequestBuilder.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review
 
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateReviewScheduleStatusRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateReviewScheduleStatusRequest
 
-fun aValidUpdateActionPlanReviewStatusRequest(
+fun aValidUpdateReviewScheduleStatusRequest(
   prisonId: String = "BXI",
   status: ReviewScheduleStatus = ReviewScheduleStatus.EXEMPT_PRISONER_DRUG_OR_ALCOHOL_DEPENDENCY,
-): CreateReviewScheduleStatusRequest =
-  CreateReviewScheduleStatusRequest(
+): UpdateReviewScheduleStatusRequest =
+  UpdateReviewScheduleStatusRequest(
     prisonId = prisonId,
     status = status,
   )


### PR DESCRIPTION
Renamed `CreateReviewScheduleStatusRequest` to `UpdateReviewScheduleStatusRequest` to better align it to it's use case / controller method
IE. its the request body to Update the Review Schedule Status, not to create it 