### PR TITLE
handle when legal status is null

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PagedPrisonerResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PagedPrisonerResponse.kt
@@ -10,7 +10,7 @@ data class PagedPrisonerResponse(
 
 data class Prisoner(
   val prisonerNumber: String,
-  val legalStatus: LegalStatus,
+  val legalStatus: LegalStatus = LegalStatus.OTHER,
   val releaseDate: LocalDate?,
   val prisonId: String?,
   @field:JsonProperty(value = "indeterminateSentence", defaultValue = "false")


### PR DESCRIPTION
Found while testing the ETL - it is possible for the legal status to be returned as null from prisoner search api. 

Whether this could happen in live or not I don't know but propose this change to at least prevent the ETL from failing. 