### PR TITLE
RR-1170 - Map notes into GoalResponses

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -61,6 +61,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanReviewsResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ArchiveGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CompleteGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateConversationRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CreateEducationRequest
@@ -325,6 +326,29 @@ abstract class IntegrationTestBase {
     webTestClient.put()
       .uri("/action-plans/{prisonNumber}/goals/{goalReference}/archive", prisonNumber, archiveGoalRequest.goalReference)
       .withBody(archiveGoalRequest)
+      .bearerToken(
+        aValidTokenWithAuthority(
+          GOALS_RW,
+          privateKey = keyPair.private,
+          username = username,
+          displayName = displayName,
+        ),
+      )
+      .contentType(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isNoContent
+  }
+
+  fun completeGoal(
+    prisonNumber: String,
+    completeGoalRequest: CompleteGoalRequest,
+    username: String = "auser_gen",
+    displayName: String = "Albert User",
+  ) {
+    webTestClient.put()
+      .uri("/action-plans/{prisonNumber}/goals/{goalReference}/complete", prisonNumber, completeGoalRequest.goalReference)
+      .withBody(completeGoalRequest)
       .bearerToken(
         aValidTokenWithAuthority(
           GOALS_RW,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetGoalsTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetGoalsTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
 import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
@@ -8,12 +9,13 @@ import uk.gov.justice.digital.hmpps.domain.aValidReference
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ActionPlanResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GetGoalsResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidArchiveGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCompleteGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalRequest
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateStepRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.assertThat
 
 class GetGoalsTest : IntegrationTestBase() {
 
@@ -22,13 +24,27 @@ class GetGoalsTest : IntegrationTestBase() {
   }
 
   private val prisonNumber = aValidPrisonNumber()
-  private val archivedGoal = "Learn French"
-  private val prisonerGoals = listOf(archivedGoal, "Pass Health and Safety City & Guilds", "Get a black belt")
+
+  @BeforeEach
+  fun createPrisonerActionPlanAndGoals() {
+    createActionPlan(
+      prisonNumber = prisonNumber,
+      createActionPlanRequest = aValidCreateActionPlanRequest(
+        goals = listOf(
+          aValidCreateGoalRequest(title = "Goal 1", notes = null),
+          aValidCreateGoalRequest(title = "Goal 2", notes = "Only goal 2 has a goal note"),
+          aValidCreateGoalRequest(title = "Goal 3", notes = null),
+          aValidCreateGoalRequest(title = "Goal 4", notes = null),
+          aValidCreateGoalRequest(title = "Goal 5", notes = null),
+        ),
+      ),
+    )
+  }
 
   @Test
   fun `should return unauthorized given no bearer token`() {
     webTestClient.get()
-      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
+      .uri(URI_TEMPLATE, prisonNumber, aValidReference())
       .exchange()
       .expectStatus()
       .isUnauthorized
@@ -36,8 +52,12 @@ class GetGoalsTest : IntegrationTestBase() {
 
   @Test
   fun `should return 404 if no goals at all exist for prisoner yet`() {
+    // Given
+    val prisonNumberWithNoGoals = "Z9999AZ"
+
+    // When
     webTestClient.get()
-      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
+      .uri(URI_TEMPLATE, prisonNumberWithNoGoals, aValidReference())
       .bearerToken(
         aValidTokenWithAuthority(
           GOALS_RO,
@@ -51,13 +71,115 @@ class GetGoalsTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should return goals with view only role`() {
+  fun `should return goals given prisoner has goals`() {
     // Given
-    anActionPlanExistsWithAnArchivedGoal()
 
     // When
     val response = webTestClient.get()
-      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
+      .uri(URI_TEMPLATE, prisonNumber, aValidReference())
+      .bearerToken(
+        aValidTokenWithAuthority(
+          GOALS_RO,
+          privateKey = keyPair.private,
+        ),
+      )
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(GetGoalsResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()!!
+    assertThat(actual.goals).hasSize(5)
+    actual.goals.onEach {
+      assertThat(it).hasStatus(GoalStatus.ACTIVE)
+    }
+    assertThat(actual.goals[0]).hasTitle("Goal 1")
+    assertThat(actual.goals[1]).hasTitle("Goal 2")
+    assertThat(actual.goals[2]).hasTitle("Goal 3")
+    assertThat(actual.goals[3]).hasTitle("Goal 4")
+    assertThat(actual.goals[4]).hasTitle("Goal 5")
+  }
+
+  @Test
+  fun `should return goals including mapping any notes`() {
+    // Given
+    val prisonerGoals = getActionPlan(prisonNumber).goals
+    archiveGoal(
+      prisonNumber = prisonNumber,
+      archiveGoalRequest = aValidArchiveGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 3" }.goalReference,
+        note = "Goal 3 archive note",
+      ),
+    )
+    completeGoal(
+      prisonNumber = prisonNumber,
+      completeGoalRequest = aValidCompleteGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 2" }.goalReference,
+        note = "Goal 2 completion note",
+      ),
+    )
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, prisonNumber, aValidReference())
+      .bearerToken(
+        aValidTokenWithAuthority(
+          GOALS_RO,
+          privateKey = keyPair.private,
+        ),
+      )
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(GetGoalsResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()!!
+    assertThat(actual.goals).hasSize(5)
+    assertThat(actual.goals[0])
+      .hasTitle("Goal 1")
+      .hasNoNotes()
+    assertThat(actual.goals[1])
+      .hasTitle("Goal 2")
+      .hasGoalNote("Only goal 2 has a goal note")
+      .hasNoArchiveNote()
+      .hasCompletedNote("Goal 2 completion note")
+    assertThat(actual.goals[2])
+      .hasTitle("Goal 3")
+      .hasNoGoalNote()
+      .hasArchiveNote("Goal 3 archive note")
+      .hasNoCompletedNote()
+    assertThat(actual.goals[3])
+      .hasTitle("Goal 4")
+      .hasNoNotes()
+    assertThat(actual.goals[4])
+      .hasTitle("Goal 5")
+      .hasNoNotes()
+  }
+
+  @Test
+  fun `Should return only in-progress goals if requested`() {
+    // Given
+    val prisonerGoals = getActionPlan(prisonNumber).goals
+    archiveGoal(
+      prisonNumber = prisonNumber,
+      archiveGoalRequest = aValidArchiveGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 3" }.goalReference,
+      ),
+    )
+    completeGoal(
+      prisonNumber = prisonNumber,
+      completeGoalRequest = aValidCompleteGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 4" }.goalReference,
+      ),
+    )
+
+    // When
+    val response = webTestClient.get()
+      .uri("$URI_TEMPLATE?status=ACTIVE", prisonNumber, aValidReference())
       .bearerToken(
         aValidTokenWithAuthority(
           GOALS_RO,
@@ -73,43 +195,31 @@ class GetGoalsTest : IntegrationTestBase() {
     // Then
     val actual = response.responseBody.blockFirst()!!
     assertThat(actual.goals).hasSize(3)
-    assertThat(actual.goals.map { it.title }).isEqualTo(prisonerGoals)
+    assertThat(actual.goals[0]).hasTitle("Goal 1")
+    assertThat(actual.goals[1]).hasTitle("Goal 2")
+    assertThat(actual.goals[2]).hasTitle("Goal 5")
   }
 
   @Test
-  fun `should return goals with edit role`() {
+  fun `Should return only archived goals if requested`() {
     // Given
-    anActionPlanExistsWithAnArchivedGoal()
+    val prisonerGoals = getActionPlan(prisonNumber).goals
+    archiveGoal(
+      prisonNumber = prisonNumber,
+      archiveGoalRequest = aValidArchiveGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 2" }.goalReference,
+      ),
+    )
+    archiveGoal(
+      prisonNumber = prisonNumber,
+      archiveGoalRequest = aValidArchiveGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 4" }.goalReference,
+      ),
+    )
 
     // When
     val response = webTestClient.get()
-      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
-      .bearerToken(
-        aValidTokenWithAuthority(
-          GOALS_RW,
-          privateKey = keyPair.private,
-        ),
-      )
-      .contentType(APPLICATION_JSON)
-      .exchange()
-      .expectStatus()
-      .isOk
-      .returnResult(GetGoalsResponse::class.java)
-
-    // Then
-    val actual = response.responseBody.blockFirst()!!
-    assertThat(actual.goals).hasSize(3)
-    assertThat(actual.goals.map { it.title }).isEqualTo(prisonerGoals)
-  }
-
-  @Test
-  fun `Should return only in-progress goals if requested`() {
-    // Given
-    anActionPlanExistsWithAnArchivedGoal()
-
-    // When
-    val response = webTestClient.get()
-      .uri("$URI_TEMPLATE?status=ACTIVE", aValidPrisonNumber(), aValidReference())
+      .uri("$URI_TEMPLATE?status=ARCHIVED", prisonNumber, aValidReference())
       .bearerToken(
         aValidTokenWithAuthority(
           GOALS_RO,
@@ -125,43 +235,36 @@ class GetGoalsTest : IntegrationTestBase() {
     // Then
     val actual = response.responseBody.blockFirst()!!
     assertThat(actual.goals).hasSize(2)
-    assertThat(actual.goals.map { it.title }).isEqualTo(prisonerGoals - archivedGoal)
-  }
-
-  @Test
-  fun `Should return only archived goals if requested`() {
-    // Given
-    anActionPlanExistsWithAnArchivedGoal()
-
-    // When
-    val response = webTestClient.get()
-      .uri("$URI_TEMPLATE?status=ARCHIVED", aValidPrisonNumber(), aValidReference())
-      .bearerToken(
-        aValidTokenWithAuthority(
-          GOALS_RO,
-          privateKey = keyPair.private,
-        ),
-      )
-      .contentType(APPLICATION_JSON)
-      .exchange()
-      .expectStatus()
-      .isOk
-      .returnResult(GetGoalsResponse::class.java)
-
-    // Then
-    val actual = response.responseBody.blockFirst()!!
-    assertThat(actual.goals).hasSize(1)
-    assertThat(actual.goals[0].title).isEqualTo(archivedGoal)
+    assertThat(actual.goals[0]).hasTitle("Goal 2")
+    assertThat(actual.goals[1]).hasTitle("Goal 4")
   }
 
   @Test
   fun `Should return archived and in-progress goals if requested with a comma delimited list`() {
     // Given
-    anActionPlanExistsWithAnArchivedGoal()
+    val prisonerGoals = getActionPlan(prisonNumber).goals
+    archiveGoal(
+      prisonNumber = prisonNumber,
+      archiveGoalRequest = aValidArchiveGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 4" }.goalReference,
+      ),
+    )
+    archiveGoal(
+      prisonNumber = prisonNumber,
+      archiveGoalRequest = aValidArchiveGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 5" }.goalReference,
+      ),
+    )
+    completeGoal(
+      prisonNumber = prisonNumber,
+      completeGoalRequest = aValidCompleteGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 3" }.goalReference,
+      ),
+    )
 
     // When
     val response = webTestClient.get()
-      .uri("$URI_TEMPLATE?status=ARCHIVED,ACTIVE", aValidPrisonNumber(), aValidReference())
+      .uri("$URI_TEMPLATE?status=ARCHIVED,ACTIVE", prisonNumber, aValidReference())
       .bearerToken(
         aValidTokenWithAuthority(
           GOALS_RO,
@@ -176,18 +279,39 @@ class GetGoalsTest : IntegrationTestBase() {
 
     // Then
     val actual = response.responseBody.blockFirst()!!
-    assertThat(actual.goals).hasSize(3)
-    assertThat(actual.goals.map { it.title }).isEqualTo(prisonerGoals)
+    assertThat(actual.goals).hasSize(4)
+    assertThat(actual.goals[0]).hasTitle("Goal 1").hasStatus(GoalStatus.ACTIVE)
+    assertThat(actual.goals[1]).hasTitle("Goal 2").hasStatus(GoalStatus.ACTIVE)
+    assertThat(actual.goals[2]).hasTitle("Goal 4").hasStatus(GoalStatus.ARCHIVED)
+    assertThat(actual.goals[3]).hasTitle("Goal 5").hasStatus(GoalStatus.ARCHIVED)
   }
 
   @Test
   fun `Should return archived and in-progress goals if requested with multiple status query string parameters`() {
     // Given
-    anActionPlanExistsWithAnArchivedGoal()
+    val prisonerGoals = getActionPlan(prisonNumber).goals
+    archiveGoal(
+      prisonNumber = prisonNumber,
+      archiveGoalRequest = aValidArchiveGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 4" }.goalReference,
+      ),
+    )
+    archiveGoal(
+      prisonNumber = prisonNumber,
+      archiveGoalRequest = aValidArchiveGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 5" }.goalReference,
+      ),
+    )
+    completeGoal(
+      prisonNumber = prisonNumber,
+      completeGoalRequest = aValidCompleteGoalRequest(
+        goalReference = prisonerGoals.first { it.title == "Goal 3" }.goalReference,
+      ),
+    )
 
     // When
     val response = webTestClient.get()
-      .uri("$URI_TEMPLATE?status=ARCHIVED&status=ACTIVE", aValidPrisonNumber(), aValidReference())
+      .uri("$URI_TEMPLATE?status=ARCHIVED&status=ACTIVE", prisonNumber, aValidReference())
       .bearerToken(
         aValidTokenWithAuthority(
           GOALS_RO,
@@ -202,18 +326,20 @@ class GetGoalsTest : IntegrationTestBase() {
 
     // Then
     val actual = response.responseBody.blockFirst()!!
-    assertThat(actual.goals).hasSize(3)
-    assertThat(actual.goals.map { it.title }).isEqualTo(prisonerGoals)
+    assertThat(actual.goals).hasSize(4)
+    assertThat(actual.goals[0]).hasTitle("Goal 1").hasStatus(GoalStatus.ACTIVE)
+    assertThat(actual.goals[1]).hasTitle("Goal 2").hasStatus(GoalStatus.ACTIVE)
+    assertThat(actual.goals[2]).hasTitle("Goal 4").hasStatus(GoalStatus.ARCHIVED)
+    assertThat(actual.goals[3]).hasTitle("Goal 5").hasStatus(GoalStatus.ARCHIVED)
   }
 
   @Test
   fun `Should return 200 response with empty goals collection given prisoner has goals but none match the status filter`() {
     // Given
-    anActionPlanExistsWithAnArchivedGoal()
 
     // When
     val response = webTestClient.get()
-      .uri("$URI_TEMPLATE?status=COMPLETED", aValidPrisonNumber(), aValidReference())
+      .uri("$URI_TEMPLATE?status=COMPLETED", prisonNumber, aValidReference())
       .bearerToken(
         aValidTokenWithAuthority(
           GOALS_RO,
@@ -234,7 +360,7 @@ class GetGoalsTest : IntegrationTestBase() {
   @Test
   fun `Should return 400 if requested status is not recognised`() {
     webTestClient.get()
-      .uri("$URI_TEMPLATE?status=FOO", aValidPrisonNumber(), aValidReference())
+      .uri("$URI_TEMPLATE?status=FOO", prisonNumber, aValidReference())
       .bearerToken(
         aValidTokenWithAuthority(
           GOALS_RO,
@@ -245,33 +371,5 @@ class GetGoalsTest : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isBadRequest
-  }
-
-  private fun anActionPlanExistsWithAnArchivedGoal(): ActionPlanResponse {
-    val createGoalsRequests = prisonerGoals.map { title ->
-      aValidCreateGoalRequest(
-        title = title,
-        steps = listOf(
-          aValidCreateStepRequest(
-            title = "Book course",
-          ),
-          aValidCreateStepRequest(
-            title = "Attend course",
-          ),
-        ),
-      )
-    }
-    createActionPlan(
-      username = "auser_gen",
-      displayName = "Albert User",
-      prisonNumber = prisonNumber,
-      createActionPlanRequest = aValidCreateActionPlanRequest(
-        goals = createGoalsRequests,
-      ),
-    )
-    val actionPlan = getActionPlan(prisonNumber)
-    val goalToArchive = actionPlan.goals.first { it.title == archivedGoal }
-    archiveGoal(prisonNumber, aValidArchiveGoalRequest(goalToArchive.goalReference))
-    return actionPlan
   }
 }


### PR DESCRIPTION
PR to fix a bug where the response data from the `getGoals` API response does not currently map in the associated notes for each goal.
