### PR TITLE
Fix dates on InductionScheduleHistoryEntity and ReviewScheduleHistoryEntity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionSchedulePersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaInductionSchedulePersistenceAdapter.kt
@@ -57,9 +57,10 @@ class JpaInductionSchedulePersistenceAdapter(
     )
 
     // Save the updated schedule and return the mapped domain object.
-    val inductionSchedule = inductionScheduleRepository.saveAndFlush(updatedSchedule)
-    saveInductionScheduleHistory(inductionSchedule)
-    return inductionScheduleEntityMapper.fromEntityToDomain(inductionSchedule)
+    return inductionScheduleRepository.saveAndFlush(updatedSchedule).let {
+      saveInductionScheduleHistory(it)
+      inductionScheduleEntityMapper.fromEntityToDomain(it)
+    }
   }
 
   override fun getInductionScheduleHistory(prisonNumber: String): List<InductionScheduleHistory> {
@@ -79,9 +80,10 @@ class JpaInductionSchedulePersistenceAdapter(
       updatedAtPrison = updateInductionScheduleStatusDto.updatedAtPrison
     }
 
-    val savedReviewScheduleEntity = inductionScheduleRepository.save(inductionScheduleEntity)
-    saveInductionScheduleHistory(savedReviewScheduleEntity)
-    return inductionScheduleEntityMapper.fromEntityToDomain(savedReviewScheduleEntity)
+    return inductionScheduleRepository.saveAndFlush(inductionScheduleEntity).let {
+      saveInductionScheduleHistory(it)
+      inductionScheduleEntityMapper.fromEntityToDomain(it)
+    }
   }
 
   private fun saveInductionScheduleHistory(inductionScheduleEntity: InductionScheduleEntity) {
@@ -91,12 +93,12 @@ class JpaInductionSchedulePersistenceAdapter(
           ?.plus(1) ?: 1,
         reference = reference,
         prisonNumber = prisonNumber,
-        updatedAt = updatedAt,
+        updatedAt = updatedAt!!,
         updatedAtPrison = updatedAtPrison,
-        createdAt = createdAt,
+        createdAt = createdAt!!,
         createdAtPrison = createdAtPrison,
-        updatedBy = updatedBy,
-        createdBy = createdBy,
+        updatedBy = updatedBy!!,
+        createdBy = createdBy!!,
         scheduleStatus = scheduleStatus,
         exemptionReason = exemptionReason,
         scheduleCalculationRule = scheduleCalculationRule,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionScheduleHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionScheduleHistoryEntity.kt
@@ -13,19 +13,17 @@ import java.time.LocalDate
 import java.util.UUID
 
 /**
- * Represents the schedule for when a prisoner's Induction must be completed by.
+ * Represents an immutable history record of the schedule for when a prisoner's Induction must be completed by.
  */
 @Table(name = "induction_schedule_history")
 @Entity
 data class InductionScheduleHistoryEntity(
 
-  @Id
-  @GeneratedValue
-  @UuidGenerator
-  var id: UUID? = null,
-
   @Column(updatable = false)
   val reference: UUID,
+
+  @Column(updatable = false)
+  val version: Int,
 
   @Column(updatable = false)
   val prisonNumber: String,
@@ -34,33 +32,36 @@ data class InductionScheduleHistoryEntity(
   @Enumerated(value = EnumType.STRING)
   val scheduleCalculationRule: InductionScheduleCalculationRule,
 
-  @Column(updatable = true)
-  var deadlineDate: LocalDate,
+  @Column(updatable = false)
+  val deadlineDate: LocalDate,
 
-  @Column(updatable = true)
+  @Column(updatable = false)
   @Enumerated(value = EnumType.STRING)
-  var scheduleStatus: InductionScheduleStatus,
-
-  val version: Int,
-
-  @Column
-  var exemptionReason: String?,
+  val scheduleStatus: InductionScheduleStatus,
 
   @Column(updatable = false)
-  var createdBy: String? = null,
+  val exemptionReason: String?,
 
   @Column(updatable = false)
-  var createdAt: Instant? = null,
+  val createdBy: String,
 
-  @Column
-  var updatedBy: String? = null,
+  @Column(updatable = false)
+  val createdAt: Instant,
 
-  @Column
-  var updatedAt: Instant? = null,
+  @Column(updatable = false)
+  val updatedBy: String,
+
+  @Column(updatable = false)
+  val updatedAt: Instant,
 
   @Column(updatable = false)
   val createdAtPrison: String,
 
-  @Column
-  var updatedAtPrison: String,
-)
+  @Column(updatable = false)
+  val updatedAtPrison: String,
+) {
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/review/ReviewScheduleHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/review/ReviewScheduleHistoryEntity.kt
@@ -12,55 +12,59 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
+/**
+ * Represents an immutable history record of the schedule for when a prisoner's Review must be completed by.
+ */
 @Table(name = "review_schedule_history")
 @Entity
 data class ReviewScheduleHistoryEntity(
-
-  @Id
-  @GeneratedValue
-  @UuidGenerator
-  var id: UUID? = null,
-
-  val version: Int,
 
   @Column(updatable = false)
   val reference: UUID,
 
   @Column(updatable = false)
+  val version: Int,
+
+  @Column(updatable = false)
   val prisonNumber: String,
 
-  @Column
-  var earliestReviewDate: LocalDate,
+  @Column(updatable = false)
+  val earliestReviewDate: LocalDate,
 
-  @Column
-  var latestReviewDate: LocalDate,
+  @Column(updatable = false)
+  val latestReviewDate: LocalDate,
 
-  @Column
+  @Column(updatable = false)
   @Enumerated(value = EnumType.STRING)
-  var scheduleCalculationRule: ReviewScheduleCalculationRule,
+  val scheduleCalculationRule: ReviewScheduleCalculationRule,
 
-  @Column
+  @Column(updatable = false)
   @Enumerated(value = EnumType.STRING)
-  var scheduleStatus: ReviewScheduleStatus,
+  val scheduleStatus: ReviewScheduleStatus,
 
-  @Column
-  var exemptionReason: String?,
+  @Column(updatable = false)
+  val exemptionReason: String?,
 
   @Column(updatable = false)
   val createdAtPrison: String,
 
-  @Column
-  var updatedAtPrison: String,
+  @Column(updatable = false)
+  val updatedAtPrison: String,
 
   @Column(updatable = false)
-  var createdBy: String? = null,
+  val createdBy: String,
 
   @Column(updatable = false)
-  var createdAt: Instant? = null,
+  val createdAt: Instant,
 
-  @Column
-  var updatedBy: String? = null,
+  @Column(updatable = false)
+  val updatedBy: String,
 
-  @Column
-  var updatedAt: Instant? = null,
-)
+  @Column(updatable = false)
+  val updatedAt: Instant,
+) {
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null
+}


### PR DESCRIPTION
This PR fixes a problem when recording Induction Schedule History or Review Schedule History records, in that the  updatedAt dates do not get correctly updated, which is likely to cause MN a problem when we send them the history and they expect to sort them on updated date 🤣 

![image](https://github.com/user-attachments/assets/18c6ffae-e880-4d09-8f00-2a5946904230)

The problem (I suspect) is that in some cases (the status update methods) we were calling `save` rather than `saveAndFlush` on the Induction/Review Schedule entity classes, and I don't think JPA updates the audit fields via the entiry annotations until it flushes. Therefore, the first history record is correct, but when making a status update, the updatedAt date is copied from the original entity rather than the one that has been flushed with it's new updatedAt value.

I've also been explicit in the History entity classes re: them being immutable, and making the fields all `val` and putting `@Column(updatable = false)` on every field. It might be overly explicit, but hopefully future devs will realise these are history/audit records and are never updated 🤷‍♂️ 🤞 
