### PR TITLE
RR-1020 - Added listener for prisoner.released event

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
@@ -48,6 +48,44 @@ class ReviewScheduleService(
     }
   }
 
+  /**
+   * Updates the prisoner's active Review Schedule by setting its status to EXEMPT_PRISONER_RELEASE
+   *
+   * The prisoner's active Review Schedule is the one with the status SCHEDULED or one of the EXEMPT_ statuses.
+   * A Review Schedule with the status COMPLETE is not considered 'active'
+   */
+  fun exemptActiveReviewScheduleStatusDueToPrisonerRelease(prisonNumber: String, prisonId: String) =
+    reviewSchedulePersistenceAdapter.getActiveReviewSchedule(prisonNumber)
+      ?.run {
+        updateExemptStatus(
+          prisonNumber = prisonNumber,
+          prisonId = prisonId,
+          reviewSchedule = this,
+          newStatus = ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE,
+          exemptionReason = null,
+        )
+      }
+      ?: throw ReviewScheduleNotFoundException(prisonNumber)
+
+  /**
+   * Updates the prisoner's active Review Schedule by setting its status to EXEMPT_PRISONER_DEATH
+   *
+   * The prisoner's active Review Schedule is the one with the status SCHEDULED or one of the EXEMPT_ statuses.
+   * A Review Schedule with the status COMPLETE is not considered 'active'
+   */
+  fun exemptActiveReviewScheduleStatusDueToPrisonerDeath(prisonNumber: String, prisonId: String) =
+    reviewSchedulePersistenceAdapter.getActiveReviewSchedule(prisonNumber)
+      ?.run {
+        updateExemptStatus(
+          prisonNumber = prisonNumber,
+          prisonId = prisonId,
+          reviewSchedule = this,
+          newStatus = ReviewScheduleStatus.EXEMPT_PRISONER_DEATH,
+          exemptionReason = null,
+        )
+      }
+      ?: throw ReviewScheduleNotFoundException(prisonNumber)
+
   private fun updateExemptStatus(
     reviewSchedule: ReviewSchedule,
     newStatus: ReviewScheduleStatus,

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleServiceTest.kt
@@ -1,0 +1,159 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNotFoundException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.UpdatedReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidReviewSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.UpdateReviewScheduleStatusDto
+
+@ExtendWith(MockitoExtension::class)
+class ReviewScheduleServiceTest {
+  @InjectMocks
+  private lateinit var reviewScheduleService: ReviewScheduleService
+
+  @Mock
+  private lateinit var reviewSchedulePersistenceAdapter: ReviewSchedulePersistenceAdapter
+
+  @Mock
+  private lateinit var reviewScheduleEventService: ReviewScheduleEventService
+
+  @Nested
+  inner class ExemptActiveReviewScheduleStatusDueToPrisonerRelease {
+    @Test
+    fun `should exempt active Review Schedule status for prisoner`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val prisonId = "BXI"
+
+      val activeReviewSchedule = aValidReviewSchedule(
+        prisonNumber = prisonNumber,
+        scheduleStatus = ReviewScheduleStatus.SCHEDULED,
+      )
+      given(reviewSchedulePersistenceAdapter.getActiveReviewSchedule(any())).willReturn(activeReviewSchedule)
+
+      val updatedReviewSchedule = activeReviewSchedule.copy(
+        scheduleStatus = ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE,
+      )
+      given(reviewSchedulePersistenceAdapter.updateReviewScheduleStatus(any())).willReturn(updatedReviewSchedule)
+
+      // When
+      reviewScheduleService.exemptActiveReviewScheduleStatusDueToPrisonerRelease(prisonNumber, prisonId)
+
+      // Then
+      verify(reviewSchedulePersistenceAdapter).getActiveReviewSchedule(prisonNumber)
+
+      val updateReviewScheduleStatusDtoCaptor = argumentCaptor<UpdateReviewScheduleStatusDto>()
+      verify(reviewSchedulePersistenceAdapter).updateReviewScheduleStatus(updateReviewScheduleStatusDtoCaptor.capture())
+      val updateReviewScheduleStatusDto = updateReviewScheduleStatusDtoCaptor.firstValue
+      assertThat(updateReviewScheduleStatusDto.reference).isEqualTo(activeReviewSchedule.reference)
+      assertThat(updateReviewScheduleStatusDto.prisonNumber).isEqualTo(prisonNumber)
+      assertThat(updateReviewScheduleStatusDto.prisonId).isEqualTo(prisonId)
+      assertThat(updateReviewScheduleStatusDto.scheduleStatus).isEqualTo(ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE)
+
+      val updateReviewScheduleStatusCaptor = argumentCaptor<UpdatedReviewScheduleStatus>()
+      verify(reviewScheduleEventService).reviewScheduleStatusUpdated(updateReviewScheduleStatusCaptor.capture())
+      val updateReviewScheduleStatus = updateReviewScheduleStatusCaptor.firstValue
+      assertThat(updateReviewScheduleStatus.reference).isEqualTo(updatedReviewSchedule.reference)
+      assertThat(updateReviewScheduleStatus.prisonNumber).isEqualTo(prisonNumber)
+      assertThat(updateReviewScheduleStatus.updatedAtPrison).isEqualTo(prisonId)
+      assertThat(updateReviewScheduleStatus.oldStatus).isEqualTo(ReviewScheduleStatus.SCHEDULED)
+      assertThat(updateReviewScheduleStatus.newStatus).isEqualTo(ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE)
+    }
+
+    @Test
+    fun `should not exempt Review Schedule status given prisoner does not have an active review schedule`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val prisonId = "BXI"
+
+      given(reviewSchedulePersistenceAdapter.getActiveReviewSchedule(any())).willReturn(null)
+
+      // When
+      val exception = assertThrows(ReviewScheduleNotFoundException::class.java) {
+        reviewScheduleService.exemptActiveReviewScheduleStatusDueToPrisonerRelease(prisonNumber, prisonId)
+      }
+
+      // Then
+      assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
+      verify(reviewSchedulePersistenceAdapter).getActiveReviewSchedule(prisonNumber)
+      verifyNoInteractions(reviewScheduleEventService)
+    }
+  }
+
+  @Nested
+  inner class ExemptActiveReviewScheduleStatusDueToPrisonerDeath {
+    @Test
+    fun `should exempt active Review Schedule status for prisoner`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val prisonId = "BXI"
+
+      val activeReviewSchedule = aValidReviewSchedule(
+        prisonNumber = prisonNumber,
+        scheduleStatus = ReviewScheduleStatus.SCHEDULED,
+      )
+      given(reviewSchedulePersistenceAdapter.getActiveReviewSchedule(any())).willReturn(activeReviewSchedule)
+
+      val updatedReviewSchedule = activeReviewSchedule.copy(
+        scheduleStatus = ReviewScheduleStatus.EXEMPT_PRISONER_DEATH,
+      )
+      given(reviewSchedulePersistenceAdapter.updateReviewScheduleStatus(any())).willReturn(updatedReviewSchedule)
+
+      // When
+      reviewScheduleService.exemptActiveReviewScheduleStatusDueToPrisonerDeath(prisonNumber, prisonId)
+
+      // Then
+      verify(reviewSchedulePersistenceAdapter).getActiveReviewSchedule(prisonNumber)
+
+      val updateReviewScheduleStatusDtoCaptor = argumentCaptor<UpdateReviewScheduleStatusDto>()
+      verify(reviewSchedulePersistenceAdapter).updateReviewScheduleStatus(updateReviewScheduleStatusDtoCaptor.capture())
+      val updateReviewScheduleStatusDto = updateReviewScheduleStatusDtoCaptor.firstValue
+      assertThat(updateReviewScheduleStatusDto.reference).isEqualTo(activeReviewSchedule.reference)
+      assertThat(updateReviewScheduleStatusDto.prisonNumber).isEqualTo(prisonNumber)
+      assertThat(updateReviewScheduleStatusDto.prisonId).isEqualTo(prisonId)
+      assertThat(updateReviewScheduleStatusDto.scheduleStatus).isEqualTo(ReviewScheduleStatus.EXEMPT_PRISONER_DEATH)
+
+      val updateReviewScheduleStatusCaptor = argumentCaptor<UpdatedReviewScheduleStatus>()
+      verify(reviewScheduleEventService).reviewScheduleStatusUpdated(updateReviewScheduleStatusCaptor.capture())
+      val updateReviewScheduleStatus = updateReviewScheduleStatusCaptor.firstValue
+      assertThat(updateReviewScheduleStatus.reference).isEqualTo(updatedReviewSchedule.reference)
+      assertThat(updateReviewScheduleStatus.prisonNumber).isEqualTo(prisonNumber)
+      assertThat(updateReviewScheduleStatus.updatedAtPrison).isEqualTo(prisonId)
+      assertThat(updateReviewScheduleStatus.oldStatus).isEqualTo(ReviewScheduleStatus.SCHEDULED)
+      assertThat(updateReviewScheduleStatus.newStatus).isEqualTo(ReviewScheduleStatus.EXEMPT_PRISONER_DEATH)
+    }
+
+    @Test
+    fun `should not exempt Review Schedule status given prisoner does not have an active review schedule`() {
+      // Given
+      val prisonNumber = aValidPrisonNumber()
+      val prisonId = "BXI"
+
+      given(reviewSchedulePersistenceAdapter.getActiveReviewSchedule(any())).willReturn(null)
+
+      // When
+      val exception = assertThrows(ReviewScheduleNotFoundException::class.java) {
+        reviewScheduleService.exemptActiveReviewScheduleStatusDueToPrisonerDeath(prisonNumber, prisonId)
+      }
+
+      // Then
+      assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
+      verify(reviewSchedulePersistenceAdapter).getActiveReviewSchedule(prisonNumber)
+      verifyNoInteractions(reviewScheduleEventService)
+    }
+  }
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -608,6 +608,18 @@ abstract class IntegrationTestBase {
     reviewScheduleHistoryRepository.saveAndFlush(reviewScheduleEntity)
   }
 
+  fun updateReviewScheduleRecordStatus(
+    prisonNumber: String,
+    status: ReviewScheduleStatus = ReviewScheduleStatus.SCHEDULED,
+    exemptionReason: String? = null,
+  ) {
+    val reviewScheduleEntity = reviewScheduleRepository.findActiveReviewSchedule(prisonNumber)
+    reviewScheduleEntity?.run {
+      scheduleStatus = status
+      reviewScheduleRepository.saveAndFlush(reviewScheduleEntity)
+    }
+  }
+
   fun sendDomainEvent(
     message: SqsMessage,
     queueUrl: String = domainEventQueue.queueUrl,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventTest.kt
@@ -10,13 +10,13 @@ import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch.aValidPrisoner
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionScheduleStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RECEIVED_INTO_PRISON
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequestForPrisonerNotLookingToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.assertThat
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import java.time.OffsetDateTime
-import java.util.UUID
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleCalculationRule as InductionScheduleCalculationRuleResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus as InductionScheduleStatusResponse
 
@@ -31,7 +31,10 @@ class PrisonerReceivedEventTest : IntegrationTestBase() {
 
     val earliestDateTime = OffsetDateTime.now()
 
-    val sqsMessage = prisonerReceivedSqsMessage(prisonNumber)
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RECEIVED_INTO_PRISON,
+    )
 
     // When
     sendDomainEvent(sqsMessage)
@@ -98,7 +101,10 @@ class PrisonerReceivedEventTest : IntegrationTestBase() {
 
     val earliestDateTime = OffsetDateTime.now()
 
-    val sqsMessage = prisonerReceivedSqsMessage(prisonNumber)
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RECEIVED_INTO_PRISON,
+    )
 
     // When
     sendDomainEvent(sqsMessage)
@@ -124,21 +130,4 @@ class PrisonerReceivedEventTest : IntegrationTestBase() {
     assertThat(reviewScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
     assertThat(reviewScheduleEvent.detailUrl).isEqualTo("http://localhost:8080/reviews/$prisonNumber/review-schedule")
   }
-
-  private fun prisonerReceivedSqsMessage(prisonNumber: String): SqsMessage =
-    SqsMessage(
-      Type = "Notification",
-      Message = """
-        {
-          "eventType": "prison-offender-events.prisoner.received",
-          "personReference": { "identifiers": [ { "type": "NOMS", "value": "$prisonNumber" } ] },
-          "occurredAt": "2024-08-08T09:07:55+01:00",
-          "publishedAt": "2024-08-08T09:08:55.673395103+01:00",
-          "description": "A prisoner has been received into prison",
-          "version": "1.0",
-          "additionalInformation": { "nomsNumber": "$prisonNumber", "reason": "ADMISSION", "details": "ACTIVE IN:ADM-N", "currentLocation": "IN_PRISON", "prisonId": "SWI", "nomisMovementReasonCode": "N", "currentPrisonStatus": "UNDER_PRISON_CARE" }
-        }        
-      """.trimIndent(),
-      MessageId = UUID.randomUUID(),
-    )
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedEventTest.kt
@@ -1,0 +1,114 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
+import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RELEASED_FROM_PRISON
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequestForPrisonerNotLookingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.assertThat
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleStatus as ReviewScheduleStatusEntity
+
+@Isolated
+class PrisonerReleasedEventTest : IntegrationTestBase() {
+  @Test
+  fun `should update Review Schedule given Review Schedule given prisoner has an active Review Schedule`() {
+    // Given
+    // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
+    val prisonNumber = aValidPrisonNumber()
+    createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork())
+    createActionPlan(prisonNumber)
+
+    // The above calls set the data up but they will also generate events so clear these out before starting the test.
+    // Before clearing the queues though we need to wait until the "plp.review-schedule.updated" event on the REVIEW queue is received.
+    await untilCallTo {
+      reviewScheduleEventQueue.countAllMessagesOnQueue()
+    } matches { it != null && it > 0 }
+    clearQueues()
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RELEASED_FROM_PRISON,
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    val actionPlanReviews = getActionPlanReviews(prisonNumber)
+    assertThat(actionPlanReviews)
+      .latestReviewSchedule {
+        it.hasStatus(ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE)
+      }
+  }
+
+  @Test
+  fun `should not update Review Schedule given prisoner does not have an active Review Schedule`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
+    createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork())
+    createActionPlan(prisonNumber)
+    // Before updating the status of the Review Schedule we need to wait until 1 "plp.review-schedule.updated" event on the REVIEW queue is received (which is the creation of the initial Review Schedule)
+    await untilCallTo {
+      reviewScheduleEventQueue.countAllMessagesOnQueue()
+    } matches { it != null && it > 0 }
+    // Update the status of the Review Schedule to Completed, which means the prisoner no longer has an active Review Schedule
+    updateReviewScheduleRecordStatus(prisonNumber, ReviewScheduleStatusEntity.COMPLETED)
+
+    clearQueues()
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RELEASED_FROM_PRISON,
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    val actionPlanReviews = getActionPlanReviews(prisonNumber)
+    assertThat(actionPlanReviews)
+      .latestReviewSchedule {
+        it.hasStatus(ReviewScheduleStatus.COMPLETED)
+      }
+  }
+
+  @Test
+  fun `should not create or update Review Schedule given prisoner does not have a Review Schedule at all`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    assertThat(runCatching { getActionPlanReviews(prisonNumber) }.getOrNull()).isNull()
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RELEASED_FROM_PRISON,
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    assertThat(runCatching { getActionPlanReviews(prisonNumber) }.getOrNull()).isNull()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedFromPrisonEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedFromPrisonEventService.kt
@@ -2,15 +2,45 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
 
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNotFoundException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewScheduleService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.RELEASED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.RELEASED_TO_HOSPITAL
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.SENT_TO_COURT
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.TEMPORARY_ABSENCE_RELEASE
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.TRANSFERRED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.UNKNOWN
 
 private val log = KotlinLogging.logger {}
 
 @Service
-class PrisonerReleasedFromPrisonEventService {
+class PrisonerReleasedFromPrisonEventService(
+  private val reviewScheduleService: ReviewScheduleService,
+) {
   fun process(
     inboundEvent: InboundEvent,
     additionalInformation: PrisonerReleasedAdditionalInformation,
   ) =
-    log.info { "Processing Prisoner Released From Prison Event with reason ${additionalInformation.reason}" }
+    with(additionalInformation) {
+      when (reason) {
+        RELEASED -> {
+          log.info { "Processing Prisoner Released From Prison Event with reason RELEASED for prisoner [$nomsNumber]" }
+          try {
+            reviewScheduleService.exemptActiveReviewScheduleStatusDueToPrisonerRelease(
+              prisonNumber = nomsNumber,
+              prisonId = prisonId,
+            ).also {
+              log.debug { "Review Schedule for prisoner [$nomsNumber] set to exempt: EXEMPT_PRISONER_RELEASE" }
+            }
+          } catch (e: ReviewScheduleNotFoundException) {
+            log.debug { "Prisoner [$nomsNumber] does not have an active Review Schedule; no need to set it as exempt" }
+          }
+        }
+
+        TEMPORARY_ABSENCE_RELEASE, RELEASED_TO_HOSPITAL, SENT_TO_COURT, TRANSFERRED, UNKNOWN -> {
+          log.debug { "Ignoring Processing Prisoner Released From Prison Event with reason $reason" }
+        }
+      }
+    }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedFromPrisonEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedFromPrisonEventServiceTest.kt
@@ -1,0 +1,115 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNotFoundException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewScheduleService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.RELEASED
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+class PrisonerReleasedFromPrisonEventServiceTest {
+  @InjectMocks
+  private lateinit var eventService: PrisonerReleasedFromPrisonEventService
+
+  @Mock
+  private lateinit var reviewScheduleService: ReviewScheduleService
+
+  private val objectMapper = ObjectMapper()
+
+  @Test
+  fun `should process event given reason is prisoner released`() {
+    // Given
+    val additionalInformation = PrisonerReleasedAdditionalInformation(
+      nomsNumber = "A1234BC",
+      reason = RELEASED,
+      prisonId = "BXI",
+      nomisMovementReasonCode = "",
+      details = null,
+      currentLocation = null,
+      currentPrisonStatus = null,
+    )
+    val inboundEvent = anInboundEvent(additionalInformation)
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(reviewScheduleService).exemptActiveReviewScheduleStatusDueToPrisonerRelease(
+      prisonNumber = "A1234BC",
+      prisonId = "BXI",
+    )
+  }
+
+  @Test
+  fun `should process event given reason is prisoner released but prisoner does not have an active Review Schedule`() {
+    // Given
+    val additionalInformation = PrisonerReleasedAdditionalInformation(
+      nomsNumber = "A1234BC",
+      reason = RELEASED,
+      prisonId = "BXI",
+      nomisMovementReasonCode = "",
+      details = null,
+      currentLocation = null,
+      currentPrisonStatus = null,
+    )
+    val inboundEvent = anInboundEvent(additionalInformation)
+
+    given(reviewScheduleService.exemptActiveReviewScheduleStatusDueToPrisonerRelease(any(), any()))
+      .willThrow(ReviewScheduleNotFoundException("A1234BC"))
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(reviewScheduleService).exemptActiveReviewScheduleStatusDueToPrisonerRelease(
+      prisonNumber = "A1234BC",
+      prisonId = "BXI",
+    )
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = ["TEMPORARY_ABSENCE_RELEASE", "RELEASED_TO_HOSPITAL", "SENT_TO_COURT", "TRANSFERRED", "UNKNOWN"])
+  fun `should process event but not call service given reason is not a prisoner release reason that we should process`(reason: Reason) {
+    // Given
+    val additionalInformation = PrisonerReleasedAdditionalInformation(
+      nomsNumber = "A1234BC",
+      reason = reason,
+      prisonId = "BXI",
+      nomisMovementReasonCode = "",
+      details = null,
+      currentLocation = null,
+      currentPrisonStatus = null,
+    )
+    val inboundEvent = anInboundEvent(additionalInformation)
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verifyNoInteractions(reviewScheduleService)
+  }
+
+  private fun anInboundEvent(additionalInformation: PrisonerReleasedAdditionalInformation): InboundEvent =
+    InboundEvent(
+      eventType = EventType.PRISONER_RELEASED_FROM_PRISON,
+      personReference = PersonReference(listOf(Identifier(type = "noms", value = "A1234BC"))),
+      occurredAt = Instant.now(),
+      publishedAt = Instant.now(),
+      description = "Prisoner released from prison event",
+      version = "1.0",
+      additionalInformation = objectMapper.writeValueAsString(additionalInformation),
+    )
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformationBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformationBuilder.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
+
+fun aValidPrisonerReceivedAdditionalInformation(
+  prisonNumber: String = aValidPrisonNumber(),
+  prisonId: String = "BXI",
+  reason: PrisonerReceivedAdditionalInformation.Reason = PrisonerReceivedAdditionalInformation.Reason.ADMISSION,
+  currentLocation: PrisonerReceivedAdditionalInformation.Location = PrisonerReceivedAdditionalInformation.Location.IN_PRISON,
+  currentPrisonStatus: PrisonerReceivedAdditionalInformation.PrisonStatus = PrisonerReceivedAdditionalInformation.PrisonStatus.UNDER_PRISON_CARE,
+): PrisonerReceivedAdditionalInformation =
+  PrisonerReceivedAdditionalInformation(
+    nomsNumber = prisonNumber,
+    reason = reason,
+    details = "ACTIVE IN:ADM-N",
+    currentLocation = currentLocation,
+    prisonId = prisonId,
+    nomisMovementReasonCode = "N",
+    currentPrisonStatus = currentPrisonStatus,
+  )
+
+fun aValidPrisonerReleasedAdditionalInformation(
+  prisonNumber: String = aValidPrisonNumber(),
+  prisonId: String = "BXI",
+  reason: PrisonerReleasedAdditionalInformation.Reason = PrisonerReleasedAdditionalInformation.Reason.RELEASED,
+  currentLocation: PrisonerReleasedAdditionalInformation.Location = PrisonerReleasedAdditionalInformation.Location.OUTSIDE_PRISON,
+  currentPrisonStatus: PrisonerReleasedAdditionalInformation.PrisonStatus = PrisonerReleasedAdditionalInformation.PrisonStatus.NOT_UNDER_PRISON_CARE,
+): PrisonerReleasedAdditionalInformation =
+  PrisonerReleasedAdditionalInformation(
+    nomsNumber = prisonNumber,
+    reason = reason,
+    details = "ACTIVE IN:ADM-N",
+    currentLocation = currentLocation,
+    prisonId = prisonId,
+    nomisMovementReasonCode = "N",
+    currentPrisonStatus = currentPrisonStatus,
+  )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/SqdMessageBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/SqdMessageBuilder.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RECEIVED_INTO_PRISON
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RELEASED_FROM_PRISON
+import java.time.Instant
+import java.util.UUID
+
+fun aValidHmppsDomainEventsSqsMessage(
+  prisonNumber: String = aValidPrisonNumber(),
+  eventType: EventType = PRISONER_RECEIVED_INTO_PRISON,
+  occurredAt: Instant = Instant.now().minusSeconds(10),
+  publishedAt: Instant = Instant.now(),
+  description: String = "A prisoner has been received into prison",
+  version: String = "1.0",
+  additionalInformation: AdditionalInformation =
+    when (eventType) {
+      PRISONER_RECEIVED_INTO_PRISON -> aValidPrisonerReceivedAdditionalInformation(prisonNumber)
+      PRISONER_RELEASED_FROM_PRISON -> aValidPrisonerReleasedAdditionalInformation(prisonNumber)
+    },
+): SqsMessage =
+  SqsMessage(
+    Type = "Notification",
+    Message = """
+        {
+          "eventType": "${eventType.eventType}",
+          "personReference": { "identifiers": [ { "type": "NOMS", "value": "$prisonNumber" } ] },
+          "occurredAt": "$occurredAt",
+          "publishedAt": "$publishedAt",
+          "description": "$description",
+          "version": "$version",
+          "additionalInformation": ${ObjectMapper().writeValueAsString(additionalInformation)}
+        }        
+    """.trimIndent(),
+    MessageId = UUID.randomUUID(),
+  )


### PR DESCRIPTION
This PR adds the listener for the prisoner released event, and implements the code to update their Review Schedule as necessary:
* If the prisoner does not have a Review Schedule, do nothing
* If the prisoner has a Review Schedule, but it is already `COMPLETE` (ie. they have already had their last review before release), do nothing
* All other cases, update the Review Schedule to have status `EXEMPT_PRISONER_RELEASE`