### PR TITLE
RR-1203 - Remove displayName field from Timeline Entity

### DIFF
--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/TimelineEvent.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/TimelineEvent.kt
@@ -25,7 +25,7 @@ data class TimelineEvent(
   /**
    * A map of useful contextual information about the event.
    */
-  val contextualInfo: Map<TimelineEventContext, String>?,
+  val contextualInfo: Map<TimelineEventContext, String>,
   /**
    * The ID of the Prison where the Prisoner is based at the time of the event.
    */
@@ -34,10 +34,6 @@ data class TimelineEvent(
    * The username of the person who caused this event. Set to 'system' if the event was not actioned by a DPS user.
    */
   val actionedBy: String,
-  /**
-   * The name of the person who caused this event (if applicable).
-   */
-  val actionedByDisplayName: String? = null,
   /**
    * The date and time when the event occurred.
    */
@@ -52,10 +48,9 @@ data class TimelineEvent(
     fun newTimelineEvent(
       sourceReference: String,
       eventType: TimelineEventType,
-      contextualInfo: Map<TimelineEventContext, String>? = null,
+      contextualInfo: Map<TimelineEventContext, String> = emptyMap(),
       prisonId: String,
       actionedBy: String,
-      actionedByDisplayName: String? = null,
       timestamp: Instant = Instant.now(),
       correlationId: UUID = UUID.randomUUID(),
     ) = TimelineEvent(
@@ -65,7 +60,6 @@ data class TimelineEvent(
       contextualInfo = contextualInfo,
       prisonId = prisonId,
       actionedBy = actionedBy,
-      actionedByDisplayName = actionedByDisplayName,
       timestamp = timestamp,
       correlationId = correlationId,
     )

--- a/domain/timeline/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/TimeLineBuilder.kt
+++ b/domain/timeline/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/TimeLineBuilder.kt
@@ -17,10 +17,9 @@ fun aValidTimelineEvent(
   reference: UUID = UUID.randomUUID(),
   sourceReference: String = UUID.randomUUID().toString(),
   eventType: TimelineEventType = TimelineEventType.GOAL_CREATED,
-  contextualInfo: Map<TimelineEventContext, String>? = null,
+  contextualInfo: Map<TimelineEventContext, String> = emptyMap(),
   prisonId: String = "BXI",
   actionedBy: String = "asmith_gen",
-  actionedByDisplayName: String? = "Alex Smith",
   timestamp: Instant = Instant.now(),
   correlationId: UUID = UUID.randomUUID(),
 ) = TimelineEvent(
@@ -30,7 +29,6 @@ fun aValidTimelineEvent(
   contextualInfo = contextualInfo,
   prisonId = prisonId,
   actionedBy = actionedBy,
-  actionedByDisplayName = actionedByDisplayName,
   timestamp = timestamp,
   correlationId = correlationId,
 )
@@ -39,10 +37,9 @@ fun aValidPrisonMovementTimelineEvent(
   reference: UUID = UUID.randomUUID(),
   sourceReference: String = "1",
   eventType: TimelineEventType = TimelineEventType.PRISON_ADMISSION,
-  contextualInfo: Map<TimelineEventContext, String>? = null,
+  contextualInfo: Map<TimelineEventContext, String> = emptyMap(),
   prisonId: String = "BXI",
   actionedBy: String = "system",
-  actionedByDisplayName: String? = null,
   timestamp: Instant = Instant.now(),
   correlationId: UUID = UUID.randomUUID(),
 ) = TimelineEvent(
@@ -52,7 +49,6 @@ fun aValidPrisonMovementTimelineEvent(
   contextualInfo = contextualInfo,
   prisonId = prisonId,
   actionedBy = actionedBy,
-  actionedByDisplayName = actionedByDisplayName,
   timestamp = timestamp,
   correlationId = correlationId,
 )

--- a/domain/timeline/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/TimelineEventAssert.kt
+++ b/domain/timeline/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/TimelineEventAssert.kt
@@ -21,16 +21,6 @@ class TimelineEventAssert(actual: TimelineEvent?) :
     return this
   }
 
-  fun wasActionedByDisplayName(expected: String): TimelineEventAssert {
-    isNotNull
-    with(actual!!) {
-      if (actionedByDisplayName != expected) {
-        failWithMessage("Expected actionedByDisplayName to be $expected, but was $actionedByDisplayName")
-      }
-    }
-    return this
-  }
-
   fun hasPrisonId(expected: String): TimelineEventAssert {
     isNotNull
     with(actual!!) {
@@ -65,16 +55,6 @@ class TimelineEventAssert(actual: TimelineEvent?) :
     with(actual!!) {
       if (contextualInfo != expected) {
         failWithMessage("Expected contextualInfo to be $expected, but was $contextualInfo")
-      }
-    }
-    return this
-  }
-
-  fun hasNoContextualInfo(): TimelineEventAssert {
-    isNotNull
-    with(actual!!) {
-      if (contextualInfo != null) {
-        failWithMessage("Expected contextualInfo to be null, but was $contextualInfo")
       }
     }
     return this

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEntity.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderBy
 import jakarta.persistence.Table
-import jakarta.validation.constraints.NotNull
 import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
@@ -20,34 +19,30 @@ import java.util.UUID
 
 @Table(name = "timeline")
 @Entity
-class TimelineEntity(
-  @Id
-  @GeneratedValue
-  @UuidGenerator
-  var id: UUID? = null,
+data class TimelineEntity(
+  @Column(updatable = false)
+  val reference: UUID,
 
   @Column(updatable = false)
-  @field:NotNull
-  var reference: UUID? = null,
-
-  @Column(updatable = false)
-  @field:NotNull
-  var prisonNumber: String,
+  val prisonNumber: String,
 
   @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "timeline_id", nullable = false)
   @OrderBy(value = "createdAt")
-  @field:NotNull
-  var events: MutableList<TimelineEventEntity>? = null,
+  val events: MutableList<TimelineEventEntity>,
+) {
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null
 
   @Column(updatable = false)
   @CreationTimestamp
-  var createdAt: Instant? = null,
+  var createdAt: Instant? = null
 
   @Column
   @UpdateTimestamp
-  var updatedAt: Instant? = null,
-) {
+  var updatedAt: Instant? = null
 
   companion object {
 
@@ -64,7 +59,7 @@ class TimelineEntity(
   }
 
   fun addEvent(timelineEvent: TimelineEventEntity): TimelineEntity {
-    events!!.add(timelineEvent)
+    events.add(timelineEvent)
     return this
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEventEntity.kt
@@ -12,7 +12,6 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.MapKeyColumn
 import jakarta.persistence.MapKeyEnumerated
 import jakarta.persistence.Table
-import jakarta.validation.constraints.NotNull
 import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UuidGenerator
@@ -21,24 +20,16 @@ import java.util.UUID
 
 @Table(name = "timeline_event")
 @Entity
-class TimelineEventEntity(
-  @Id
-  @GeneratedValue
-  @UuidGenerator
-  var id: UUID? = null,
+data class TimelineEventEntity(
+  @Column(updatable = false)
+  val reference: UUID,
 
   @Column(updatable = false)
-  @field:NotNull
-  var reference: UUID? = null,
-
-  @Column(updatable = false)
-  @field:NotNull
-  var sourceReference: String? = null,
+  val sourceReference: String,
 
   @Column(updatable = false)
   @Enumerated(value = EnumType.STRING)
-  @field:NotNull
-  var eventType: TimelineEventType? = null,
+  val eventType: TimelineEventType,
 
   @ElementCollection
   @MapKeyColumn(name = "name")
@@ -48,49 +39,41 @@ class TimelineEventEntity(
     name = "timeline_event_contextual_info",
     joinColumns = [JoinColumn(name = "timeline_event_id")],
   )
-  var contextualInfo: Map<TimelineEventContext, String>? = null,
+  val contextualInfo: Map<TimelineEventContext, String>,
 
   /**
    * The ID of the prison that the prisoner was at when the event occurred.
    */
   @Column(updatable = false)
-  @field:NotNull
-  var prisonId: String? = null,
+  val prisonId: String,
 
   /**
    * The username of the person who caused this event. Set to 'system' if the event was not actioned by a DPS user.
    */
   @Column(updatable = false)
-  @field:NotNull
-  var actionedBy: String? = null,
-
-  /**
-   * The name of the person who caused this event (if applicable).
-   */
-  @Column(updatable = false)
-  var actionedByDisplayName: String? = null,
+  val actionedBy: String,
 
   /**
    * The timestamp of the original event (not when this entity was saved to the DB - see createdAt).
    */
   @Column(updatable = false)
-  @field:NotNull
-  var timestamp: Instant? = null,
+  val timestamp: Instant,
 
   /**
-   * The timestamp that this entity was created.
+   * A correlation ID.
    */
+  @Column(updatable = false)
+  val correlationId: UUID,
+) {
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null
+
   @Column(updatable = false)
   @CreationTimestamp
-  var createdAt: Instant? = null,
+  var createdAt: Instant? = null
 
-  /**
-   * An optional correlation ID.
-   */
-  @Column(updatable = false)
-  @field:NotNull
-  var correlationId: UUID? = null,
-) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/timeline/TimelineEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/timeline/TimelineEntityMapper.kt
@@ -1,14 +1,17 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.timeline
 
-import org.mapstruct.Mapper
+import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.domain.timeline.Timeline
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.timeline.TimelineEntity
 
-@Mapper(
-  uses = [
-    TimelineEventEntityMapper::class,
-  ],
-)
-interface TimelineEntityMapper {
-  fun fromEntityToDomain(persisted: TimelineEntity): Timeline
+@Component
+class TimelineEntityMapper(private val timelineEventEntityMapper: TimelineEventEntityMapper) {
+  fun fromEntityToDomain(persisted: TimelineEntity): Timeline =
+    with(persisted) {
+      Timeline(
+        reference = reference,
+        prisonNumber = prisonNumber,
+        events = events.map { timelineEventEntityMapper.fromEntityToDomain(it) },
+      )
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/timeline/TimelineEventEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/timeline/TimelineEventEntityMapper.kt
@@ -16,12 +16,11 @@ class TimelineEventEntityMapper {
         reference = reference,
         sourceReference = sourceReference,
         eventType = toTimelineEventType(eventType),
-        contextualInfo = contextualInfo?.let { contextualInfo ->
+        contextualInfo = contextualInfo.let { contextualInfo ->
           contextualInfo.keys.associate { toTimelineEventContext(it) to contextualInfo.getValue(it) }
         },
         prisonId = prisonId,
         actionedBy = actionedBy,
-        actionedByDisplayName = actionedByDisplayName,
         timestamp = timestamp,
         correlationId = correlationId,
       )
@@ -30,18 +29,16 @@ class TimelineEventEntityMapper {
   fun fromEntityToDomain(persisted: TimelineEventEntity): TimelineEvent =
     with(persisted) {
       TimelineEvent(
-        reference = reference!!,
-        sourceReference = sourceReference!!,
-        eventType = toTimelineEventType(eventType!!),
-        contextualInfo = contextualInfo?.let { contextualInfo ->
+        reference = reference,
+        sourceReference = sourceReference,
+        eventType = toTimelineEventType(eventType),
+        contextualInfo = contextualInfo.let { contextualInfo ->
           contextualInfo.keys.associate { toTimelineEventContext(it) to contextualInfo.getValue(it) }
         },
-        prisonId = prisonId!!,
-        actionedBy = actionedBy!!,
-        // TODO, this display name field will be removed from the domain as part of the RBAC work, so no point mapping it
-        actionedByDisplayName = null,
-        timestamp = timestamp!!,
-        correlationId = correlationId!!,
+        prisonId = prisonId,
+        actionedBy = actionedBy,
+        timestamp = timestamp,
+        correlationId = correlationId,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/timeline/TimelineEventResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/timeline/TimelineEventResourceMapper.kt
@@ -30,8 +30,8 @@ class TimelineEventResourceMapper(
       )
     }
 
-  private fun buildContextualInfo(contextualInfo: Map<TimelineEventContext, String>?): Map<String, String> =
-    contextualInfo?.mapKeys { it.key.toString() } ?: emptyMap()
+  private fun buildContextualInfo(contextualInfo: Map<TimelineEventContext, String>): Map<String, String> =
+    contextualInfo.mapKeys { it.key.toString() } ?: emptyMap()
 
   private fun toTimelineEventType(timelineEventType: TimelineEventTypeDomain): TimelineEventTypeApi =
     when (timelineEventType) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncConversationEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncConversationEventService.kt
@@ -42,7 +42,6 @@ class AsyncConversationEventService(
         contextualInfo = buildContextualInfo(this),
         prisonId = note.createdAtPrison,
         actionedBy = note.createdBy!!,
-        actionedByDisplayName = note.createdByDisplayName,
         timestamp = note.createdAt!!,
       )
     }
@@ -55,7 +54,6 @@ class AsyncConversationEventService(
         contextualInfo = buildContextualInfo(this),
         prisonId = note.lastUpdatedAtPrison,
         actionedBy = note.lastUpdatedBy!!,
-        actionedByDisplayName = note.lastUpdatedByDisplayName,
         timestamp = note.lastUpdatedAt!!,
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventService.kt
@@ -40,7 +40,6 @@ class AsyncInductionEventService(
         eventType = TimelineEventType.INDUCTION_CREATED,
         prisonId = createdAtPrison,
         actionedBy = induction.createdBy!!,
-        actionedByDisplayName = induction.createdByDisplayName,
         timestamp = induction.createdAt!!,
       )
     }
@@ -52,7 +51,6 @@ class AsyncInductionEventService(
         eventType = TimelineEventType.INDUCTION_UPDATED,
         prisonId = lastUpdatedAtPrison,
         actionedBy = induction.lastUpdatedBy!!,
-        actionedByDisplayName = induction.lastUpdatedByDisplayName,
         timestamp = induction.lastUpdatedAt!!,
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TimelineEventFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TimelineEventFactory.kt
@@ -25,7 +25,7 @@ class TimelineEventFactory {
         actionPlan.goals[0],
         actionPlan.reference,
         TimelineEventType.ACTION_PLAN_CREATED,
-        contextualInfo = null,
+        contextualInfo = emptyMap(),
         correlationId = correlationId,
       ),
     )
@@ -192,7 +192,7 @@ class TimelineEventFactory {
     goal: Goal,
     sourceReference: UUID,
     eventType: TimelineEventType,
-    contextualInfo: Map<TimelineEventContext, String>?,
+    contextualInfo: Map<TimelineEventContext, String>,
     correlationId: UUID = UUID.randomUUID(),
   ) =
     TimelineEvent.newTimelineEvent(
@@ -201,7 +201,6 @@ class TimelineEventFactory {
       // we can use the lastUpdatedBy fields for create action plan/create goal events, since it will be the same as the actionedBy fields initially
       prisonId = goal.lastUpdatedAtPrison,
       actionedBy = goal.lastUpdatedBy!!,
-      actionedByDisplayName = goal.lastUpdatedByDisplayName!!,
       contextualInfo = contextualInfo,
       correlationId = correlationId,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/mapper/PrisonMovementEventsMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/mapper/PrisonMovementEventsMapper.kt
@@ -35,7 +35,6 @@ class PrisonMovementEventsMapper(
       contextualInfo = getContextualInfo(prisonMovement),
       prisonId = getPrisonId(prisonMovement),
       actionedBy = SYSTEM_USER,
-      actionedByDisplayName = null,
     )
 
   private fun toEventType(movementType: PrisonMovementType): TimelineEventType =
@@ -45,12 +44,12 @@ class PrisonMovementEventsMapper(
       PrisonMovementType.TRANSFER -> TimelineEventType.PRISON_TRANSFER
     }
 
-  private fun getContextualInfo(prisonMovement: PrisonMovementEvent): Map<TimelineEventContext, String>? =
+  private fun getContextualInfo(prisonMovement: PrisonMovementEvent): Map<TimelineEventContext, String> =
     // For transfers, this is the ID of the prison they were transferred from. Otherwise, null
     if (prisonMovement.movementType == PrisonMovementType.TRANSFER) {
       mapOf(TimelineEventContext.PRISON_TRANSFERRED_FROM to prisonMovement.fromPrisonId!!)
     } else {
-      null
+      emptyMap()
     }
 
   private fun getPrisonId(prisonMovement: PrisonMovementEvent): String =

--- a/src/main/resources/db/migration/common/V2024.12.29.0001__drop_display_name_field_from_timeline_event_table.sql
+++ b/src/main/resources/db/migration/common/V2024.12.29.0001__drop_display_name_field_from_timeline_event_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE timeline_event
+    DROP COLUMN actioned_by_display_name;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/timeline/TimelineEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/timeline/TimelineEntityMapperTest.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 class TimelineEntityMapperTest {
 
   @InjectMocks
-  private lateinit var mapper: TimelineEntityMapperImpl
+  private lateinit var mapper: TimelineEntityMapper
 
   @Mock
   private lateinit var eventMapper: TimelineEventEntityMapper

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/timeline/TimelineEventEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/timeline/TimelineEventEntityMapperTest.kt
@@ -28,10 +28,9 @@ class TimelineEventEntityMapperTest {
       reference = reference,
       sourceReference = sourceReference,
       eventType = TimelineEventTypeEntity.STEP_UPDATED,
-      contextualInfo = null,
+      contextualInfo = emptyMap(),
       prisonId = prisonId,
       actionedBy = timelineEvent.actionedBy,
-      actionedByDisplayName = timelineEvent.actionedByDisplayName,
       timestamp = timelineEvent.timestamp,
       correlationId = timelineEvent.correlationId,
     )
@@ -42,7 +41,6 @@ class TimelineEventEntityMapperTest {
     // Then
     assertThat(actual)
       .doesNotHaveJpaManagedFieldsPopulated()
-      .hasAReference()
       .usingRecursiveComparison()
       .ignoringFields("id", "createdAt")
       .isEqualTo(expected)
@@ -58,18 +56,17 @@ class TimelineEventEntityMapperTest {
       reference = reference,
       sourceReference = sourceReference,
       eventType = TimelineEventTypeEntity.STEP_UPDATED,
-      contextualInfo = null,
+      contextualInfo = emptyMap(),
       prisonId = prisonId,
     )
     val expected = aValidTimelineEvent(
       reference = reference,
       sourceReference = sourceReference,
       eventType = TimelineEventTypeDomain.STEP_UPDATED,
-      contextualInfo = null,
+      contextualInfo = emptyMap(),
       prisonId = prisonId,
-      timestamp = timelineEventEntity.timestamp!!,
-      correlationId = timelineEventEntity.correlationId!!,
-      actionedByDisplayName = null,
+      timestamp = timelineEventEntity.timestamp,
+      correlationId = timelineEventEntity.correlationId,
     )
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncConversationEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncConversationEventServiceTest.kt
@@ -49,7 +49,6 @@ class AsyncConversationEventServiceTest {
           eventType = TimelineEventType.CONVERSATION_CREATED,
           prisonId = note.createdAtPrison,
           actionedBy = note.createdBy!!,
-          actionedByDisplayName = note.createdByDisplayName,
           timestamp = note.createdAt!!,
           contextualInfo = mapOf(TimelineEventContext.CONVERSATION_TYPE to "REVIEW"),
         )
@@ -79,7 +78,6 @@ class AsyncConversationEventServiceTest {
           eventType = TimelineEventType.CONVERSATION_UPDATED,
           prisonId = note.lastUpdatedAtPrison,
           actionedBy = note.lastUpdatedBy!!,
-          actionedByDisplayName = note.lastUpdatedByDisplayName,
           timestamp = note.lastUpdatedAt!!,
           contextualInfo = mapOf(TimelineEventContext.CONVERSATION_TYPE to "REVIEW"),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncInductionEventServiceTest.kt
@@ -48,9 +48,8 @@ class AsyncInductionEventServiceTest {
           eventType = TimelineEventType.INDUCTION_CREATED,
           prisonId = createdAtPrison,
           actionedBy = induction.createdBy!!,
-          actionedByDisplayName = induction.createdByDisplayName,
           timestamp = induction.createdAt!!,
-          contextualInfo = null,
+          contextualInfo = emptyMap(),
         )
       }
 
@@ -75,9 +74,8 @@ class AsyncInductionEventServiceTest {
           eventType = TimelineEventType.INDUCTION_UPDATED,
           prisonId = lastUpdatedAtPrison,
           actionedBy = induction.lastUpdatedBy!!,
-          actionedByDisplayName = induction.lastUpdatedByDisplayName,
           timestamp = induction.lastUpdatedAt!!,
-          contextualInfo = null,
+          contextualInfo = emptyMap(),
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncReviewEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AsyncReviewEventServiceTest.kt
@@ -70,7 +70,6 @@ class AsyncReviewEventServiceTest {
       eventType = TimelineEventType.ACTION_PLAN_REVIEW_COMPLETED,
       prisonId = completedReview.createdAtPrison,
       actionedBy = completedReview.createdBy,
-      actionedByDisplayName = null,
       timestamp = completedReview.createdAt,
       contextualInfo = mapOf(
         COMPLETED_REVIEW_ENTERED_ONLINE_AT to completedReview.createdAt.toString(),
@@ -112,7 +111,6 @@ class AsyncReviewEventServiceTest {
       eventType = TimelineEventType.ACTION_PLAN_REVIEW_COMPLETED,
       prisonId = completedReview.createdAtPrison,
       actionedBy = completedReview.createdBy,
-      actionedByDisplayName = null,
       timestamp = completedReview.createdAt,
       contextualInfo = mapOf(
         COMPLETED_REVIEW_ENTERED_ONLINE_AT to completedReview.createdAt.toString(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TimelineEventFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TimelineEventFactoryTest.kt
@@ -45,8 +45,6 @@ class TimelineEventFactoryTest {
       .hasEventType(TimelineEventType.ACTION_PLAN_CREATED)
       .hasPrisonId(goal.createdAtPrison)
       .wasActionedBy(goal.lastUpdatedBy!!)
-      .wasActionedByDisplayName(goal.lastUpdatedByDisplayName!!)
-      .hasNoContextualInfo()
 
     val goalCreatedEvent = actual[1]
     assertThat(goalCreatedEvent)
@@ -54,7 +52,6 @@ class TimelineEventFactoryTest {
       .hasEventType(TimelineEventType.GOAL_CREATED)
       .hasPrisonId(goal.createdAtPrison)
       .wasActionedBy(goal.lastUpdatedBy!!)
-      .wasActionedByDisplayName(goal.lastUpdatedByDisplayName!!)
       .hasContextualInfo(mapOf(TimelineEventContext.GOAL_TITLE to goal.title))
       .hasCorrelationId(actionPlanCreatedEvent.correlationId)
   }
@@ -73,7 +70,6 @@ class TimelineEventFactoryTest {
       .hasEventType(TimelineEventType.GOAL_CREATED)
       .hasPrisonId(goal.createdAtPrison)
       .wasActionedBy(goal.lastUpdatedBy!!)
-      .wasActionedByDisplayName(goal.lastUpdatedByDisplayName!!)
       .hasContextualInfo(mapOf(TimelineEventContext.GOAL_TITLE to goal.title))
   }
 
@@ -89,7 +85,6 @@ class TimelineEventFactoryTest {
         eventType = TimelineEventType.GOAL_UPDATED,
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
-        actionedByDisplayName = updatedGoal.lastUpdatedByDisplayName!!,
         contextualInfo = mapOf(TimelineEventContext.GOAL_TITLE to updatedGoal.title),
       ),
     )
@@ -128,7 +123,6 @@ class TimelineEventFactoryTest {
         eventType = TimelineEventType.GOAL_UPDATED,
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
-        actionedByDisplayName = updatedGoal.lastUpdatedByDisplayName!!,
         contextualInfo = mapOf(TimelineEventContext.GOAL_TITLE to previousGoal.title),
       ),
       newTimelineEvent(
@@ -136,7 +130,6 @@ class TimelineEventFactoryTest {
         eventType = TimelineEventType.STEP_UPDATED,
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
-        actionedByDisplayName = updatedGoal.lastUpdatedByDisplayName!!,
         contextualInfo = mapOf(TimelineEventContext.STEP_TITLE to "Book Spanish course"),
       ),
     )
@@ -173,7 +166,6 @@ class TimelineEventFactoryTest {
         eventType = TimelineEventType.GOAL_UPDATED,
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
-        actionedByDisplayName = updatedGoal.lastUpdatedByDisplayName!!,
         contextualInfo = mapOf(TimelineEventContext.GOAL_TITLE to previousGoal.title),
       ),
       newTimelineEvent(
@@ -181,7 +173,6 @@ class TimelineEventFactoryTest {
         eventType = TimelineEventType.STEP_STARTED,
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
-        actionedByDisplayName = updatedGoal.lastUpdatedByDisplayName!!,
         contextualInfo = mapOf(TimelineEventContext.STEP_TITLE to "Book course"),
       ),
     )
@@ -234,7 +225,6 @@ class TimelineEventFactoryTest {
         eventType = TimelineEventType.GOAL_UPDATED,
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
-        actionedByDisplayName = updatedGoal.lastUpdatedByDisplayName!!,
         contextualInfo = mapOf(TimelineEventContext.GOAL_TITLE to "Learn Spanish"),
       ),
       newTimelineEvent(
@@ -242,7 +232,6 @@ class TimelineEventFactoryTest {
         eventType = TimelineEventType.STEP_COMPLETED,
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
-        actionedByDisplayName = updatedGoal.lastUpdatedByDisplayName!!,
         contextualInfo = mapOf(TimelineEventContext.STEP_TITLE to "Book Spanish course"),
       ),
       newTimelineEvent(
@@ -250,7 +239,6 @@ class TimelineEventFactoryTest {
         eventType = TimelineEventType.STEP_UPDATED,
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
-        actionedByDisplayName = updatedGoal.lastUpdatedByDisplayName!!,
         contextualInfo = mapOf(TimelineEventContext.STEP_TITLE to "Book Spanish course"),
       ),
       newTimelineEvent(
@@ -258,7 +246,6 @@ class TimelineEventFactoryTest {
         eventType = TimelineEventType.STEP_STARTED,
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
-        actionedByDisplayName = updatedGoal.lastUpdatedByDisplayName!!,
         contextualInfo = mapOf(TimelineEventContext.STEP_TITLE to "Complete course"),
       ),
     )
@@ -292,7 +279,6 @@ class TimelineEventFactoryTest {
       .hasEventType(TimelineEventType.GOAL_ARCHIVED)
       .hasPrisonId(goal.createdAtPrison)
       .wasActionedBy(goal.lastUpdatedBy!!)
-      .wasActionedByDisplayName(goal.lastUpdatedByDisplayName!!)
       .hasContextualInfo(
         mapOf(
           TimelineEventContext.GOAL_TITLE to goal.title,
@@ -319,7 +305,6 @@ class TimelineEventFactoryTest {
       .hasEventType(TimelineEventType.GOAL_ARCHIVED)
       .hasPrisonId(goal.createdAtPrison)
       .wasActionedBy(goal.lastUpdatedBy!!)
-      .wasActionedByDisplayName(goal.lastUpdatedByDisplayName!!)
       .hasContextualInfo(
         mapOf(
           TimelineEventContext.GOAL_TITLE to goal.title,
@@ -343,7 +328,6 @@ class TimelineEventFactoryTest {
       .hasEventType(TimelineEventType.GOAL_UNARCHIVED)
       .hasPrisonId(goal.createdAtPrison)
       .wasActionedBy(goal.lastUpdatedBy!!)
-      .wasActionedByDisplayName(goal.lastUpdatedByDisplayName!!)
       .hasContextualInfo(mapOf(TimelineEventContext.GOAL_TITLE to goal.title))
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEntityAssert.kt
@@ -63,21 +63,11 @@ class TimelineEntityAssert(actual: TimelineEntity?) :
     return this
   }
 
-  fun hasAReference(): TimelineEntityAssert {
-    isNotNull
-    with(actual!!) {
-      if (reference == null) {
-        failWithMessage("Expected reference to be populated, but was $reference")
-      }
-    }
-    return this
-  }
-
   fun hasNumberOfEvents(numberOfEvents: Int): TimelineEntityAssert {
     isNotNull
     with(actual!!) {
-      if (events!!.size != numberOfEvents) {
-        failWithMessage("Expected Timeline to be have $numberOfEvents events, but has ${events!!.size}")
+      if (events.size != numberOfEvents) {
+        failWithMessage("Expected Timeline to be have $numberOfEvents events, but has ${events.size}")
       }
     }
     return this
@@ -91,7 +81,7 @@ class TimelineEntityAssert(actual: TimelineEntity?) :
   fun event(eventNumber: Int, consumer: Consumer<TimelineEventEntityAssert>): TimelineEntityAssert {
     isNotNull
     with(actual!!) {
-      val event = events!![eventNumber]
+      val event = events[eventNumber]
       consumer.accept(assertThat(event))
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEntityBuilder.kt
@@ -5,17 +5,18 @@ import java.time.Instant
 import java.util.UUID
 
 fun aValidTimelineEntity(
-  id: UUID = UUID.randomUUID(),
+  id: UUID? = UUID.randomUUID(),
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = aValidPrisonNumber(),
   events: MutableList<TimelineEventEntity> = mutableListOf(aValidTimelineEventEntity()),
-  createdAt: Instant = Instant.now(),
-  updatedAt: Instant = Instant.now(),
+  createdAt: Instant? = Instant.now(),
+  updatedAt: Instant? = Instant.now(),
 ) = TimelineEntity(
-  id = id,
   reference = reference,
   prisonNumber = prisonNumber,
   events = events,
-  createdAt = createdAt,
-  updatedAt = updatedAt,
-)
+).apply {
+  this.id = id
+  this.createdAt = createdAt
+  this.updatedAt = updatedAt
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEventEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEventEntityAssert.kt
@@ -52,16 +52,6 @@ class TimelineEventEntityAssert(actual: TimelineEventEntity?) :
     return this
   }
 
-  fun wasActionedByDisplayName(expected: String): TimelineEventEntityAssert {
-    isNotNull
-    with(actual!!) {
-      if (actionedByDisplayName != expected) {
-        failWithMessage("Expected actionedByDisplayName to be $expected, but was $actionedByDisplayName")
-      }
-    }
-    return this
-  }
-
   fun wasCreatedAt(expected: Instant): TimelineEventEntityAssert {
     isNotNull
     with(actual!!) {
@@ -77,16 +67,6 @@ class TimelineEventEntityAssert(actual: TimelineEventEntity?) :
     with(actual!!) {
       if (prisonId != expected) {
         failWithMessage("Expected prisonId to be $expected, but was $prisonId")
-      }
-    }
-    return this
-  }
-
-  fun hasAReference(): TimelineEventEntityAssert {
-    isNotNull
-    with(actual!!) {
-      if (reference == null) {
-        failWithMessage("Expected reference to be populated, but was $reference")
       }
     }
     return this
@@ -117,16 +97,6 @@ class TimelineEventEntityAssert(actual: TimelineEventEntity?) :
     with(actual!!) {
       if (contextualInfo != expected) {
         failWithMessage("Expected contextualInfo to be $expected, but was $contextualInfo")
-      }
-    }
-    return this
-  }
-
-  fun hasNoContextualInfo(): TimelineEventEntityAssert {
-    isNotNull
-    with(actual!!) {
-      if (contextualInfo != null) {
-        failWithMessage("Expected contextualInfo to be null, but was $contextualInfo")
       }
     }
     return this

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEventEntityBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/timeline/TimelineEventEntityBuilder.kt
@@ -8,23 +8,22 @@ fun aValidTimelineEventEntity(
   reference: UUID = UUID.randomUUID(),
   sourceReference: String = UUID.randomUUID().toString(),
   eventType: TimelineEventType = TimelineEventType.GOAL_CREATED,
-  contextualInfo: Map<TimelineEventContext, String>? = null,
+  contextualInfo: Map<TimelineEventContext, String> = emptyMap(),
   prisonId: String = "BXI",
   actionedBy: String = "asmith_gen",
-  actionedByDisplayName: String? = "Alex Smith",
   timestamp: Instant = Instant.now(),
   createdAt: Instant = Instant.now(),
   correlationId: UUID = UUID.randomUUID(),
 ) = TimelineEventEntity(
-  id = id,
   reference = reference,
   sourceReference = sourceReference,
   eventType = eventType,
   contextualInfo = contextualInfo,
   prisonId = prisonId,
   actionedBy = actionedBy,
-  actionedByDisplayName = actionedByDisplayName,
   timestamp = timestamp,
-  createdAt = createdAt,
   correlationId = correlationId,
-)
+).apply {
+  this.id = id
+  this.createdAt = createdAt
+}


### PR DESCRIPTION
This PR is the first of a few very similar ones that we'll need to do over the next couple of weeks , and is related to the RBAC work.

RBAC is going to become important again soon because we need to have different roles etc for users who can do reviews etc; and in order to do the RBAC work (more specifically, to create granular roles) we need the UI to not use the user token, and instead use the system token. 
We've done this work for the read operations that the UI makes 👍 , but not the write operations yet. In preparation for doing the changes to the write operations (to use the system token) we need to remove the code in the API that writes the "display name" fields to the database entities via the custom annotation that uses the username claim from the token. (ie. before we can get the UI to use the system token that will not carry a username claim, we need to remove the code that reads it and writes it to the database, otherwise we'll get NPEs etc)

As you can see in this PR it's quite a lot of change (but it is mostly deletes, with a little refactoring around the edges), so I'm proposing (and we have tickets) to do each entity (or logical group of entities) at a time (rather than the whole lot in one massive PR)

This PR is the first in this sequence, and addresses the TimelineEvent entity.

