### PR TITLE
Handle DB constraint error

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -244,7 +244,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       updatedByDisplayName = updateDisplayName,
       updatedAtPrison = "MDI",
     )
-    shortDelayForTimestampChecking()
+    shortDelay()
 
     // When
     webTestClient.put()
@@ -392,7 +392,7 @@ class UpdateInductionTest : IntegrationTestBase() {
       updatedByDisplayName = updateDisplayName,
       updatedAtPrison = "MDI",
     )
-    shortDelayForTimestampChecking()
+    shortDelay()
 
     // When
     webTestClient.put()
@@ -676,9 +676,5 @@ class UpdateInductionTest : IntegrationTestBase() {
         .wasUpdatedBy("buser_gen")
         .wasCreatedAtPrison("MDI")
     }
-  }
-
-  private fun shortDelayForTimestampChecking() {
-    Thread.sleep(200)
   }
 }


### PR DESCRIPTION
Not 100% happy with this as it feels like a bit of a bodge.

Basically when we get the constraint issue - pause and then try again. I'm presuming that this is happening because the timeline records are still being written to the database asynchronously and some tests aren't using the await and check the timeline is complete - since they don't need to test this. 
 