### PR TITLE
RR-1213 - Fix contextualInfo for ACTION_PLAN_CREATED timeline event

### DIFF
--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/InductionBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/InductionBuilder.kt
@@ -29,7 +29,7 @@ fun aFullyPopulatedInduction(
   conductedBy: String? = "John Smith",
   conductedByRole: String? = "Peer Mentor",
   conductedAt: LocalDate? = LocalDate.now(),
-  note: NoteDto? = aValidNoteDto(prisonNumber, noteType = NoteType.INDUCTION, entityType = EntityType.INDUCTION),
+  note: NoteDto? = aValidNoteDto(noteType = NoteType.INDUCTION, entityType = EntityType.INDUCTION),
 ) = Induction(
   reference = reference,
   prisonNumber = prisonNumber,

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/dto/CreateNoteDtoBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/note/dto/CreateNoteDtoBuilder.kt
@@ -29,10 +29,10 @@ fun aValidNoteDto(
   entityReference: UUID = UUID.randomUUID(),
   entityType: EntityType = EntityType.GOAL,
   noteType: NoteType = NoteType.GOAL,
-  createdBy: String = "created_username",
+  createdBy: String = "asmith_gen",
   createdAt: Instant = Instant.now(),
   createdAtPrison: String = "BXI",
-  lastUpdatedBy: String = "updated_username",
+  lastUpdatedBy: String = "bjones_gen",
   lastUpdatedAt: Instant = Instant.now(),
   lastUpdatedAtPrison: String = "MDI",
 ): NoteDto =
@@ -48,5 +48,4 @@ fun aValidNoteDto(
     lastUpdatedAt = lastUpdatedAt,
     createdBy = createdBy,
     lastUpdatedBy = lastUpdatedBy,
-
   )

--- a/domain/timeline/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/TimelineEventAssert.kt
+++ b/domain/timeline/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/TimelineEventAssert.kt
@@ -60,6 +60,16 @@ class TimelineEventAssert(actual: TimelineEvent?) :
     return this
   }
 
+  fun hasEmptyContextualInfo(): TimelineEventAssert {
+    isNotNull
+    with(actual!!) {
+      if (contextualInfo.isNotEmpty()) {
+        failWithMessage("Expected contextualInfo to be empty, but was $contextualInfo")
+      }
+    }
+    return this
+  }
+
   fun hasCorrelationId(expected: UUID): TimelineEventAssert {
     isNotNull
     with(actual!!) {


### PR DESCRIPTION
Fix for the contextualInfo field of the ACTION_PLAN_CREATED timeline event
We only want to write it if the induction was created using the new UI journey