### PR TITLE
Remove displayName from JwtAccessTokenBuilder and all places that used it

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -348,7 +348,6 @@ abstract class IntegrationTestBase {
     prisonNumber: String,
     createInductionRequest: CreateInductionRequest,
     username: String = "auser_gen",
-    displayName: String = "Albert User",
   ) {
     webTestClient.post()
       .uri(INDUCTION_URI_TEMPLATE, prisonNumber)
@@ -358,7 +357,6 @@ abstract class IntegrationTestBase {
           INDUCTIONS_RW,
           privateKey = keyPair.private,
           username = username,
-          displayName = displayName,
         ),
       )
       .contentType(APPLICATION_JSON)
@@ -381,7 +379,6 @@ abstract class IntegrationTestBase {
     prisonNumber: String,
     archiveGoalRequest: ArchiveGoalRequest,
     username: String = "auser_gen",
-    displayName: String = "Albert User",
   ) {
     webTestClient.put()
       .uri("/action-plans/{prisonNumber}/goals/{goalReference}/archive", prisonNumber, archiveGoalRequest.goalReference)
@@ -391,7 +388,6 @@ abstract class IntegrationTestBase {
           GOALS_RW,
           privateKey = keyPair.private,
           username = username,
-          displayName = displayName,
         ),
       )
       .contentType(APPLICATION_JSON)
@@ -404,7 +400,6 @@ abstract class IntegrationTestBase {
     prisonNumber: String,
     completeGoalRequest: CompleteGoalRequest,
     username: String = "auser_gen",
-    displayName: String = "Albert User",
   ) {
     webTestClient.put()
       .uri("/action-plans/{prisonNumber}/goals/{goalReference}/complete", prisonNumber, completeGoalRequest.goalReference)
@@ -414,7 +409,6 @@ abstract class IntegrationTestBase {
           GOALS_RW,
           privateKey = keyPair.private,
           username = username,
-          displayName = displayName,
         ),
       )
       .contentType(APPLICATION_JSON)
@@ -427,7 +421,6 @@ abstract class IntegrationTestBase {
     prisonNumber: String,
     createConversationRequest: CreateConversationRequest = aValidCreateConversationRequest(),
     username: String = "auser_gen",
-    displayName: String = "Albert User",
   ) {
     webTestClient.post()
       .uri("/conversations/{prisonNumber}", prisonNumber)
@@ -437,7 +430,6 @@ abstract class IntegrationTestBase {
           CONVERSATIONS_RW,
           privateKey = keyPair.private,
           username = username,
-          displayName = displayName,
         ),
       )
       .contentType(APPLICATION_JSON)
@@ -465,7 +457,6 @@ abstract class IntegrationTestBase {
     prisonNumber: String,
     createEducationRequest: CreateEducationRequest = aValidCreateEducationRequest(),
     username: String = "auser_gen",
-    displayName: String = "Albert User",
   ) {
     webTestClient.post()
       .uri(EDUCATION_URI_TEMPLATE, prisonNumber)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
@@ -295,7 +295,6 @@ class ArchiveGoalTest : IntegrationTestBase() {
       aValidTokenWithAuthority(
         GOALS_RW,
         username = "buser_gen",
-        displayName = "Bernie User",
         privateKey = keyPair.private,
       ),
     )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CompleteGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CompleteGoalTest.kt
@@ -265,7 +265,6 @@ class CompleteGoalTest : IntegrationTestBase() {
       aValidTokenWithAuthority(
         GOALS_RW,
         username = "buser_gen",
-        displayName = "Bernie User",
         privateKey = keyPair.private,
       ),
     )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanTest.kt
@@ -174,7 +174,6 @@ class CreateActionPlanTest : IntegrationTestBase() {
         aValidTokenWithAuthority(
           ACTIONPLANS_RW,
           username = dpsUsername,
-          displayName = displayName,
           privateKey = keyPair.private,
         ),
       )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateInductionTest.kt
@@ -144,7 +144,6 @@ class CreateInductionTest : IntegrationTestBase() {
     val prisonNumber = anotherValidPrisonNumber()
     val createRequest = aValidCreateInductionRequestForPrisonerLookingToWork()
     val dpsUsername = "auser_gen"
-    val displayName = "Albert User"
 
     // When
     webTestClient.post()
@@ -154,7 +153,6 @@ class CreateInductionTest : IntegrationTestBase() {
         aValidTokenWithAuthority(
           INDUCTIONS_RW,
           username = dpsUsername,
-          displayName = displayName,
           privateKey = keyPair.private,
         ),
       )
@@ -192,7 +190,6 @@ class CreateInductionTest : IntegrationTestBase() {
     val prisonNumber = aValidPrisonNumber()
     val createRequest = aValidCreateInductionRequestForPrisonerNotLookingToWork()
     val dpsUsername = "auser_gen"
-    val displayName = "Albert User"
 
     // When
     webTestClient.post()
@@ -202,7 +199,6 @@ class CreateInductionTest : IntegrationTestBase() {
         aValidTokenWithAuthority(
           INDUCTIONS_RW,
           username = dpsUsername,
-          displayName = displayName,
           privateKey = keyPair.private,
         ),
       )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetConversationTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetConversationTest.kt
@@ -117,7 +117,6 @@ class GetConversationTest : IntegrationTestBase() {
           CONVERSATIONS_RO,
           privateKey = keyPair.private,
           username = createUsername,
-          displayName = createDisplayName,
         ),
       )
       .contentType(MediaType.APPLICATION_JSON)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt
@@ -76,7 +76,6 @@ class GetInductionTest : IntegrationTestBase() {
       prisonNumber = prisonNumber,
       createInductionRequest = aValidCreateInductionRequestForPrisonerNotLookingToWork(),
       username = "asmith_gen",
-      displayName = "Alex Smith",
     )
     val expectedWorkOnRelease = aValidWorkOnReleaseResponseForPrisonerNotLookingToWork()
     val expectedPreviousQualifications =
@@ -127,7 +126,6 @@ class GetInductionTest : IntegrationTestBase() {
       prisonNumber = prisonNumber,
       createInductionRequest = aValidCreateInductionRequestForPrisonerLookingToWork(),
       username = "asmith_gen",
-      displayName = "Alex Smith",
     )
     val expectedWorkOnRelease = aValidWorkOnReleaseResponseForPrisonerLookingToWork()
     val expectedPreviousQualifications = aValidPreviousQualificationsResponse()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
@@ -289,7 +289,6 @@ class UnarchiveGoalTest : IntegrationTestBase() {
       aValidTokenWithAuthority(
         GOALS_RW,
         username = "buser_gen",
-        displayName = "Bernie User",
         privateKey = keyPair.private,
       ),
     )
@@ -307,7 +306,6 @@ class UnarchiveGoalTest : IntegrationTestBase() {
       aValidTokenWithAuthority(
         GOALS_RW,
         username = "buser_gen",
-        displayName = "Bernie User",
         privateKey = keyPair.private,
       ),
     )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateConversationTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateConversationTest.kt
@@ -154,17 +154,14 @@ class UpdateConversationTest : IntegrationTestBase() {
     )
 
     val creatorUsername = "auser_gen"
-    val creatorName = "Albert User"
 
     val editorUsername = "bruser_gen"
-    val editorName = "Bernie User"
 
     // When
     createConversation(
       prisonNumber,
       createReviewConversationRequest,
       creatorUsername,
-      creatorName,
     )
 
     val createdConversation = conversationRepository.findAllByPrisonNumber(prisonNumber).first()
@@ -176,7 +173,6 @@ class UpdateConversationTest : IntegrationTestBase() {
         aValidTokenWithAuthority(
           CONVERSATIONS_RW,
           username = editorUsername,
-          displayName = editorName,
           privateKey = keyPair.private,
         ),
       )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateEductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateEductionTest.kt
@@ -146,7 +146,6 @@ class UpdateEductionTest : IntegrationTestBase() {
         ),
       ),
       username = "auser_gen",
-      displayName = "Albert User",
     )
 
     val prisonerEducationRecord = getEducation(prisonNumber)
@@ -196,7 +195,6 @@ class UpdateEductionTest : IntegrationTestBase() {
           EDUCATION_RW,
           privateKey = keyPair.private,
           username = "buser_gen",
-          displayName = "Bernie User",
         ),
       )
       .contentType(APPLICATION_JSON)
@@ -270,7 +268,6 @@ class UpdateEductionTest : IntegrationTestBase() {
         ),
       ),
       username = "auser_gen",
-      displayName = "Albert User",
     )
 
     val prisonerEducationRecord = getEducation(prisonNumber)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -251,7 +251,6 @@ class UpdateGoalTest : IntegrationTestBase() {
         aValidTokenWithAuthority(
           GOALS_RW,
           username = "buser_gen",
-          displayName = "Bernie User",
           privateKey = keyPair.private,
         ),
       )
@@ -374,7 +373,6 @@ class UpdateGoalTest : IntegrationTestBase() {
         aValidTokenWithAuthority(
           GOALS_RW,
           username = "buser_gen",
-          displayName = "Bernie User",
           privateKey = keyPair.private,
         ),
       )
@@ -495,7 +493,6 @@ class UpdateGoalTest : IntegrationTestBase() {
         aValidTokenWithAuthority(
           GOALS_RW,
           username = "buser_gen",
-          displayName = "Bernie User",
           privateKey = keyPair.private,
         ),
       )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -156,7 +156,6 @@ class UpdateInductionTest : IntegrationTestBase() {
     val updateDisplayName = "Bernie User"
     createInduction(
       username = createUsername,
-      displayName = createDisplayName,
       prisonNumber = prisonNumber,
       createInductionRequest = aValidCreateInductionRequestForPrisonerLookingToWork(),
     )
@@ -255,7 +254,6 @@ class UpdateInductionTest : IntegrationTestBase() {
         aValidTokenWithAuthority(
           INDUCTIONS_RW,
           username = updateUsername,
-          displayName = updateDisplayName,
           privateKey = keyPair.private,
         ),
       )
@@ -319,7 +317,6 @@ class UpdateInductionTest : IntegrationTestBase() {
     val updateDisplayName = "Bernie User"
     createInduction(
       username = createUsername,
-      displayName = createDisplayName,
       prisonNumber = prisonNumber,
       createInductionRequest = aValidCreateInductionRequestForPrisonerNotLookingToWork(),
     )
@@ -404,7 +401,6 @@ class UpdateInductionTest : IntegrationTestBase() {
         aValidTokenWithAuthority(
           INDUCTIONS_RW,
           username = updateUsername,
-          displayName = updateDisplayName,
           privateKey = keyPair.private,
         ),
       )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/JwtAccessTokenBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/JwtAccessTokenBuilder.kt
@@ -11,31 +11,26 @@ import java.util.UUID
 fun aValidTokenWithAuthority(
   role: String,
   username: String = "auser_gen",
-  displayName: String = "Albert User",
   privateKey: PrivateKey,
 ): String =
   buildAccessToken(
     username = username,
-    displayName = displayName,
     roles = listOf(role),
     privateKey = privateKey,
   )
 
 fun aValidTokenWithNoAuthorities(
   username: String = "auser_gen",
-  displayName: String = "Albert User",
   privateKey: PrivateKey,
 ): String =
   buildAccessToken(
     username = username,
-    displayName = displayName,
     roles = emptyList(),
     privateKey = privateKey,
   )
 
 fun buildAccessToken(
   username: String = "auser_gen",
-  displayName: String = "Albert User",
   roles: List<String> = emptyList(),
   clientId: UUID = UUID.randomUUID(),
   privateKey: PrivateKey,
@@ -48,7 +43,6 @@ fun buildAccessToken(
         "user_name" to username,
         "auth_source" to "nomis",
         "user_uuid" to UUID.randomUUID(),
-        "name" to displayName,
         "client_id" to clientId,
       ),
     )


### PR DESCRIPTION
Final tidy up of displayName stuff - this PR removes the `displayName` argument from the functions in `JwtAccessTokenBuilder` (that build JWTs for the purpose of integration tests), and all places that used them