### PR TITLE
Specific rules for existing prisoners wrt induction deaslines

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
@@ -26,7 +26,7 @@ abstract class InductionScheduleDateCalculationService(
    * Known implementations at this time are those for the CIAG PEF and PES contracts, where a prisoner's initial Induction Schedule
    * is created differently under those contracts.
    */
-  abstract fun determineCreateInductionScheduleDto(prisonNumber: String, admissionDate: LocalDate, prisonId: String, newAdmission: Boolean = true): CreateInductionScheduleDto
+  abstract fun determineCreateInductionScheduleDto(prisonNumber: String, admissionDate: LocalDate, prisonId: String, newAdmission: Boolean = true, releaseDate: LocalDate? = null): CreateInductionScheduleDto
 
   fun calculateAdjustedInductionDueDate(inductionSchedule: InductionSchedule): LocalDate =
     with(inductionSchedule) {

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
@@ -31,6 +31,7 @@ class InductionScheduleService(
     prisonerAdmissionDate: LocalDate,
     prisonId: String,
     newAdmission: Boolean = true,
+    releaseDate: LocalDate? = null,
   ): InductionSchedule {
     // Check for an existing Induction Schedule
     val inductionSchedule = runCatching {
@@ -46,6 +47,7 @@ class InductionScheduleService(
       admissionDate = prisonerAdmissionDate,
       prisonId = prisonId,
       newAdmission = newAdmission,
+      releaseDate = releaseDate,
     )
     return inductionSchedulePersistenceAdapter.createInductionSchedule(createInductionScheduleDto)
       .also {
@@ -66,6 +68,7 @@ class InductionScheduleService(
     prisonNumber: String,
     prisonerAdmissionDate: LocalDate,
     prisonId: String,
+    releaseDate: LocalDate?,
   ): InductionSchedule {
     val inductionSchedule = inductionSchedulePersistenceAdapter.getInductionSchedule(prisonNumber)
       ?: throw InductionScheduleNotFoundException(prisonNumber)
@@ -79,6 +82,7 @@ class InductionScheduleService(
         prisonNumber = prisonNumber,
         admissionDate = prisonerAdmissionDate,
         prisonId = prisonId,
+        releaseDate = releaseDate,
       ).deadlineDate
 
       updateInductionSchedule(

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
@@ -23,6 +23,7 @@ class InductionScheduleDateCalculationServiceTest {
       admissionDate: LocalDate,
       prisonId: String,
       newAdmission: Boolean,
+      releaseDate: LocalDate?,
     ): CreateInductionScheduleDto {
       TODO("Not implemented here")
     }

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleServiceTest.kt
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -153,7 +154,7 @@ class InductionScheduleServiceTest {
       given(inductionSchedulePersistenceAdapter.getInductionSchedule(any())).willReturn(null)
 
       val createInductionScheduleDto = aValidCreateInductionScheduleDto(prisonNumber = prisonNumber)
-      given(inductionScheduleDateCalculationService.determineCreateInductionScheduleDto(any(), any(), any(), any())).willReturn(createInductionScheduleDto)
+      given(inductionScheduleDateCalculationService.determineCreateInductionScheduleDto(any(), any(), any(), any(), anyOrNull())).willReturn(createInductionScheduleDto)
 
       val expectedInductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber)
       given(inductionSchedulePersistenceAdapter.createInductionSchedule(any())).willReturn(expectedInductionSchedule)
@@ -164,7 +165,7 @@ class InductionScheduleServiceTest {
       // Then
       assertThat(actual).isEqualTo(expectedInductionSchedule)
       verify(inductionSchedulePersistenceAdapter).getInductionSchedule(prisonNumber)
-      verify(inductionScheduleDateCalculationService).determineCreateInductionScheduleDto(prisonNumber, admissionDate, prisonId, true)
+      verify(inductionScheduleDateCalculationService).determineCreateInductionScheduleDto(prisonNumber, admissionDate, prisonId, true, null)
       verify(inductionSchedulePersistenceAdapter).createInductionSchedule(createInductionScheduleDto)
       verify(inductionScheduleEventService).inductionScheduleCreated(actual)
     }
@@ -213,7 +214,7 @@ class InductionScheduleServiceTest {
       given(inductionSchedulePersistenceAdapter.getInductionSchedule(any())).willReturn(inductionSchedule)
 
       val expectedDueDate = prisonerAdmissionDate.plusDays(20)
-      given(inductionScheduleDateCalculationService.determineCreateInductionScheduleDto(any(), any(), any(), any())).willReturn(
+      given(inductionScheduleDateCalculationService.determineCreateInductionScheduleDto(any(), any(), any(), any(), anyOrNull())).willReturn(
         aValidCreateInductionScheduleDto(
           prisonNumber = prisonNumber,
           deadlineDate = expectedDueDate,
@@ -248,7 +249,7 @@ class InductionScheduleServiceTest {
       )
 
       // When
-      val actual = service.reschedulePrisonersInductionSchedule(prisonNumber, prisonerAdmissionDate, PRISON_ID)
+      val actual = service.reschedulePrisonersInductionSchedule(prisonNumber, prisonerAdmissionDate, PRISON_ID, null)
 
       // Then
       assertThat(actual).isEqualTo(expectedInductionSchedule)
@@ -268,7 +269,7 @@ class InductionScheduleServiceTest {
 
       // When
       val exception = catchThrowableOfType(InvalidInductionScheduleStatusException::class.java) {
-        service.reschedulePrisonersInductionSchedule(prisonNumber, TODAY, PRISON_ID)
+        service.reschedulePrisonersInductionSchedule(prisonNumber, TODAY, PRISON_ID, null)
       }
 
       // Then
@@ -287,7 +288,7 @@ class InductionScheduleServiceTest {
 
       // When
       val exception = catchThrowableOfType(InductionScheduleNotFoundException::class.java) {
-        service.reschedulePrisonersInductionSchedule(prisonNumber, TODAY, PRISON_ID)
+        service.reschedulePrisonersInductionSchedule(prisonNumber, TODAY, PRISON_ID, null)
       }
 
       // Then

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
@@ -56,6 +56,7 @@ class PrisonerReceivedIntoPrisonEventService(
         prisonNumber = nomsNumber,
         prisonerAdmissionDate = prisonerAdmissionDate,
         prisonId = prisonId,
+        releaseDate = prisoner.releaseDate,
       )
     } catch (e: InductionScheduleAlreadyExistsException) {
       // Prisoner already has an Induction Schedule
@@ -67,7 +68,12 @@ class PrisonerReceivedIntoPrisonEventService(
 
         else -> {
           // The Induction was not completed so need to reschedule it with a new deadline date.
-          inductionScheduleService.reschedulePrisonersInductionSchedule(nomsNumber, prisonerAdmissionDate, prisonId)
+          inductionScheduleService.reschedulePrisonersInductionSchedule(
+            nomsNumber,
+            prisonerAdmissionDate = prisonerAdmissionDate,
+            prisonId = prisonId,
+            releaseDate = prisoner.releaseDate,
+          )
         }
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ScheduleEtlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ScheduleEtlController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import io.swagger.v3.oas.annotations.Hidden
 import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -35,6 +36,7 @@ private val log = KotlinLogging.logger {}
 @Hidden
 @RestController
 class ScheduleEtlController(
+  @Value("\${EDUCATION_CONTRACTS_START_DATE:}") private val scheduleDateNotBefore: LocalDate? = null,
   private val prisonerSearchApiService: PrisonerSearchApiService,
   private val inductionRepository: InductionRepository,
   private val actionPlanRepository: ActionPlanRepository,
@@ -66,9 +68,11 @@ class ScheduleEtlController(
     val prisonersWithoutReviewSchedules = filterPrisonersWithoutReviewSchedules(allPrisoners)
     val prisonersWithoutInductionSchedule = filterPrisonersWithoutInductionSchedule(allPrisoners)
     val prisonersWithInductions = filterPrisonersWithInductions(allPrisoners)
-    val prisonersWithInductionsAndNoReviewSchedule = filterPrisonersWithInductionButNoReviewSchedule(prisonersWithInductions, prisonersWithoutReviewSchedules)
+    val prisonersWithInductionsAndNoReviewSchedule =
+      filterPrisonersWithInductionButNoReviewSchedule(prisonersWithInductions, prisonersWithoutReviewSchedules)
 
-    val eligibleInductionSchedulePrisoners = filterPrisonersWithNoInduction(prisonersWithoutInductionSchedule, prisonersWithInductions)
+    val eligibleInductionSchedulePrisoners =
+      filterPrisonersWithNoInduction(prisonersWithoutInductionSchedule, prisonersWithInductions)
     val eligibleReviewSchedulePrisoners = filterPrisonersWithActionPlans(prisonersWithInductionsAndNoReviewSchedule)
 
     val totalPrisonersWithInductionSchedule = totalPrisonersInPrison - prisonersWithoutInductionSchedule.size
@@ -133,17 +137,24 @@ class ScheduleEtlController(
     failedInductionSchedules: MutableList<String>,
   ) {
     eligibleInductionSchedulePrisoners.forEach { prisoner ->
-      val prisonNumber = prisoner.prisonerNumber
-      try {
-        createInductionSchedule(prisoner)
-        createdInductionSchedules.add(prisonNumber)
-      } catch (e: Exception) {
-        handleInductionScheduleCreationError(prisonNumber, e, failedInductionSchedules)
+      if (prisoner.releaseDate?.isBefore(scheduleDateNotBefore?.plusDays(7)) == true) {
+        log.info { "Induction for prisoner ${prisoner.prisonerNumber} skipped due to release within 7 days of go-live." }
+      } else {
+        val prisonNumber = prisoner.prisonerNumber
+        try {
+          createInductionSchedule(prisoner)
+          createdInductionSchedules.add(prisonNumber)
+        } catch (e: Exception) {
+          handleInductionScheduleCreationError(prisonNumber, e, failedInductionSchedules)
+        }
       }
     }
   }
 
-  private fun filterPrisonersWithNoInduction(prisoners: List<Prisoner>, prisonersWithInductions: List<Prisoner>): List<Prisoner> {
+  private fun filterPrisonersWithNoInduction(
+    prisoners: List<Prisoner>,
+    prisonersWithInductions: List<Prisoner>,
+  ): List<Prisoner> {
     val prisonerNumbersWithInductions = prisonersWithInductions.map { it.prisonerNumber }.toSet()
     return prisoners.filter { it.prisonerNumber !in prisonerNumbersWithInductions }
   }
@@ -169,7 +180,10 @@ class ScheduleEtlController(
     return prisoners.filter { it.prisonerNumber in prisonersWithInductions }
   }
 
-  private fun filterPrisonersWithInductionButNoReviewSchedule(prisonersWithInduction: List<Prisoner>, prisonersWithoutReviewSchedules: List<Prisoner>): List<Prisoner> {
+  private fun filterPrisonersWithInductionButNoReviewSchedule(
+    prisonersWithInduction: List<Prisoner>,
+    prisonersWithoutReviewSchedules: List<Prisoner>,
+  ): List<Prisoner> {
     val prisonNumbersWithNoReviewSchedule = prisonersWithoutReviewSchedules.map { it.prisonerNumber }
     return prisonersWithInduction.filter { it.prisonerNumber in prisonNumbersWithNoReviewSchedule }
   }
@@ -197,6 +211,7 @@ class ScheduleEtlController(
       prisonerAdmissionDate = LocalDate.now(),
       prisonId = prisoner.prisonId ?: "N/A",
       newAdmission = false,
+      releaseDate = prisoner.releaseDate,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationService.kt
@@ -38,6 +38,7 @@ class PefInductionScheduleDateCalculationService(
     admissionDate: LocalDate,
     prisonId: String,
     newAdmission: Boolean,
+    releaseDate: LocalDate?,
   ): CreateInductionScheduleDto {
     return if (newAdmission) {
       CreateInductionScheduleDto(
@@ -50,11 +51,21 @@ class PefInductionScheduleDateCalculationService(
     } else {
       CreateInductionScheduleDto(
         prisonNumber = prisonNumber,
-        deadlineDate = baseScheduleDate().plusMonths(6),
+        deadlineDate = calculateDeadlineDate(releaseDate),
         scheduleCalculationRule = InductionScheduleCalculationRule.EXISTING_PRISONER,
         scheduleStatus = InductionScheduleStatus.SCHEDULED,
         prisonId = prisonId,
       )
+    }
+  }
+
+  private fun calculateDeadlineDate(releaseDate: LocalDate?): LocalDate {
+    val sixMonthsAfterBase = baseScheduleDate().plusMonths(6)
+
+    return when {
+      releaseDate == null -> sixMonthsAfterBase
+      releaseDate.isBefore(sixMonthsAfterBase) -> releaseDate.minusDays(7)
+      else -> sixMonthsAfterBase
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationService.kt
@@ -28,7 +28,7 @@ class PesInductionScheduleDateCalculationService : InductionScheduleDateCalculat
    * Once the S&A's have been completed in Curious the [InductionSchedule] has it's status set to SCHEDULED and the
    * deadline date correctly set (via a listener on the event sent from Curious)
    */
-  override fun determineCreateInductionScheduleDto(prisonNumber: String, admissionDate: LocalDate, prisonId: String, newAdmission: Boolean): CreateInductionScheduleDto =
+  override fun determineCreateInductionScheduleDto(prisonNumber: String, admissionDate: LocalDate, prisonId: String, newAdmission: Boolean, releaseDate: LocalDate?): CreateInductionScheduleDto =
     CreateInductionScheduleDto(
       prisonNumber = prisonNumber,
       deadlineDate = LocalDate.now(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -77,7 +78,7 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     eventService.process(inboundEvent, additionalInformation)
 
     // Then
-    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId)
+    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId, releaseDate = prisoner.releaseDate)
     verifyNoInteractions(reviewScheduleService)
   }
 
@@ -99,7 +100,7 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     )
 
     val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = COMPLETED)
-    given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any())).willThrow(
+    given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any(), anyOrNull())).willThrow(
       InductionScheduleAlreadyExistsException(inductionSchedule),
     )
 
@@ -117,7 +118,7 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     eventService.process(inboundEvent, additionalInformation)
 
     // Then
-    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId)
+    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId, releaseDate = prisoner.releaseDate)
     verify(reviewScheduleService).getActiveReviewScheduleForPrisoner(prisonNumber)
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)
     verify(createInitialReviewScheduleMapper).fromPrisonerToDomain(prisoner, isTransfer = false, isReadmission = true)
@@ -145,7 +146,7 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     )
 
     val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = COMPLETED)
-    given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any())).willThrow(
+    given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any(), anyOrNull())).willThrow(
       InductionScheduleAlreadyExistsException(inductionSchedule),
     )
 
@@ -162,7 +163,7 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     eventService.process(inboundEvent, additionalInformation)
 
     // Then
-    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId)
+    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId, releaseDate = prisoner.releaseDate)
     verify(reviewScheduleService).getActiveReviewScheduleForPrisoner(prisonNumber)
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)
     verify(reviewScheduleService).exemptActiveReviewScheduleStatusDueToUnknownReason(prisonNumber, prisonId)
@@ -191,7 +192,7 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     )
 
     val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = SCHEDULED)
-    given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any())).willThrow(
+    given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any(), anyOrNull())).willThrow(
       InductionScheduleAlreadyExistsException(inductionSchedule),
     )
 
@@ -199,8 +200,8 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     eventService.process(inboundEvent, additionalInformation)
 
     // Then
-    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId)
-    verify(inductionScheduleService).reschedulePrisonersInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId)
+    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId, releaseDate = prisoner.releaseDate)
+    verify(inductionScheduleService).reschedulePrisonersInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId, releaseDate = prisoner.releaseDate)
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)
   }
 


### PR DESCRIPTION
PR to address the following:

For prisoners who have a release date that falls prior to the deadline set on the 1st October 2025 then; 

We will set the deadline as their release date minus 7 days. This will reduce the risk of setting deadlines that are already overdue on go-live
If a prisoner is due to be released within 7 days of go live date (i.e. if they are released before 8 April) then they are exempt from the requirement

