### PR TITLE
merge offender

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
@@ -190,32 +190,31 @@ class InductionScheduleService(
   }
 
   /**
-   * Updates the prisoner's Induction Schedule by setting its status to EXEMPT_PRISONER_DEATH.
+   * Updates the prisoner's Induction Schedule by setting its status to the provided exemption status.
    */
-  fun exemptActiveInductionScheduleStatusDueToPrisonerDeath(prisonNumber: String, prisonId: String) {
+  private fun exemptActiveInductionSchedule(
+    prisonNumber: String,
+    prisonId: String,
+    status: InductionScheduleStatus,
+  ) {
     val inductionSchedule = inductionSchedulePersistenceAdapter.getActiveInductionSchedule(prisonNumber)
       ?: throw InductionScheduleNotFoundException(prisonNumber)
 
     updateInductionSchedule(
       inductionSchedule = inductionSchedule,
-      newStatus = InductionScheduleStatus.EXEMPT_PRISONER_DEATH,
+      newStatus = status,
       prisonId = prisonId,
     )
   }
 
-  /**
-   * Updates the prisoner's Induction Schedule by setting its status to EXEMPT_PRISONER_RELEASE.
-   */
-  fun exemptActiveInductionScheduleStatusDueToPrisonerRelease(prisonNumber: String, prisonId: String) {
-    val inductionSchedule = inductionSchedulePersistenceAdapter.getActiveInductionSchedule(prisonNumber)
-      ?: throw InductionScheduleNotFoundException(prisonNumber)
+  fun exemptActiveInductionScheduleStatusDueToPrisonerDeath(prisonNumber: String, prisonId: String) =
+    exemptActiveInductionSchedule(prisonNumber, prisonId, InductionScheduleStatus.EXEMPT_PRISONER_DEATH)
 
-    updateInductionSchedule(
-      inductionSchedule = inductionSchedule,
-      newStatus = InductionScheduleStatus.EXEMPT_PRISONER_RELEASE,
-      prisonId = prisonId,
-    )
-  }
+  fun exemptActiveInductionScheduleStatusDueToPrisonerRelease(prisonNumber: String, prisonId: String) =
+    exemptActiveInductionSchedule(prisonNumber, prisonId, InductionScheduleStatus.EXEMPT_PRISONER_RELEASE)
+
+  fun exemptActiveInductionScheduleStatusDueToMerge(prisonNumber: String, prisonId: String) =
+    exemptActiveInductionSchedule(prisonNumber, prisonId, InductionScheduleStatus.EXEMPT_PRISONER_MERGE)
 
   fun updateInductionSchedule(
     inductionSchedule: InductionSchedule,

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
@@ -133,67 +133,42 @@ class ReviewScheduleService(
   }
 
   /**
-   * Updates the prisoner's active Review Schedule by setting its status to EXEMPT_PRISONER_RELEASE
+   * Updates the prisoner's active Review Schedule by setting its status to the provided exemption status.
    *
    * The prisoner's active Review Schedule is the one with the status SCHEDULED or one of the EXEMPT_ statuses.
-   * A Review Schedule with the status COMPLETE, EXEMPT_PRISONER_RELEASE, EXEMPT_PRISONER_DEATH or EXEMPT_UNKNOWN is not considered 'active'
+   * A Review Schedule with the status COMPLETE, EXEMPT_PRISONER_RELEASE, EXEMPT_PRISONER_DEATH, or EXEMPT_UNKNOWN is not considered 'active.'
    */
+  private fun exemptActiveReviewSchedule(
+    prisonNumber: String,
+    prisonId: String,
+    status: ReviewScheduleStatus,
+  ) {
+    reviewSchedulePersistenceAdapter.getActiveReviewSchedule(prisonNumber)
+      ?.run {
+        updateExemptStatus(
+          prisonNumber = prisonNumber,
+          prisonId = prisonId,
+          reviewSchedule = this,
+          newStatus = status,
+          exemptionReason = null,
+        ).also {
+          log.debug { "Review Schedule for prisoner [$prisonNumber] set to exempt: $status" }
+        }
+      }
+      ?: throw ReviewScheduleNotFoundException(prisonNumber)
+  }
+
   fun exemptActiveReviewScheduleStatusDueToPrisonerRelease(prisonNumber: String, prisonId: String) =
-    reviewSchedulePersistenceAdapter.getActiveReviewSchedule(prisonNumber)
-      ?.run {
-        updateExemptStatus(
-          prisonNumber = prisonNumber,
-          prisonId = prisonId,
-          reviewSchedule = this,
-          newStatus = ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE,
-          exemptionReason = null,
-        ).also {
-          log.debug { "Review Schedule for prisoner [$prisonNumber] set to exempt: EXEMPT_PRISONER_RELEASE" }
-        }
-      }
-      ?: throw ReviewScheduleNotFoundException(prisonNumber)
+    exemptActiveReviewSchedule(prisonNumber, prisonId, ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE)
 
-  /**
-   * Updates the prisoner's active Review Schedule by setting its status to EXEMPT_PRISONER_DEATH
-   *
-   * The prisoner's active Review Schedule is the one with the status SCHEDULED or one of the EXEMPT_ statuses.
-   * A Review Schedule with the status COMPLETE, EXEMPT_PRISONER_RELEASE, EXEMPT_PRISONER_DEATH or EXEMPT_UNKNOWN is not considered 'active'
-   */
+  fun exemptActiveReviewScheduleStatusDueToMerge(prisonNumber: String, prisonId: String) =
+    exemptActiveReviewSchedule(prisonNumber, prisonId, ReviewScheduleStatus.EXEMPT_PRISONER_MERGE)
+
   fun exemptActiveReviewScheduleStatusDueToPrisonerDeath(prisonNumber: String, prisonId: String) =
-    reviewSchedulePersistenceAdapter.getActiveReviewSchedule(prisonNumber)
-      ?.run {
-        updateExemptStatus(
-          prisonNumber = prisonNumber,
-          prisonId = prisonId,
-          reviewSchedule = this,
-          newStatus = ReviewScheduleStatus.EXEMPT_PRISONER_DEATH,
-          exemptionReason = null,
-        ).also {
-          log.debug { "Review Schedule for prisoner [$prisonNumber] set to exempt: EXEMPT_PRISONER_DEATH" }
-        }
-      }
-      ?: throw ReviewScheduleNotFoundException(prisonNumber)
+    exemptActiveReviewSchedule(prisonNumber, prisonId, ReviewScheduleStatus.EXEMPT_PRISONER_DEATH)
 
-  /**
-   * Updates the prisoner's active Review Schedule by setting its status to EXEMPT_UNKNOWN
-   *
-   * The prisoner's active Review Schedule is the one with the status SCHEDULED or one of the EXEMPT_ statuses.
-   * A Review Schedule with the status COMPLETE, EXEMPT_PRISONER_RELEASE, EXEMPT_PRISONER_DEATH or EXEMPT_UNKNOWN is not considered 'active'
-   */
   fun exemptActiveReviewScheduleStatusDueToUnknownReason(prisonNumber: String, prisonId: String) =
-    reviewSchedulePersistenceAdapter.getActiveReviewSchedule(prisonNumber)
-      ?.run {
-        updateExemptStatus(
-          prisonNumber = prisonNumber,
-          prisonId = prisonId,
-          reviewSchedule = this,
-          newStatus = ReviewScheduleStatus.EXEMPT_UNKNOWN,
-          exemptionReason = null,
-        ).also {
-          log.debug { "Review Schedule for prisoner [$prisonNumber] set to exempt: EXEMPT_UNKNOWN" }
-        }
-      }
-      ?: throw ReviewScheduleNotFoundException(prisonNumber)
+    exemptActiveReviewSchedule(prisonNumber, prisonId, ReviewScheduleStatus.EXEMPT_UNKNOWN)
 
   /**
    * Updates the prisoner's active Review Schedule by setting its status to EXEMPT_PRISONER_TRANSFER, then immediately

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerExemptDueToMergeEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerExemptDueToMergeEventTest.kt
@@ -1,0 +1,169 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilAsserted
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
+import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_MERGED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequestForPrisonerNotLookingToWork
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.assertThat
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionScheduleStatus as InductionScheduleStatusEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleStatus as ReviewScheduleStatusEntity
+
+@Isolated
+class PrisonerExemptDueToMergeEventTest : IntegrationTestBase() {
+  @Test
+  fun `should update Review Schedule given merged prisoner had an active Review Schedule`() {
+    // Given
+    // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
+    val prisonNumber = aValidPrisonNumber()
+    createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork())
+    createActionPlan(prisonNumber)
+
+    // The above calls set the data up but they will also generate events so clear these out before starting the test.
+    // Before clearing the queues though we need to wait until the "plp.review-schedule.updated" event on the REVIEW queue is received.
+    await untilCallTo {
+      reviewScheduleEventQueue.countAllMessagesOnQueue()
+    } matches { it != null && it > 0 }
+    clearQueues()
+
+    val sqsMessage = sqsMessage(prisonNumber)
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    val actionPlanReviews = getActionPlanReviews(prisonNumber)
+    assertThat(actionPlanReviews)
+      .latestReviewSchedule {
+        it.hasStatus(ReviewScheduleStatus.EXEMPT_PRISONER_MERGE)
+      }
+  }
+
+  @Test
+  fun `should not update Review Schedule given merged prisoner does not have an active Review Schedule`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
+    createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork())
+    createActionPlan(prisonNumber)
+    // Before updating the status of the Review Schedule we need to wait until 1 "plp.review-schedule.updated" event on the REVIEW queue is received (which is the creation of the initial Review Schedule)
+    await untilCallTo {
+      reviewScheduleEventQueue.countAllMessagesOnQueue()
+    } matches { it != null && it > 0 }
+    // Update the status of the Review Schedule to Completed, which means the prisoner no longer has an active Review Schedule
+    updateReviewScheduleRecordStatus(prisonNumber, ReviewScheduleStatusEntity.COMPLETED)
+
+    clearQueues()
+
+    val sqsMessage = sqsMessage(prisonNumber)
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    val actionPlanReviews = getActionPlanReviews(prisonNumber)
+    assertThat(actionPlanReviews)
+      .latestReviewSchedule {
+        it.hasStatus(ReviewScheduleStatus.COMPLETED)
+      }
+  }
+
+  @Test
+  fun `should not create or update Review Schedule given merged prisoner does not have a Review Schedule at all`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    assertThat(runCatching { getActionPlanReviews(prisonNumber) }.getOrNull()).isNull()
+
+    val sqsMessage = sqsMessage(prisonNumber)
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    assertThat(runCatching { getActionPlanReviews(prisonNumber) }.getOrNull()).isNull()
+  }
+
+  @Test
+  fun `should update Induction Schedule given merged prisoner had an active Induction Schedule`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    createInductionSchedule(prisonNumber)
+
+    val sqsMessage = sqsMessage(prisonNumber)
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    await untilAsserted {
+      val inductionSchedule = getInductionSchedule(prisonNumber)
+      assertThat(inductionSchedule)
+        .wasStatus(InductionScheduleStatus.EXEMPT_PRISONER_MERGE)
+    }
+  }
+
+  @Test
+  fun `should not update Induction Schedule given merged prisoner had a completed Induction Schedule`() {
+    // Given
+    val prisonNumber = aValidPrisonNumber()
+    createInductionSchedule(prisonNumber, status = InductionScheduleStatusEntity.COMPLETED)
+
+    val sqsMessage = sqsMessage(prisonNumber)
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    await untilAsserted {
+      val inductionSchedule = getInductionSchedule(prisonNumber)
+      assertThat(inductionSchedule)
+        .wasStatus(InductionScheduleStatus.COMPLETED)
+    }
+  }
+
+  private fun sqsMessage(prisonNumber: String): SqsMessage {
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_MERGED,
+      additionalInformation = aValidPrisonerMergedAdditionalInformation(
+        removedNomsNumber = prisonNumber,
+        reason = AdditionalInformation.PrisonerMergedAdditionalInformation.Reason.MERGE,
+      ),
+    )
+    return sqsMessage
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
 import com.fasterxml.jackson.databind.ObjectMapper
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_MERGED
@@ -21,6 +22,7 @@ class InboundEventsService(
   private val mapper: ObjectMapper,
   private val prisonerReceivedIntoPrisonEventService: PrisonerReceivedIntoPrisonEventService,
   private val prisonerReleasedFromPrisonEventService: PrisonerReleasedFromPrisonEventService,
+  private val prisonerMergedEventService: PrisonerMergedEventService,
 ) {
 
   fun process(inboundEvent: InboundEvent) =
@@ -37,7 +39,8 @@ class InboundEventsService(
           prisonerReleasedFromPrisonEventService.process(inboundEvent, additionalInformation)
         }
         PRISONER_MERGED -> {
-          // TODO process prisoner merged message
+          val additionalInformation = eventAdditionalInformation<PrisonerMergedAdditionalInformation>(inboundEvent)
+          prisonerMergedEventService.process(inboundEvent, additionalInformation)
         }
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerMergedEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerMergedEventService.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleNotFoundException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNotFoundException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewScheduleService
+
+private val log = KotlinLogging.logger {}
+
+private const val REVIEW_SCHEDULE = "Review Schedule"
+private const val INDUCTION_SCHEDULE = "Induction Schedule"
+
+@Service
+class PrisonerMergedEventService(
+  private val reviewScheduleService: ReviewScheduleService,
+  private val inductionScheduleService: InductionScheduleService,
+) {
+  fun process(
+    inboundEvent: InboundEvent,
+    additionalInformation: AdditionalInformation.PrisonerMergedAdditionalInformation,
+  ) =
+    with(additionalInformation) {
+      log.info { "Processing Prisoner Merged event removed noms number [$removedNomsNumber]" }
+      handle(
+        REVIEW_SCHEDULE,
+      ) { reviewScheduleService.exemptActiveReviewScheduleStatusDueToMerge(removedNomsNumber, "N/A") }
+      handle(
+        INDUCTION_SCHEDULE,
+      ) { inductionScheduleService.exemptActiveInductionScheduleStatusDueToMerge(removedNomsNumber, "N/A") }
+    }
+
+  private fun handle(
+    scheduleType: String,
+    action: () -> Unit,
+  ) {
+    try {
+      action()
+    } catch (e: Exception) {
+      if (e is ReviewScheduleNotFoundException || e is InductionScheduleNotFoundException) {
+        log.debug { "Prisoner does not have an active $scheduleType; no need to set it as exempt" }
+      } else {
+        throw e // Re-throw unexpected exceptions
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/InboundEventsServiceTest.kt
@@ -9,6 +9,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation.Reason.MERGE
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Location.IN_PRISON
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.PrisonStatus.UNDER_PRISON_CARE
@@ -30,6 +32,9 @@ class InboundEventsServiceTest {
 
   @Mock
   private lateinit var prisonerReleasedFromPrisonEventService: PrisonerReleasedFromPrisonEventService
+
+  @Mock
+  private lateinit var prisonerMergedEventService: PrisonerMergedEventService
 
   @InjectMocks
   private lateinit var inboundEventsService: InboundEventsService
@@ -106,5 +111,38 @@ class InboundEventsServiceTest {
       PrisonerReleasedAdditionalInformation::class.java,
     )
     verify(prisonerReleasedFromPrisonEventService).process(inboundEvent, expectedAdditionalInformation)
+  }
+
+  @Test
+  fun `should process inbound event given prisoner merged event`() {
+    // Given
+    val inboundEvent = InboundEvent(
+      eventType = EventType.PRISONER_MERGED,
+      description = "A prisoner has been merged from A4321BC to A1234BC",
+      personReference = PersonReference(
+        identifiers = listOf(Identifier("NOMS", "A1234BC")),
+      ),
+      version = "1.0",
+      occurredAt = Instant.parse("2024-08-08T09:07:55+01:00"),
+      publishedAt = Instant.parse("2024-08-08T09:08:55.673395103+01:00"),
+      additionalInformation = "{ \\\"nomsNumber\\\":\\\"A4321BC\\\", \\\"removedNomsNumber\\\":\\\"A4432FD\\\", \\\"reason\\\":\\\"MERGE\\\" }",
+    )
+
+    val expectedAdditionalInformation = PrisonerMergedAdditionalInformation(
+      nomsNumber = "A1234BC",
+      reason = MERGE,
+      removedNomsNumber = "A4321BC",
+    )
+    given(objectMapper.readValue(any<String>(), any<Class<*>>())).willReturn(expectedAdditionalInformation)
+
+    // When
+    inboundEventsService.process(inboundEvent)
+
+    // Then
+    verify(objectMapper).readValue(
+      inboundEvent.additionalInformation,
+      PrisonerMergedAdditionalInformation::class.java,
+    )
+    verify(prisonerMergedEventService).process(inboundEvent, expectedAdditionalInformation)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerMergedEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerMergedEventServiceTest.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewScheduleService
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+class PrisonerMergedEventServiceTest {
+  @InjectMocks
+  private lateinit var eventService: PrisonerMergedEventService
+
+  @Mock
+  private lateinit var reviewScheduleService: ReviewScheduleService
+
+  @Mock
+  private lateinit var inductionScheduleService: InductionScheduleService
+
+  private val objectMapper = ObjectMapper()
+
+  @Test
+  fun `should process event given prisoner is merged`() {
+    // Given
+    val removedNomsNumber = randomValidPrisonNumber()
+
+    val additionalInformation = aValidPrisonerMergedAdditionalInformation(
+      prisonNumber = "A1234BC",
+      reason = PrisonerMergedAdditionalInformation.Reason.MERGE,
+      removedNomsNumber = removedNomsNumber,
+    )
+    val inboundEvent = anInboundEvent(additionalInformation)
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(reviewScheduleService).exemptActiveReviewScheduleStatusDueToMerge(
+      prisonNumber = removedNomsNumber,
+      prisonId = "N/A",
+    )
+  }
+
+  private fun anInboundEvent(additionalInformation: PrisonerMergedAdditionalInformation): InboundEvent =
+    InboundEvent(
+      eventType = EventType.PRISONER_MERGED,
+      personReference = PersonReference(listOf(Identifier(type = "noms", value = "A1234BC"))),
+      occurredAt = Instant.now(),
+      publishedAt = Instant.now(),
+      description = "Prisoner merged event",
+      version = "1.0",
+      additionalInformation = objectMapper.writeValueAsString(additionalInformation),
+    )
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformationBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AdditionalInformationBuilder.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
 
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation.Reason
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
 
@@ -45,9 +47,9 @@ fun aValidPrisonerReleasedAdditionalInformation(
 fun aValidPrisonerMergedAdditionalInformation(
   prisonNumber: String = aValidPrisonNumber(),
   removedNomsNumber: String,
-  reason: AdditionalInformation.PrisonerMergedAdditionalInformation.Reason = AdditionalInformation.PrisonerMergedAdditionalInformation.Reason.MERGE,
-): AdditionalInformation.PrisonerMergedAdditionalInformation =
-  AdditionalInformation.PrisonerMergedAdditionalInformation(
+  reason: Reason = Reason.MERGE,
+): PrisonerMergedAdditionalInformation =
+  PrisonerMergedAdditionalInformation(
     nomsNumber = prisonNumber,
     reason = reason,
     removedNomsNumber = removedNomsNumber,


### PR DESCRIPTION
Second PR for merge offender message processing. Here I'm checking to see if the person has a review or induction schedule then marking them as EXEMPT_PRISONER_MERGE. 

I wonder if we should also mark something else on the plp record to say that this person is removed due to merge? We don't store a prisoner record so maybe something on action plan? 