### PR TITLE
Fix `GetGoalsTest`

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
@@ -316,7 +316,6 @@ class ArchiveGoalTest : IntegrationTestBase() {
     )
     createActionPlan(
       username = "auser_gen",
-      displayName = "Albert User",
       prisonNumber = prisonNumber,
       createActionPlanRequest = createActionPlanRequest,
     )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CompleteGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CompleteGoalTest.kt
@@ -289,7 +289,6 @@ class CompleteGoalTest : IntegrationTestBase() {
     )
     createActionPlan(
       username = "auser_gen",
-      displayName = "Albert User",
       prisonNumber = prisonNumber,
       createActionPlanRequest = createActionPlanRequest,
     )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
@@ -333,7 +333,6 @@ class UnarchiveGoalTest : IntegrationTestBase() {
     )
     createActionPlan(
       username = "auser_gen",
-      displayName = "Albert User",
       prisonNumber = prisonNumber,
       createActionPlanRequest = createActionPlanRequest,
     )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -198,7 +198,6 @@ class UpdateGoalTest : IntegrationTestBase() {
     val prisonNumber = aValidPrisonNumber()
     createActionPlan(
       username = "auser_gen",
-      displayName = "Albert User",
       prisonNumber = prisonNumber,
       createActionPlanRequest = aValidCreateActionPlanRequest(
         goals = listOf(
@@ -321,7 +320,6 @@ class UpdateGoalTest : IntegrationTestBase() {
     val prisonNumber = aValidPrisonNumber()
     createActionPlan(
       username = "auser_gen",
-      displayName = "Albert User",
       prisonNumber = prisonNumber,
       createActionPlanRequest = aValidCreateActionPlanRequest(
         goals = listOf(
@@ -444,7 +442,6 @@ class UpdateGoalTest : IntegrationTestBase() {
     val prisonNumber = aValidPrisonNumber()
     createActionPlan(
       username = "auser_gen",
-      displayName = "Albert User",
       prisonNumber = prisonNumber,
       createActionPlanRequest = aValidCreateActionPlanRequest(
         goals = listOf(

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GetGoalsResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/GetGoalsResponseAssert.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GetGoalsResponse
+import java.util.*
+import java.util.function.Consumer
+
+fun assertThat(actual: GetGoalsResponse?) = GetGoalsResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [GetGoalsResponse]
+ */
+class GetGoalsResponseAssert(actual: GetGoalsResponse?) :
+  AbstractObjectAssert<GetGoalsResponseAssert, GetGoalsResponse?>(actual, GetGoalsResponseAssert::class.java) {
+
+  fun hasNumberOfGoals(expected: Int): GetGoalsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (goals.size != expected) {
+        failWithMessage("Expected $expected goals but there were ${goals.size} goals")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [GoalResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [GoalResponseAssert].
+   * Returns this [GetGoalsResponseAssert] to allow further chained assertions on the parent [GetGoalsResponse]
+   *
+   * The `goalNumber` parameter is not zero indexed to make for better readability in tests. IE. the first goal
+   * should be referenced as `.goal(1) { .... }`
+   */
+  fun goal(goalNumber: Int, consumer: Consumer<GoalResponseAssert>): GetGoalsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val goal = goals[goalNumber - 1]
+      consumer.accept(assertThat(goal))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into all child [GoalResponse]s. Takes a lambda as the method argument
+   * to call assertion methods provided by [GoalResponseAssert].
+   * Returns this [GetGoalsResponseAssert] to allow further chained assertions on the parent [GetGoalsResponse]
+   * The assertions on all [GoalResponse]s must pass as true.
+   */
+  fun allGoals(consumer: Consumer<GoalResponseAssert>): GetGoalsResponseAssert {
+    isNotNull
+    with(actual!!) {
+      goals.onEach {
+        consumer.accept(assertThat(it))
+      }
+    }
+    return this
+  }
+}


### PR DESCRIPTION
PR to fix the `GetGoalsTest` integration test (once and for all with any luck 🤞 )

It does this by forcing the creation order of the goals, but creating them one and a time via the API call. The tests in this test class (that do care about goal order) can then be more definitive about the assertions and goal ordering etc.