### PR TITLE
RR-1020 - Exempt prisoners Review on prisoner.released event (due to death)

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
@@ -63,7 +63,9 @@ class ReviewScheduleService(
           reviewSchedule = this,
           newStatus = ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE,
           exemptionReason = null,
-        )
+        ).also {
+          log.debug { "Review Schedule for prisoner [$prisonNumber] set to exempt: EXEMPT_PRISONER_RELEASE" }
+        }
       }
       ?: throw ReviewScheduleNotFoundException(prisonNumber)
 
@@ -82,7 +84,9 @@ class ReviewScheduleService(
           reviewSchedule = this,
           newStatus = ReviewScheduleStatus.EXEMPT_PRISONER_DEATH,
           exemptionReason = null,
-        )
+        ).also {
+          log.debug { "Review Schedule for prisoner [$prisonNumber] set to exempt: EXEMPT_PRISONER_DEATH" }
+        }
       }
       ?: throw ReviewScheduleNotFoundException(prisonNumber)
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedDueToDeathEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedDueToDeathEventTest.kt
@@ -15,9 +15,9 @@ import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleStatus as ReviewScheduleStatusEntity
 
 @Isolated
-class PrisonerReleasedEventTest : IntegrationTestBase() {
+class PrisonerReleasedDueToDeathEventTest : IntegrationTestBase() {
   @Test
-  fun `should update Review Schedule given released prisoner has an active Review Schedule`() {
+  fun `should update Review Schedule given deceased prisoner had an active Review Schedule`() {
     // Given
     // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
     val prisonNumber = aValidPrisonNumber()
@@ -36,7 +36,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
       eventType = PRISONER_RELEASED_FROM_PRISON,
       additionalInformation = aValidPrisonerReleasedAdditionalInformation(
         prisonNumber = prisonNumber,
-        nomisMovementReasonCode = "CR",
+        nomisMovementReasonCode = "DEC",
       ),
     )
 
@@ -52,7 +52,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
     val actionPlanReviews = getActionPlanReviews(prisonNumber)
     assertThat(actionPlanReviews)
       .latestReviewSchedule {
-        it.hasStatus(ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE)
+        it.hasStatus(ReviewScheduleStatus.EXEMPT_PRISONER_DEATH)
       }
   }
 
@@ -77,7 +77,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
       eventType = PRISONER_RELEASED_FROM_PRISON,
       additionalInformation = aValidPrisonerReleasedAdditionalInformation(
         prisonNumber = prisonNumber,
-        nomisMovementReasonCode = "CR",
+        nomisMovementReasonCode = "DEC",
       ),
     )
 
@@ -108,7 +108,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
       eventType = PRISONER_RELEASED_FROM_PRISON,
       additionalInformation = aValidPrisonerReleasedAdditionalInformation(
         prisonNumber = prisonNumber,
-        nomisMovementReasonCode = "CR",
+        nomisMovementReasonCode = "DEC",
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformation.kt
@@ -52,6 +52,9 @@ sealed class AdditionalInformation {
     val prisonId: String,
     val nomisMovementReasonCode: String,
   ) : AdditionalInformation() {
+
+    val releaseTriggeredByPrisonerDeath: Boolean = nomisMovementReasonCode == "DEC"
+
     enum class Reason {
       TEMPORARY_ABSENCE_RELEASE,
       RELEASED_TO_HOSPITAL,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedFromPrisonEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedFromPrisonEventServiceTest.kt
@@ -54,6 +54,30 @@ class PrisonerReleasedFromPrisonEventServiceTest {
   }
 
   @Test
+  fun `should process event given reason is prisoner released due to death`() {
+    // Given
+    val additionalInformation = PrisonerReleasedAdditionalInformation(
+      nomsNumber = "A1234BC",
+      reason = RELEASED,
+      prisonId = "BXI",
+      nomisMovementReasonCode = "DEC",
+      details = null,
+      currentLocation = null,
+      currentPrisonStatus = null,
+    )
+    val inboundEvent = anInboundEvent(additionalInformation)
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(reviewScheduleService).exemptActiveReviewScheduleStatusDueToPrisonerDeath(
+      prisonNumber = "A1234BC",
+      prisonId = "BXI",
+    )
+  }
+
+  @Test
   fun `should process event given reason is prisoner released but prisoner does not have an active Review Schedule`() {
     // Given
     val additionalInformation = PrisonerReleasedAdditionalInformation(
@@ -75,6 +99,33 @@ class PrisonerReleasedFromPrisonEventServiceTest {
 
     // Then
     verify(reviewScheduleService).exemptActiveReviewScheduleStatusDueToPrisonerRelease(
+      prisonNumber = "A1234BC",
+      prisonId = "BXI",
+    )
+  }
+
+  @Test
+  fun `should process event given reason is prisoner released due to death but prisoner does not have an active Review Schedule`() {
+    // Given
+    val additionalInformation = PrisonerReleasedAdditionalInformation(
+      nomsNumber = "A1234BC",
+      reason = RELEASED,
+      prisonId = "BXI",
+      nomisMovementReasonCode = "DEC",
+      details = null,
+      currentLocation = null,
+      currentPrisonStatus = null,
+    )
+    val inboundEvent = anInboundEvent(additionalInformation)
+
+    given(reviewScheduleService.exemptActiveReviewScheduleStatusDueToPrisonerDeath(any(), any()))
+      .willThrow(ReviewScheduleNotFoundException("A1234BC"))
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(reviewScheduleService).exemptActiveReviewScheduleStatusDueToPrisonerDeath(
       prisonNumber = "A1234BC",
       prisonId = "BXI",
     )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformationBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformationBuilder.kt
@@ -8,16 +8,18 @@ fun aValidPrisonerReceivedAdditionalInformation(
   prisonNumber: String = aValidPrisonNumber(),
   prisonId: String = "BXI",
   reason: PrisonerReceivedAdditionalInformation.Reason = PrisonerReceivedAdditionalInformation.Reason.ADMISSION,
+  details: String? = "ACTIVE IN:ADM-N",
   currentLocation: PrisonerReceivedAdditionalInformation.Location = PrisonerReceivedAdditionalInformation.Location.IN_PRISON,
   currentPrisonStatus: PrisonerReceivedAdditionalInformation.PrisonStatus = PrisonerReceivedAdditionalInformation.PrisonStatus.UNDER_PRISON_CARE,
+  nomisMovementReasonCode: String = "N",
 ): PrisonerReceivedAdditionalInformation =
   PrisonerReceivedAdditionalInformation(
     nomsNumber = prisonNumber,
     reason = reason,
-    details = "ACTIVE IN:ADM-N",
+    details = details,
     currentLocation = currentLocation,
     prisonId = prisonId,
-    nomisMovementReasonCode = "N",
+    nomisMovementReasonCode = nomisMovementReasonCode,
     currentPrisonStatus = currentPrisonStatus,
   )
 
@@ -25,15 +27,17 @@ fun aValidPrisonerReleasedAdditionalInformation(
   prisonNumber: String = aValidPrisonNumber(),
   prisonId: String = "BXI",
   reason: PrisonerReleasedAdditionalInformation.Reason = PrisonerReleasedAdditionalInformation.Reason.RELEASED,
+  details: String? = "Movement reason code CR",
   currentLocation: PrisonerReleasedAdditionalInformation.Location = PrisonerReleasedAdditionalInformation.Location.OUTSIDE_PRISON,
   currentPrisonStatus: PrisonerReleasedAdditionalInformation.PrisonStatus = PrisonerReleasedAdditionalInformation.PrisonStatus.NOT_UNDER_PRISON_CARE,
+  nomisMovementReasonCode: String = "CR",
 ): PrisonerReleasedAdditionalInformation =
   PrisonerReleasedAdditionalInformation(
     nomsNumber = prisonNumber,
     reason = reason,
-    details = "ACTIVE IN:ADM-N",
+    details = details,
     currentLocation = currentLocation,
     prisonId = prisonId,
-    nomisMovementReasonCode = "N",
+    nomisMovementReasonCode = nomisMovementReasonCode,
     currentPrisonStatus = currentPrisonStatus,
   )


### PR DESCRIPTION
This PR continues the work re: automatically exempting a prisoners Review due to the `prisoner.released` event.

A previous PR added the basic code to listen to the `prisoner.released` event and exempt the prisoner's Review Schedule; though that PR did not consider _why_ the prisoner had been released (`nomisReasonCode`)

This PR changes that so that if the prisoner is released the Review Schedule is exempted with status `EXEMPT_PRISONER_RELEASE`

But if they are released due to death (`nomisReasonCode == DEC`), then the Review Schedule is exempted with status `EXEMPT_PRISONER_DEATH`

