### PR TITLE
Optional env var to specify the date the Educational Contracts start

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/ReviewSchedule.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/ReviewSchedule.kt
@@ -65,23 +65,22 @@ data class ReviewScheduleWindow(
   val dateTo: LocalDate,
 ) {
   companion object {
-    fun fromTodayToTenDays(): ReviewScheduleWindow = with(LocalDate.now()) {
-      ReviewScheduleWindow(this, plusDays(10))
-    }
-    fun fromOneToThreeMonths(): ReviewScheduleWindow = with(LocalDate.now()) {
-      ReviewScheduleWindow(plusMonths(1), plusMonths(3))
-    }
-    fun fromOneMonthToSpecificDate(dateTo: LocalDate): ReviewScheduleWindow = with(LocalDate.now()) {
-      ReviewScheduleWindow(plusMonths(1), dateTo)
-    }
-    fun fromTwoToThreeMonths(): ReviewScheduleWindow = with(LocalDate.now()) {
-      ReviewScheduleWindow(plusMonths(2), plusMonths(3))
-    }
-    fun fromFourToSixMonths(): ReviewScheduleWindow = with(LocalDate.now()) {
-      ReviewScheduleWindow(plusMonths(4), plusMonths(6))
-    }
-    fun fromTenToTwelveMonths(): ReviewScheduleWindow = with(LocalDate.now()) {
-      ReviewScheduleWindow(plusMonths(10), plusMonths(12))
-    }
+    fun fromTodayToTenDays(baseDate: LocalDate): ReviewScheduleWindow =
+      ReviewScheduleWindow(baseDate, baseDate.plusDays(10))
+
+    fun fromOneToThreeMonths(baseDate: LocalDate): ReviewScheduleWindow =
+      ReviewScheduleWindow(baseDate.plusMonths(1), baseDate.plusMonths(3))
+
+    fun fromOneMonthToSpecificDate(baseDate: LocalDate, dateTo: LocalDate): ReviewScheduleWindow =
+      ReviewScheduleWindow(baseDate.plusMonths(1), dateTo)
+
+    fun fromTwoToThreeMonths(baseDate: LocalDate): ReviewScheduleWindow =
+      ReviewScheduleWindow(baseDate.plusMonths(2), baseDate.plusMonths(3))
+
+    fun fromFourToSixMonths(baseDate: LocalDate): ReviewScheduleWindow =
+      ReviewScheduleWindow(baseDate.plusMonths(4), baseDate.plusMonths(6))
+
+    fun fromTenToTwelveMonths(baseDate: LocalDate): ReviewScheduleWindow =
+      ReviewScheduleWindow(baseDate.plusMonths(10), baseDate.plusMonths(12))
   }
 }

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
@@ -19,9 +19,8 @@ private val log = KotlinLogging.logger {}
 class ReviewScheduleService(
   private val reviewSchedulePersistenceAdapter: ReviewSchedulePersistenceAdapter,
   private val reviewScheduleEventService: ReviewScheduleEventService,
+  private val reviewScheduleDateCalculationService: ReviewScheduleDateCalculationService,
 ) {
-
-  private val reviewScheduleDateCalculationService = ReviewScheduleDateCalculationService()
 
   private val reviewScheduleStatusTransitionValidator = ReviewScheduleStatusTransitionValidator()
 

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewService.kt
@@ -27,9 +27,8 @@ class ReviewService(
   private val reviewPersistenceAdapter: ReviewPersistenceAdapter,
   private val reviewSchedulePersistenceAdapter: ReviewSchedulePersistenceAdapter,
   private val reviewScheduleService: ReviewScheduleService,
+  private val reviewScheduleDateCalculationService: ReviewScheduleDateCalculationService,
 ) {
-
-  private val reviewScheduleDateCalculationService = ReviewScheduleDateCalculationService()
 
   /**
    * Returns a list of all [CompletedReview]s for the prisoner identified by their prison number. An empty list is

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleServiceCreateInitialReviewScheduleTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleServiceCreateInitialReviewScheduleTest.kt
@@ -2,13 +2,13 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.servi
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -30,7 +30,6 @@ import java.util.stream.Stream
 
 @ExtendWith(MockitoExtension::class)
 class ReviewScheduleServiceCreateInitialReviewScheduleTest {
-  @InjectMocks
   private lateinit var service: ReviewScheduleService
 
   @Mock
@@ -38,6 +37,17 @@ class ReviewScheduleServiceCreateInitialReviewScheduleTest {
 
   @Mock
   private lateinit var reviewEventService: ReviewScheduleEventService
+
+  private val reviewScheduleDateCalculationService = ReviewScheduleDateCalculationService()
+
+  @BeforeEach
+  fun setupService() {
+    service = ReviewScheduleService(
+      reviewSchedulePersistenceAdapter = reviewSchedulePersistenceAdapter,
+      reviewScheduleEventService = reviewEventService,
+      reviewScheduleDateCalculationService = reviewScheduleDateCalculationService,
+    )
+  }
 
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("prisonersInitialReview_testCases")

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleServiceTest.kt
@@ -3,10 +3,10 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.servi
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowableOfType
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -31,7 +31,6 @@ import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
 class ReviewScheduleServiceTest {
-  @InjectMocks
   private lateinit var reviewScheduleService: ReviewScheduleService
 
   @Mock
@@ -40,10 +39,21 @@ class ReviewScheduleServiceTest {
   @Mock
   private lateinit var reviewScheduleEventService: ReviewScheduleEventService
 
+  private val reviewScheduleDateCalculationService = ReviewScheduleDateCalculationService()
+
   companion object {
     private val PRISON_NUMBER = randomValidPrisonNumber()
     private val TODAY = LocalDate.now()
     private val NOW = Instant.now()
+  }
+
+  @BeforeEach
+  fun setupService() {
+    reviewScheduleService = ReviewScheduleService(
+      reviewSchedulePersistenceAdapter = reviewSchedulePersistenceAdapter,
+      reviewScheduleEventService = reviewScheduleEventService,
+      reviewScheduleDateCalculationService = reviewScheduleDateCalculationService,
+    )
   }
 
   @Nested

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceCreateReviewTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceCreateReviewTest.kt
@@ -2,13 +2,13 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.servi
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -37,7 +37,6 @@ import java.util.stream.Stream
 
 @ExtendWith(MockitoExtension::class)
 class ReviewServiceCreateReviewTest {
-  @InjectMocks
   private lateinit var service: ReviewService
 
   @Mock
@@ -51,6 +50,19 @@ class ReviewServiceCreateReviewTest {
 
   @Mock
   private lateinit var reviewScheduleService: ReviewScheduleService
+
+  private val reviewScheduleDateCalculationService = ReviewScheduleDateCalculationService()
+
+  @BeforeEach
+  fun setupService() {
+    service = ReviewService(
+      reviewEventService = reviewEventService,
+      reviewPersistenceAdapter = reviewPersistenceAdapter,
+      reviewSchedulePersistenceAdapter = reviewSchedulePersistenceAdapter,
+      reviewScheduleService = reviewScheduleService,
+      reviewScheduleDateCalculationService = reviewScheduleDateCalculationService,
+    )
+  }
 
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("notPrisonersLastReview_testCases")

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewServiceTest.kt
@@ -30,6 +30,9 @@ class ReviewServiceTest {
   @Mock
   private lateinit var reviewScheduleService: ReviewScheduleService
 
+  @Mock
+  private lateinit var reviewScheduleDateCalculationService: ReviewScheduleDateCalculationService
+
   companion object {
     private val PRISON_NUMBER = randomValidPrisonNumber()
   }

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/CreateReviewScheduleDtoBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/CreateReviewScheduleDtoBuilder.kt
@@ -2,10 +2,11 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto
 
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
+import java.time.LocalDate
 
 fun aValidCreateReviewScheduleDto(
   prisonNumber: String = "A1234BC",
-  reviewScheduleWindow: ReviewScheduleWindow = ReviewScheduleWindow.fromFourToSixMonths(),
+  reviewScheduleWindow: ReviewScheduleWindow = ReviewScheduleWindow.fromFourToSixMonths(LocalDate.now()),
   scheduleCalculationRule: ReviewScheduleCalculationRule = ReviewScheduleCalculationRule.MORE_THAN_60_MONTHS_TO_SERVE,
   prisonId: String = "BXI",
 ): CreateReviewScheduleDto =

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/UpdateReviewScheduleDtoBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/dto/UpdateReviewScheduleDtoBuilder.kt
@@ -3,11 +3,12 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleWindow
+import java.time.LocalDate
 import java.util.UUID
 
 fun aValidUpdateReviewScheduleDto(
   reference: UUID = UUID.randomUUID(),
-  reviewScheduleWindow: ReviewScheduleWindow = ReviewScheduleWindow.fromTenToTwelveMonths(),
+  reviewScheduleWindow: ReviewScheduleWindow = ReviewScheduleWindow.fromTenToTwelveMonths(LocalDate.now()),
   scheduleCalculationRule: ReviewScheduleCalculationRule = ReviewScheduleCalculationRule.MORE_THAN_60_MONTHS_TO_SERVE,
   scheduleStatus: ReviewScheduleStatus = ReviewScheduleStatus.SCHEDULED,
   prisonId: String = "BXI",

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -5,6 +5,9 @@ generic-service:
   ingress:
     host: learningandworkprogress-api.hmpps.service.justice.gov.uk
 
+  env:
+    EDUCATION_CONTRACTS_START_DATE: "2025-04-01"
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.conversation.service.ConversationEventService
@@ -18,6 +19,7 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.ser
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.service.NoteService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewEventService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewPersistenceAdapter
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewScheduleDateCalculationService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewScheduleEventService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewSchedulePersistenceAdapter
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewScheduleService
@@ -33,6 +35,7 @@ import uk.gov.justice.digital.hmpps.domain.timeline.service.PrisonTimelineServic
 import uk.gov.justice.digital.hmpps.domain.timeline.service.TimelinePersistenceAdapter
 import uk.gov.justice.digital.hmpps.domain.timeline.service.TimelineService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.JpaNotePersistenceAdapter
+import java.time.LocalDate
 
 /**
  * Configuration class responsible for providing domain bean implementations
@@ -88,7 +91,11 @@ class DomainConfiguration {
     inductionScheduleEventService: InductionScheduleEventService,
     inductionScheduleDateCalculationService: InductionScheduleDateCalculationService,
   ): InductionScheduleService =
-    InductionScheduleService(inductionSchedulePersistenceAdapter, inductionScheduleEventService, inductionScheduleDateCalculationService)
+    InductionScheduleService(
+      inductionSchedulePersistenceAdapter,
+      inductionScheduleEventService,
+      inductionScheduleDateCalculationService,
+    )
 
   @Bean
   fun conversationDomainService(
@@ -110,13 +117,30 @@ class DomainConfiguration {
     reviewPersistenceAdapter: ReviewPersistenceAdapter,
     reviewSchedulePersistenceAdapter: ReviewSchedulePersistenceAdapter,
     reviewScheduleService: ReviewScheduleService,
+    reviewScheduleDateCalculationService: ReviewScheduleDateCalculationService,
   ): ReviewService =
-    ReviewService(reviewEventService, reviewPersistenceAdapter, reviewSchedulePersistenceAdapter, reviewScheduleService)
+    ReviewService(
+      reviewEventService,
+      reviewPersistenceAdapter,
+      reviewSchedulePersistenceAdapter,
+      reviewScheduleService,
+      reviewScheduleDateCalculationService,
+    )
 
   @Bean
   fun reviewScheduleDomainService(
     reviewSchedulePersistenceAdapter: ReviewSchedulePersistenceAdapter,
     reviewScheduleEventService: ReviewScheduleEventService,
+    reviewScheduleDateCalculationService: ReviewScheduleDateCalculationService,
   ): ReviewScheduleService =
-    ReviewScheduleService(reviewSchedulePersistenceAdapter, reviewScheduleEventService)
+    ReviewScheduleService(
+      reviewSchedulePersistenceAdapter,
+      reviewScheduleEventService,
+      reviewScheduleDateCalculationService,
+    )
+
+  @Bean
+  fun reviewScheduleDateCalculationService(
+    @Value("\${EDUCATION_CONTRACTS_START_DATE:}") scheduleDateNotBefore: LocalDate? = null,
+  ) = ReviewScheduleDateCalculationService(scheduleDateNotBefore)
 }


### PR DESCRIPTION
This PR adds and optional env var to specify the date the Educational Contracts start and from which all schedule dates are based.

This should allow us to have the listeners etc running in prod from now, and also run the ETL in prod any time we like, and it will create "forward dated" Induction and Review schedules

The basic idea is that we set the env var in `prod` which sets the date that the new Education Contracts start (2025-04-01). This is an optional env var and is not set in other envs (though we could do if we wanted)
The date (if set) is injected into the 2 date calc classes (Induction & Review date calc classes), and is used as part of determining the deadline date for the schedule. IE. it uses the later of "today" or the injected date as the base date.

By not setting the env var in `dev` or `preprod` it means we can have schedules set which are not forward dated and are based on "today", which means we can do team testing in `dev`, and our pilot prisons can test in `preprod` before April