### PR TITLE
Fix username resolution in UserPrincipalAuditorAware

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/AuthAwareTokenConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/AuthAwareTokenConverter.kt
@@ -12,7 +12,7 @@ class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
   private val jwtGrantedAuthoritiesConverter: Converter<Jwt, Collection<GrantedAuthority>> = JwtGrantedAuthoritiesConverter()
 
   companion object {
-    const val SYSTEM: String = "system"
+    const val SYSTEM_USER: String = "system"
   }
 
   override fun convert(jwt: Jwt): AbstractAuthenticationToken {
@@ -28,7 +28,7 @@ class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
     return if (claims.containsKey("user_name")) {
       claims["user_name"] as String
     } else {
-      SYSTEM
+      SYSTEM_USER
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAware.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAware.kt
@@ -3,12 +3,14 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
 import org.springframework.data.domain.AuditorAware
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.AuthAwareTokenConverter
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.AuthAwareTokenConverter.Companion.SYSTEM_USER
 import java.util.Optional
 
 @Component
 class UserPrincipalAuditorAware : AuditorAware<String> {
   override fun getCurrentAuditor(): Optional<String> = Optional.of(
-    SecurityContextHolder.getContext()?.authentication?.name ?: AuthAwareTokenConverter.SYSTEM,
+    SecurityContextHolder.getContext()?.authentication?.principal?.let {
+      it.toString()
+    } ?: SYSTEM_USER,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/timeline/TimelineEventResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/timeline/TimelineEventResourceMapper.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEvent
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventContext
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.AuthAwareTokenConverter.Companion.SYSTEM_USER
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ManageUserService
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.PrisonerApiTimelineService.Companion.SYSTEM_USER
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventResponse
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventType as TimelineEventTypeDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType as TimelineEventTypeApi

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/ManageUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/ManageUserService.kt
@@ -4,6 +4,7 @@ import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.manageusers.ManageUsersApiClient
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.manageusers.UserDetailsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.AuthAwareTokenConverter.Companion.SYSTEM_USER
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.CacheConfiguration.Companion.USER_DETAILS
 
 @Component
@@ -12,7 +13,7 @@ class ManageUserService(
 ) {
   @Cacheable(USER_DETAILS)
   fun getUserDetails(username: String): UserDetailsDto =
-    if (username == "system") {
+    if (username == SYSTEM_USER) {
       UserDetailsDto(username, true, username)
     } else {
       manageUsersApiClient.getUserDetails(username)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerApiTimelineService.kt
@@ -16,10 +16,6 @@ class PrisonerApiTimelineService(
   private val prisonMovementEventsMapper: PrisonMovementEventsMapper,
 ) : PrisonTimelineService {
 
-  companion object {
-    const val SYSTEM_USER = "system"
-  }
-
   override fun getPrisonTimelineEvents(prisonNumber: String): List<TimelineEvent> {
     return try {
       val prisonMovementEvents = prisonApiClient.getPrisonMovementEvents(prisonNumber)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/mapper/PrisonMovementEventsMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/mapper/PrisonMovementEventsMapper.kt
@@ -7,8 +7,8 @@ import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi.PrisonMovementEvent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi.PrisonMovementEvents
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonapi.PrisonMovementType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.config.AuthAwareTokenConverter.Companion.SYSTEM_USER
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.PrisonerApiTimelineService.Companion.SYSTEM_USER
 import java.util.UUID
 
 @Component

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAwareTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/UserPrincipalAuditorAwareTest.kt
@@ -6,16 +6,14 @@ import org.junit.jupiter.api.Test
 import org.springframework.security.authentication.TestingAuthenticationToken
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
-import java.security.Principal
 import java.util.Optional
 
 class UserPrincipalAuditorAwareTest {
 
   companion object {
-    private const val USERNAME = "auser_gen"
     private val ROLES = emptyList<GrantedAuthority>()
 
-    private val PRINCIPAL = Principal { USERNAME }
+    private val PRINCIPAL = "auser_gen"
     private val AUTHENTICATION = TestingAuthenticationToken(PRINCIPAL, null, ROLES)
   }
 


### PR DESCRIPTION
This PR fixes the username that gets written to JPA fields via `UserPrincipalAuditorAware`, specifically in the case where the JWT is a system token and not one enriched with the DPS username