### PR TITLE
RR-1270 - fix bug by calling prisoner-search-api once rather than as a paged request

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/InductionSchedule.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/InductionSchedule.kt
@@ -71,8 +71,4 @@ enum class InductionScheduleStatus(
   fun isExemptionOrExclusion(): Boolean {
     return isExemption || isExclusion
   }
-
-  fun includeExceptionOnSummary(): Boolean {
-    return (isExemption || isExclusion) && includeExemptionOnSummary
-  }
 }

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionSchedulePersistenceAdapter.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionSchedulePersistenceAdapter.kt
@@ -44,6 +44,8 @@ interface InductionSchedulePersistenceAdapter {
    * Update the Induction schedule status and the deadlineDate.
    */
   fun updateInductionScheduleStatus(updateInductionScheduleStatusDto: UpdateInductionScheduleStatusDto): InductionSchedule
+
   fun getActiveInductionSchedule(prisonNumber: String): InductionSchedule?
+
   fun getInCompleteInductionSchedules(prisonerNumbers: List<String>): List<InductionSchedule>
 }

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/ReviewSchedule.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/ReviewSchedule.kt
@@ -63,10 +63,6 @@ enum class ReviewScheduleStatus(
   fun isExemptionOrExclusion(): Boolean {
     return isExemption || isExclusion
   }
-
-  fun includeExceptionOnSummary(): Boolean {
-    return (isExemption || isExclusion) && includeExemptionOnSummary
-  }
 }
 
 data class ReviewScheduleWindow(

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewSchedulePersistenceAdapter.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewSchedulePersistenceAdapter.kt
@@ -53,5 +53,6 @@ interface ReviewSchedulePersistenceAdapter {
    * Update the Review schedule status, prisonId and if present the latestReviewDate.
    */
   fun updateReviewScheduleStatus(updateReviewScheduleStatusDto: UpdateReviewScheduleStatusDto): ReviewSchedule
+
   fun getInCompleteReviewSchedules(prisonerNumbers: List<String>): List<ReviewSchedule>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerSearchApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerSearchApiService.kt
@@ -10,11 +10,12 @@ private val log = KotlinLogging.logger {}
 @Service
 class PrisonerSearchApiService(
   private val prisonerSearchApiClient: PrisonerSearchApiClient,
+// prisoner-search-api appears to be buggy in it's paged API implementation, so safest to request a large page size to get all records in one hit (arguably not the most efficient though)
+  private val pageSize: Int = 9999,
 ) {
 
   fun getAllPrisonersInPrison(prisonId: String): List<Prisoner> {
     var page = 0
-    val pageSize = 250
 
     val prisoners = mutableListOf<Prisoner>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerSearchApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerSearchApiServiceTest.kt
@@ -4,11 +4,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
-import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch.PagedPrisonerResponse
@@ -19,11 +18,12 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisoners
 
 @ExtendWith((MockitoExtension::class))
 class PrisonerSearchApiServiceTest {
-  @InjectMocks
-  private lateinit var service: PrisonerSearchApiService
+  private val prisonerSearchApiClient: PrisonerSearchApiClient = mock()
 
-  @Mock
-  private lateinit var prisonerSearchApiClient: PrisonerSearchApiClient
+  private val service = PrisonerSearchApiService(
+    prisonerSearchApiClient = prisonerSearchApiClient,
+    pageSize = 250,
+  )
 
   @Test
   fun `should get all prisoners in a prison given they are all returned in the first request`() {


### PR DESCRIPTION
This PR fixes a bug we were seeing with the `GET /session/{prisonId}/summary` endpoint, where it would return differing responses (session counts) on different calls.

The way `GET /session/{prisonId}/summary` works is that it returns session counts for prisoners in the given prison.
In our database we store records keyed by prisoner NOMS ID, but we do not hold the prison ID. Therefore in order to get the number of sessions for prisoners in BXI, you first need to know which prisoners (their NOMS ID) are in BXI, and from that you can then query the relevant PLP databases.

To get the list of prisoners in the given prison we call a `prisoner-search-api` endpoint. The [endpoint in question is a paged API](https://prisoner-search-dev.prison.service.justice.gov.uk/swagger-ui/index.html#/Popular/findByPrison), so we have written our service method to call it in a paged manner, with a nominal page size of 250.
A worked example would be Brixton where in `dev` there are 868 prisoners. With a page size of 250 we would call the API 4 times, with 3 x 250 responses plus a final response of 118
The service code keeps appending the responses to a list of prisoners, then returns the list 👍 

We have found that calling prisoner-search-api in this way is not a reliable way of getting all the prisoners in a prison. We suspect that this is because even though it always returns a total of 868 records over the 4 pages, the order of those prisoners is inconsistent, and (more problematic) you can get duplicates across page requests. We suspect this is probably an indexing or similar problem in `prisoner-search-api`:
Given the prisoners A, B, C, D, E, F, G, H, I and J; if you were to call the paged API with a page size of 3 you might expect responses:
1: [A, B, C]
2: [D, E, F]
3: [G, H, I]
4: [J]
The order is irrelevant, just as long as you get all records, and they are only represented once.

What we suspect is happening is that we get back responses such as:
1: [A, J, D]
2: [E, D, F]
3: [B, C, I]
4: [H]
where D is returned twice, and G is not returned at all.

The quick fix (for us) is to use a large page size when calling `prisoner-search-api` which ensures we get all the prisoners in one request. (though a better fix would be in `prisoner-search-api` somewhere ...)

