### PR TITLE
RR-1198 - Initial InductionScheduleDateCalculationService

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service
+
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
+import java.time.LocalDate
+
+/**
+ * Service class exposing methods that implement the business rules for calculating Induction Schedule dates.
+ *
+ * This class is deliberately final so that it cannot be subclassed, ensuring that the business rules stay within the
+ * domain.
+ */
+class InductionScheduleDateCalculationService {
+  companion object {
+    private const val EXEMPTION_ADDITIONAL_DAYS = 5L
+    private const val EXCLUSION_ADDITIONAL_DAYS = 10L
+    private const val SYSTEM_OUTAGE_ADDITIONAL_DAYS = 5L
+  }
+
+  fun calculateAdjustedInductionDueDate(inductionSchedule: InductionSchedule): LocalDate =
+    with(inductionSchedule) {
+      val additionalDays = getExtensionDays(scheduleStatus)
+      val todayPlusAdditionalDays = LocalDate.now().plusDays(additionalDays)
+      maxOf(todayPlusAdditionalDays, deadlineDate)
+    }
+
+  private fun getExtensionDays(status: InductionScheduleStatus): Long =
+    when {
+      status.isExclusion -> EXCLUSION_ADDITIONAL_DAYS
+      status.isExemption -> EXEMPTION_ADDITIONAL_DAYS
+      status == InductionScheduleStatus.EXEMPT_SYSTEM_TECHNICAL_ISSUE -> SYSTEM_OUTAGE_ADDITIONAL_DAYS
+      else -> 0 // Default case, if no condition matches
+    }
+}

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
@@ -7,13 +7,12 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.Upd
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.UpdateInductionScheduleStatusDto
 import java.time.LocalDate
 
-private const val EXEMPTION_ADDITIONAL_DAYS = 5L
-private const val EXCLUSION_ADDITIONAL_DAYS = 10L
-private const val SYSTEM_OUTAGE_ADDITIONAL_DAYS = 5L
 class InductionScheduleService(
   private val inductionSchedulePersistenceAdapter: InductionSchedulePersistenceAdapter,
   private val inductionScheduleEventService: InductionScheduleEventService,
 ) {
+
+  private val inductionScheduleDateCalculationService = InductionScheduleDateCalculationService()
 
   private val inductionScheduleStatusTransitionValidator = InductionScheduleStatusTransitionValidator()
 
@@ -68,12 +67,12 @@ class InductionScheduleService(
     inductionSchedule: InductionSchedule,
     prisonNumber: String,
   ) {
-    val newInductionDate = calculateNewInductionDate(inductionSchedule)
+    val adjustedInductionDate = inductionScheduleDateCalculationService.calculateAdjustedInductionDueDate(inductionSchedule)
     val updatedInductionSchedule = inductionSchedulePersistenceAdapter.updateInductionScheduleStatus(
       UpdateInductionScheduleStatusDto(
         reference = inductionSchedule.reference,
         scheduleStatus = InductionScheduleStatus.SCHEDULED,
-        latestDeadlineDate = newInductionDate,
+        latestDeadlineDate = adjustedInductionDate,
         prisonNumber = prisonNumber,
       ),
     )
@@ -104,13 +103,13 @@ class InductionScheduleService(
       oldDeadlineDate = inductionSchedule.deadlineDate,
     )
 
-    // Then update the induction schedule to be SCHEDULED with a new induction date
-    val newInductionDate = calculateNewInductionDate(inductionSchedule, SYSTEM_OUTAGE_ADDITIONAL_DAYS)
+    // Then update the induction schedule to be SCHEDULED with an adjusted induction date
+    val adjustedInductionDate = inductionScheduleDateCalculationService.calculateAdjustedInductionDueDate(updatedInductionScheduleFirst)
     val updatedInductionScheduleSecond = inductionSchedulePersistenceAdapter.updateInductionScheduleStatus(
       UpdateInductionScheduleStatusDto(
         reference = inductionSchedule.reference,
         scheduleStatus = InductionScheduleStatus.SCHEDULED,
-        latestDeadlineDate = newInductionDate,
+        latestDeadlineDate = adjustedInductionDate,
         prisonNumber = prisonNumber,
       ),
     )
@@ -119,22 +118,6 @@ class InductionScheduleService(
       oldStatus = inductionSchedule.scheduleStatus,
       oldDeadlineDate = inductionSchedule.deadlineDate,
     )
-  }
-
-  private fun calculateNewInductionDate(
-    inductionSchedule: InductionSchedule,
-    additionalDays: Long = getExtensionDays(inductionSchedule.scheduleStatus),
-  ): LocalDate? {
-    val todayPlusAdditionalDays = LocalDate.now().plusDays(additionalDays)
-    return maxOf(todayPlusAdditionalDays, inductionSchedule.deadlineDate)
-  }
-
-  private fun getExtensionDays(status: InductionScheduleStatus): Long {
-    return when {
-      status.isExclusion -> EXCLUSION_ADDITIONAL_DAYS
-      status.isExemption -> EXEMPTION_ADDITIONAL_DAYS
-      else -> 0 // Default case, if no condition matches
-    }
   }
 
   private fun performFollowOnEvents(

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
@@ -1,0 +1,198 @@
+package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidInductionSchedule
+import java.time.LocalDate
+
+class InductionScheduleDateCalculationServiceTest {
+  companion object {
+    private val TODAY = LocalDate.now()
+  }
+
+  private val dateCalculationService = InductionScheduleDateCalculationService()
+
+  @Nested
+  inner class CalculateAdjustedInductionDueDate {
+    @ParameterizedTest
+    @CsvSource(
+      value = [
+        "EXEMPT_PRISONER_DRUG_OR_ALCOHOL_DEPENDENCY",
+        "EXEMPT_PRISONER_OTHER_HEALTH_ISSUES",
+        "EXEMPT_SECURITY_ISSUE_RISK_TO_STAFF",
+        "EXEMPT_PRISONER_SAFETY_ISSUES",
+        "EXEMPT_PRISON_REGIME_CIRCUMSTANCES",
+      ],
+    )
+    fun `should calculate adjusted induction due date given an exemption status that is classed as an exclusion and the induction due date is later than the calculated date`(
+      scheduleStatus: InductionScheduleStatus,
+    ) {
+      // Given
+      val inductionSchedule = aValidInductionSchedule(
+        deadlineDate = TODAY.plusDays(11),
+        scheduleStatus = scheduleStatus,
+      )
+
+      val expectedReviewDate = TODAY.plusDays(11)
+
+      // When
+      val actual = dateCalculationService.calculateAdjustedInductionDueDate(inductionSchedule)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedReviewDate)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+      value = [
+        "EXEMPT_PRISONER_DRUG_OR_ALCOHOL_DEPENDENCY",
+        "EXEMPT_PRISONER_OTHER_HEALTH_ISSUES",
+        "EXEMPT_SECURITY_ISSUE_RISK_TO_STAFF",
+        "EXEMPT_PRISONER_SAFETY_ISSUES",
+        "EXEMPT_PRISON_REGIME_CIRCUMSTANCES",
+      ],
+    )
+    fun `should calculate adjusted induction due date given an exemption status that is classed as an exclusion and the induction due date is earlier than the calculated date`(
+      scheduleStatus: InductionScheduleStatus,
+    ) {
+      // Given
+      val inductionSchedule = aValidInductionSchedule(
+        deadlineDate = TODAY.plusDays(9),
+        scheduleStatus = scheduleStatus,
+      )
+
+      val expectedReviewDate = TODAY.plusDays(10)
+
+      // When
+      val actual = dateCalculationService.calculateAdjustedInductionDueDate(inductionSchedule)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedReviewDate)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+      value = [
+        "EXEMPT_PRISONER_FAILED_TO_ENGAGE",
+        "EXEMPT_PRISONER_ESCAPED_OR_ABSCONDED",
+        "EXEMPT_PRISON_STAFF_REDEPLOYMENT",
+        "EXEMPT_PRISON_OPERATION_OR_SECURITY_ISSUE",
+        "EXEMPT_PRISONER_TRANSFER",
+        "EXEMPT_PRISONER_RELEASE",
+        "EXEMPT_PRISONER_DEATH",
+        "EXEMPT_SCREENING_AND_ASSESSMENT_IN_PROGRESS",
+        "EXEMPT_SCREENING_AND_ASSESSMENT_INCOMPLETE",
+      ],
+    )
+    fun `should calculate adjusted induction due date given an exemption status that is classed as an exemption and the induction due date is later than the calculated date`(
+      scheduleStatus: InductionScheduleStatus,
+    ) {
+      // Given
+      val inductionSchedule = aValidInductionSchedule(
+        deadlineDate = TODAY.plusDays(6),
+        scheduleStatus = scheduleStatus,
+      )
+
+      val expectedReviewDate = TODAY.plusDays(6)
+
+      // When
+      val actual = dateCalculationService.calculateAdjustedInductionDueDate(inductionSchedule)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedReviewDate)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+      value = [
+        "EXEMPT_PRISONER_FAILED_TO_ENGAGE",
+        "EXEMPT_PRISONER_ESCAPED_OR_ABSCONDED",
+        "EXEMPT_PRISON_STAFF_REDEPLOYMENT",
+        "EXEMPT_PRISON_OPERATION_OR_SECURITY_ISSUE",
+        "EXEMPT_PRISONER_TRANSFER",
+        "EXEMPT_PRISONER_RELEASE",
+        "EXEMPT_PRISONER_DEATH",
+      ],
+    )
+    fun `should calculate adjusted induction due date given an exemption status that is classed as an exemption and the induction due date is earlier than the calculated date`(
+      scheduleStatus: InductionScheduleStatus,
+    ) {
+      // Given
+      val inductionSchedule = aValidInductionSchedule(
+        deadlineDate = TODAY.plusDays(4),
+        scheduleStatus = scheduleStatus,
+      )
+
+      val expectedReviewDate = TODAY.plusDays(5)
+
+      // When
+      val actual = dateCalculationService.calculateAdjustedInductionDueDate(inductionSchedule)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedReviewDate)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+      value = [
+        "SCHEDULED",
+        "COMPLETED",
+      ],
+    )
+    fun `should calculate adjusted induction due date given a status that not an exemption status`(
+      scheduleStatus: InductionScheduleStatus,
+    ) {
+      // Given
+      val inductionSchedule = aValidInductionSchedule(
+        deadlineDate = TODAY.plusDays(1),
+        scheduleStatus = scheduleStatus,
+      )
+
+      val expectedReviewDate = TODAY.plusDays(1)
+
+      // When
+      val actual = dateCalculationService.calculateAdjustedInductionDueDate(inductionSchedule)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedReviewDate)
+    }
+
+    @Test
+    fun `should calculate adjusted induction due date given EXEMPT_SYSTEM_TECHNICAL_ISSUE and the induction due date is later than the calculated date`() {
+      // Given
+      val inductionSchedule = aValidInductionSchedule(
+        deadlineDate = TODAY.plusDays(6),
+        scheduleStatus = InductionScheduleStatus.EXEMPT_SYSTEM_TECHNICAL_ISSUE,
+      )
+
+      val expectedReviewDate = TODAY.plusDays(6)
+
+      // When
+      val actual = dateCalculationService.calculateAdjustedInductionDueDate(inductionSchedule)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedReviewDate)
+    }
+
+    @Test
+    fun `should calculate adjusted induction due date given EXEMPT_SYSTEM_TECHNICAL_ISSUE and the induction due date is earlier than the calculated date`() {
+      // Given
+      val inductionSchedule = aValidInductionSchedule(
+        deadlineDate = TODAY.plusDays(4),
+        scheduleStatus = InductionScheduleStatus.EXEMPT_SYSTEM_TECHNICAL_ISSUE,
+      )
+
+      val expectedReviewDate = TODAY.plusDays(5)
+
+      // When
+      val actual = dateCalculationService.calculateAdjustedInductionDueDate(inductionSchedule)
+
+      // Then
+      assertThat(actual).isEqualTo(expectedReviewDate)
+    }
+  }
+}

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleCalculationServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleCalculationServiceTest.kt
@@ -28,7 +28,7 @@ class ReviewScheduleCalculationServiceTest {
         "EXEMPT_PRISON_REGIME_CIRCUMSTANCES",
       ],
     )
-    fun `should calculate adjusted review due date given an exception status that is classed as an exclusion and the review due date is later than the calculated date`(
+    fun `should calculate adjusted review due date given an exemption status that is classed as an exclusion and the review due date is later than the calculated date`(
       scheduleStatus: ReviewScheduleStatus,
     ) {
       // Given
@@ -56,7 +56,7 @@ class ReviewScheduleCalculationServiceTest {
         "EXEMPT_PRISON_REGIME_CIRCUMSTANCES",
       ],
     )
-    fun `should calculate adjusted review due date given an exception status that is classed as an exclusion and the review due date is earlier than the calculated date`(
+    fun `should calculate adjusted review due date given an exemption status that is classed as an exclusion and the review due date is earlier than the calculated date`(
       scheduleStatus: ReviewScheduleStatus,
     ) {
       // Given
@@ -86,7 +86,7 @@ class ReviewScheduleCalculationServiceTest {
         "EXEMPT_PRISONER_DEATH",
       ],
     )
-    fun `should calculate adjusted review due date given an exception status that is classed as an exception and the review due date is later than the calculated date`(
+    fun `should calculate adjusted review due date given an exemption status that is classed as an exemption and the review due date is later than the calculated date`(
       scheduleStatus: ReviewScheduleStatus,
     ) {
       // Given
@@ -116,7 +116,7 @@ class ReviewScheduleCalculationServiceTest {
         "EXEMPT_PRISONER_DEATH",
       ],
     )
-    fun `should calculate adjusted review due date given an exception status that is classed as an exception and the review due date is earlier than the calculated date`(
+    fun `should calculate adjusted review due date given an exemption status that is classed as an exemption and the review due date is earlier than the calculated date`(
       scheduleStatus: ReviewScheduleStatus,
     ) {
       // Given


### PR DESCRIPTION
Initial `InductionScheduleDateCalculationService` and basic refactoring

This follows a similar pattern to what we did earlier with the `ReviewScheduleDateCalculationService`, I have introduced the class `InductionScheduleDateCalculationService` with the view that all Induction Schedule date calc logic lives in one place.
At the moment I've only moved some of the logic from other classes into it - we can move some more in subsequent PRs