### PR TITLE
RR-1198 - Move getReviewSchedulesForPrisoner to ReviewScheduleService

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.servi
 
 import mu.KotlinLogging
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleHistory
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNotFoundException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.UpdatedReviewScheduleStatus
@@ -18,6 +19,19 @@ class ReviewScheduleService(
   private val reviewScheduleDateCalculationService = ReviewScheduleDateCalculationService()
 
   private val reviewScheduleStatusTransitionValidator = ReviewScheduleStatusTransitionValidator()
+
+  /**
+   * Returns a list of [ReviewSchedule] for the prisoner identified by their prison number.
+   */
+  fun getReviewSchedulesForPrisoner(prisonNumber: String): List<ReviewScheduleHistory> {
+    val responses = reviewSchedulePersistenceAdapter
+      .getReviewScheduleHistory(prisonNumber)
+
+    return responses.sortedWith(
+      compareByDescending<ReviewScheduleHistory> { it.lastUpdatedAt }
+        .thenByDescending { it.version },
+    )
+  }
 
   fun updateLatestReviewScheduleStatus(
     prisonNumber: String,

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewService.kt
@@ -4,7 +4,6 @@ import mu.KotlinLogging
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ActiveReviewScheduleAlreadyExistsException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.CompletedReview
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewSchedule
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleHistory
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNoReleaseDateForSentenceTypeException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNotFoundException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.SentenceType
@@ -54,19 +53,6 @@ class ReviewService(
     reviewSchedulePersistenceAdapter.getLatestReviewSchedule(prisonNumber) ?: throw ReviewScheduleNotFoundException(
       prisonNumber,
     )
-
-  /**
-   * Returns a list of [ReviewSchedule] for the prisoner identified by their prison number.
-   */
-  fun getReviewSchedulesForPrisoner(prisonNumber: String): List<ReviewScheduleHistory> {
-    val responses = reviewSchedulePersistenceAdapter
-      .getReviewScheduleHistory(prisonNumber)
-
-    return responses.sortedWith(
-      compareByDescending<ReviewScheduleHistory> { it.lastUpdatedAt }
-        .thenByDescending { it.version },
-    )
-  }
 
   /**
    * Returns a list of all [CompletedReview]s for the prisoner identified by their prison number. An empty list is

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceTest.kt
@@ -14,12 +14,7 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNotFoundException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidCompletedReview
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidReviewSchedule
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidReviewScheduleHistory
-import java.time.Instant
-import java.time.LocalDate
-import java.time.temporal.ChronoUnit.DAYS
-import java.time.temporal.ChronoUnit.MINUTES
-import java.util.UUID
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 
 @ExtendWith(MockitoExtension::class)
 class ReviewServiceTest {
@@ -36,8 +31,7 @@ class ReviewServiceTest {
   private lateinit var reviewSchedulePersistenceAdapter: ReviewSchedulePersistenceAdapter
 
   companion object {
-    private const val PRISON_NUMBER = "A1234AB"
-    private val TODAY = LocalDate.now()
+    private val PRISON_NUMBER = randomValidPrisonNumber()
   }
 
   @Nested
@@ -120,85 +114,6 @@ class ReviewServiceTest {
       // Then
       assertThat(actual).isEqualTo(expected)
       verify(reviewPersistenceAdapter).getCompletedReviews(PRISON_NUMBER)
-    }
-  }
-
-  @Nested
-  inner class GetReviewSchedulesForPrisoner {
-    @Test
-    fun `should get review schedules for prisoner, sorted by last updated and version`() {
-      // Given
-      val now = Instant.now()
-      val reviewSchedule1Reference = UUID.randomUUID()
-      val reviewSchedule2Reference = UUID.randomUUID()
-      val reviewSchedule3Reference = UUID.randomUUID()
-
-      given(reviewSchedulePersistenceAdapter.getReviewScheduleHistory(any())).willReturn(
-        listOf(
-          aValidReviewScheduleHistory(
-            reference = reviewSchedule3Reference,
-            version = 2,
-            lastUpdatedAt = now.minus(1, MINUTES),
-          ),
-          aValidReviewScheduleHistory(
-            reference = reviewSchedule3Reference,
-            version = 1,
-            lastUpdatedAt = now.minus(10, MINUTES),
-          ),
-          aValidReviewScheduleHistory(
-            reference = reviewSchedule1Reference,
-            version = 2,
-            lastUpdatedAt = now.minus(365, DAYS),
-          ),
-          aValidReviewScheduleHistory(
-            reference = reviewSchedule2Reference,
-            version = 1,
-            lastUpdatedAt = now.minus(5, DAYS),
-          ),
-          aValidReviewScheduleHistory(
-            reference = reviewSchedule1Reference,
-            version = 1,
-            lastUpdatedAt = now.minus(400, DAYS),
-          ),
-          aValidReviewScheduleHistory(
-            reference = reviewSchedule2Reference,
-            version = 2,
-            lastUpdatedAt = now.minus(4, DAYS),
-          ),
-        ),
-      )
-
-      val expected = listOf(
-        // Review schedule 3 first as it's updated dates are the most recent
-        "Reference: $reviewSchedule3Reference; Version: 2",
-        "Reference: $reviewSchedule3Reference; Version: 1",
-        // Review schedule 2 next
-        "Reference: $reviewSchedule2Reference; Version: 2",
-        "Reference: $reviewSchedule2Reference; Version: 1",
-        // Review schedule 1 last as it's updated dates are the earliest
-        "Reference: $reviewSchedule1Reference; Version: 2",
-        "Reference: $reviewSchedule1Reference; Version: 1",
-      )
-
-      // When
-      val actual = service.getReviewSchedulesForPrisoner(PRISON_NUMBER)
-
-      // Then
-      assertThat(actual.map { "Reference: ${it.reference}; Version: ${it.version}" }).isEqualTo(expected)
-      verify(reviewSchedulePersistenceAdapter).getReviewScheduleHistory(PRISON_NUMBER)
-    }
-
-    @Test
-    fun `should get review schedules given prisoner has no previous review schedules`() {
-      // Given
-      given(reviewSchedulePersistenceAdapter.getReviewScheduleHistory(any())).willReturn(emptyList())
-
-      // When
-      val actual = service.getReviewSchedulesForPrisoner(PRISON_NUMBER)
-
-      // Then
-      assertThat(actual).isEmpty()
-      verify(reviewSchedulePersistenceAdapter).getReviewScheduleHistory(PRISON_NUMBER)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ReviewController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ReviewController.kt
@@ -108,7 +108,7 @@ class ReviewController(
   fun getActionPlanReviewSchedules(
     @PathVariable @Pattern(regexp = PRISON_NUMBER_FORMAT) prisonNumber: String,
   ): ActionPlanReviewSchedulesResponse {
-    val reviewSchedules = reviewService.getReviewSchedulesForPrisoner(prisonNumber)
+    val reviewSchedules = reviewScheduleService.getReviewSchedulesForPrisoner(prisonNumber)
     return ActionPlanReviewSchedulesResponse(
       reviewSchedules = reviewSchedules.map { reviewScheduleHistoryResponseMapper.fromDomainToModel(it) },
     )


### PR DESCRIPTION
This PR is part of some tidying/refactoring of InductionSchedules and how they are calculated, but also ReviewSchedules where it makes sense (as they are so closely related)

This PR moves the function `getReviewSchedulesForPrisoner` from `ReviewService` to `ReviewScheduleService` which is a more logical place for it.

There are a couple of other "review schedule" related functions that are currently in `ReviewService` that I will look at moving to `ReviewScheduleService` shortly ... 🤔 