### PR TITLE
Changes to test resetting

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerExemptDueToMergeEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerExemptDueToMergeEventTest.kt
@@ -6,7 +6,7 @@ import org.awaitility.kotlin.untilAsserted
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Isolated
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_MERGED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus
@@ -24,7 +24,7 @@ class PrisonerExemptDueToMergeEventTest : IntegrationTestBase() {
   fun `should update Review Schedule given merged prisoner had an active Review Schedule`() {
     // Given
     // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork())
     createActionPlan(prisonNumber)
 
@@ -56,7 +56,7 @@ class PrisonerExemptDueToMergeEventTest : IntegrationTestBase() {
   @Test
   fun `should not update Review Schedule given merged prisoner does not have an active Review Schedule`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
     createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork())
     createActionPlan(prisonNumber)
@@ -90,7 +90,7 @@ class PrisonerExemptDueToMergeEventTest : IntegrationTestBase() {
   @Test
   fun `should not create or update Review Schedule given merged prisoner does not have a Review Schedule at all`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     assertThat(runCatching { getActionPlanReviews(prisonNumber) }.getOrNull()).isNull()
 
     val sqsMessage = sqsMessage(prisonNumber)
@@ -110,7 +110,7 @@ class PrisonerExemptDueToMergeEventTest : IntegrationTestBase() {
   @Test
   fun `should update Induction Schedule given merged prisoner had an active Induction Schedule`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createInductionSchedule(prisonNumber)
 
     val sqsMessage = sqsMessage(prisonNumber)
@@ -134,7 +134,7 @@ class PrisonerExemptDueToMergeEventTest : IntegrationTestBase() {
   @Test
   fun `should not update Induction Schedule given merged prisoner had a completed Induction Schedule`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createInductionSchedule(prisonNumber, status = InductionScheduleStatusEntity.COMPLETED)
 
     val sqsMessage = sqsMessage(prisonNumber)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventDueToTransferTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventDueToTransferTest.kt
@@ -6,9 +6,7 @@ import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Isolated
-import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch.aValidPrisoner
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.TRANSFERRED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RECEIVED_INTO_PRISON
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleStatus
@@ -29,10 +27,7 @@ class PrisonerReceivedEventDueToTransferTest : IntegrationTestBase() {
   fun `should update Review Schedule and send outbound message given 'prisoner received' (transfer) event for prisoner that has an active Review Schedule with review date later than adjusted date`() {
     // Given
     // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
-    val prisonNumber = randomValidPrisonNumber()
-    val prisoner = aValidPrisoner(prisonNumber)
-    wiremockService.stubGetPrisonerFromPrisonerSearchApi(prisonNumber, prisoner)
-
+    val prisonNumber = setUpRandomPrisoner()
     createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork(prisonId = ORIGINAL_PRISON))
     createActionPlan(prisonNumber)
 
@@ -95,9 +90,7 @@ class PrisonerReceivedEventDueToTransferTest : IntegrationTestBase() {
   fun `should update Review Schedule and send outbound message given 'prisoner received' (transfer) event for prisoner that has an active Review Schedule with review date earlier than adjusted date`() {
     // Given
     // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
-    val prisonNumber = randomValidPrisonNumber()
-    val prisoner = aValidPrisoner(prisonNumber)
-    wiremockService.stubGetPrisonerFromPrisonerSearchApi(prisonNumber, prisoner)
+    val prisonNumber = setUpRandomPrisoner()
 
     createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork(prisonId = ORIGINAL_PRISON))
     createActionPlan(prisonNumber)
@@ -160,7 +153,7 @@ class PrisonerReceivedEventDueToTransferTest : IntegrationTestBase() {
   @Test
   fun `should not update Review Schedule and not send outbound message given 'prisoner received' (transfer) event for prisoner that does not have a Review Schedule at all`() {
     // Given
-    val prisonNumber = randomValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     assertThat(getReviewSchedules(prisonNumber)).hasNumberOfReviewSchedules(0)
 
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedDueToDeathEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedDueToDeathEventTest.kt
@@ -6,7 +6,6 @@ import org.awaitility.kotlin.untilAsserted
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Isolated
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RELEASED_FROM_PRISON
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus
@@ -24,7 +23,7 @@ class PrisonerReleasedDueToDeathEventTest : IntegrationTestBase() {
   fun `should update Review Schedule given deceased prisoner had an active Review Schedule`() {
     // Given
     // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork())
     createActionPlan(prisonNumber)
 
@@ -63,7 +62,7 @@ class PrisonerReleasedDueToDeathEventTest : IntegrationTestBase() {
   @Test
   fun `should not update Review Schedule given released prisoner does not have an active Review Schedule`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
     createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork())
     createActionPlan(prisonNumber)
@@ -104,7 +103,7 @@ class PrisonerReleasedDueToDeathEventTest : IntegrationTestBase() {
   @Test
   fun `should not create or update Review Schedule given released prisoner does not have a Review Schedule at all`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     assertThat(runCatching { getActionPlanReviews(prisonNumber) }.getOrNull()).isNull()
 
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(
@@ -131,7 +130,7 @@ class PrisonerReleasedDueToDeathEventTest : IntegrationTestBase() {
   @Test
   fun `should update Induction Schedule given deceased prisoner had an active Induction Schedule`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     createInductionSchedule(prisonNumber)
 
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(
@@ -162,7 +161,7 @@ class PrisonerReleasedDueToDeathEventTest : IntegrationTestBase() {
   @Test
   fun `should not update Induction Schedule given deceased prisoner had a completed Induction Schedule`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     createInductionSchedule(prisonNumber, status = InductionScheduleStatusEntity.COMPLETED)
 
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReleasedEventTest.kt
@@ -5,7 +5,7 @@ import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Isolated
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionScheduleStatus.COMPLETED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RELEASED_FROM_PRISON
@@ -23,7 +23,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
   fun `should update Review Schedule given released prisoner has an active Review Schedule`() {
     // Given
     // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork())
     createActionPlan(prisonNumber)
 
@@ -62,7 +62,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
   @Test
   fun `should not update Review Schedule given released prisoner does not have an active Review Schedule`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     // an induction and action plan are created. This will have created the initial Review Schedule with the status SCHEDULED
     createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork())
     createActionPlan(prisonNumber)
@@ -103,7 +103,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
   @Test
   fun `should not create or update Review Schedule given released prisoner does not have a Review Schedule at all`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     assertThat(runCatching { getActionPlanReviews(prisonNumber) }.getOrNull()).isNull()
 
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(
@@ -131,7 +131,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
   fun `should update Induction Schedule given released prisoner has an active Induction Schedule`() {
     // Given
     // an induction schedule exists
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createInductionSchedule(prisonNumber)
 
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(
@@ -162,7 +162,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
   @Test
   fun `should not update Induction Schedule given released prisoner does not have an active Induction Schedule`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createInductionSchedule(prisonNumber, status = COMPLETED)
 
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(
@@ -193,7 +193,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
   @Test
   fun `should not create or update Induction Schedule given released prisoner does not have an Induction Schedule at all`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
 
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(
       prisonNumber = prisonNumber,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.aValidReference
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
@@ -41,10 +40,9 @@ class ArchiveGoalTest : IntegrationTestBase() {
     const val URI_TEMPLATE = "/action-plans/{prisonNumber}/goals/{goalReference}/archive"
   }
 
-  private val prisonNumber = randomValidPrisonNumber()
-
   @Test
   fun `should return unauthorized given no bearer token`() {
+    val prisonNumber = randomValidPrisonNumber()
     webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber, aValidReference())
       .contentType(APPLICATION_JSON)
@@ -55,6 +53,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
 
   @Test
   fun `should require the edit role`() {
+    val prisonNumber = randomValidPrisonNumber()
     webTestClient.put()
       .uri(URI_TEMPLATE, prisonNumber, aValidReference())
       .withBody(aValidArchiveGoalRequest())
@@ -68,6 +67,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 204 and archive a goal and record the reason and other text `() {
     // given
+    val prisonNumber = setUpRandomPrisoner()
     val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val reasonOther = "Because it's Monday"
     val archiveGoalRequest = aValidArchiveGoalRequest(
@@ -95,8 +95,8 @@ class ArchiveGoalTest : IntegrationTestBase() {
     await.untilAsserted {
       val timeline = getTimeline(prisonNumber)
       assertThat(timeline)
-        .hasNumberOfEvents(4)
-        .event(4) {
+        .hasNumberOfEvents(5)
+        .event(5) {
           // the 4th Timeline event will be the GOAL_ARCHIVED event
           it.hasEventType(TimelineEventType.GOAL_ARCHIVED)
             .wasActionedBy("buser_gen")
@@ -120,6 +120,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 204 and archive a goal and record the reason and other text and create an archive note`() {
     // given
+    val prisonNumber = setUpRandomPrisoner()
     val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val reasonOther = "Because it's Monday"
     val noteText = "no longer relevant"
@@ -149,9 +150,9 @@ class ArchiveGoalTest : IntegrationTestBase() {
     await.untilAsserted {
       val timeline = getTimeline(prisonNumber)
       assertThat(timeline)
-        .hasNumberOfEvents(4)
-        .event(4) {
-          // the 4th Timeline event will be the GOAL_ARCHIVED event
+        .hasNumberOfEvents(5)
+        .event(5) {
+          // the 5th Timeline event will be the GOAL_ARCHIVED event
           it.hasEventType(TimelineEventType.GOAL_ARCHIVED)
             .wasActionedBy("buser_gen")
             .hasActionedByDisplayName("Bernie User")
@@ -177,6 +178,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 404 if the goal isn't found`() {
     // given
+    val prisonNumber = randomValidPrisonNumber()
     val archiveGoalRequest = aValidArchiveGoalRequest()
     val goalReference = archiveGoalRequest.goalReference
 
@@ -196,6 +198,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 404 if the goal is for a different prisoner`() {
     // given
+    val prisonNumber = setUpRandomPrisoner()
     val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val archiveGoalRequest = aValidArchiveGoalRequest(goalReference)
     val aDifferentPrisonNumber = "Z9876YX"
@@ -215,7 +218,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
 
   @Test
   fun `should return 400 if request is malformed`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val goalReference = aValidReference()
 
     // When
@@ -244,6 +247,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 400 if other reason without description`() {
     // given
+    val prisonNumber = setUpRandomPrisoner()
     val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val archiveGoalRequest = aValidArchiveGoalRequest(
       goalReference = goalReference,
@@ -267,6 +271,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 409 if goal is already archived`() {
     // given
+    val prisonNumber = randomValidPrisonNumber()
     val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val archiveGoalRequest = aValidArchiveGoalRequest(goalReference = goalReference)
     archiveAGoal(prisonNumber, goalReference, archiveGoalRequest)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
@@ -97,7 +97,7 @@ class ArchiveGoalTest : IntegrationTestBase() {
       assertThat(timeline)
         .hasNumberOfEvents(5)
         .event(5) {
-          // the 4th Timeline event will be the GOAL_ARCHIVED event
+          // the 5th Timeline event will be the GOAL_ARCHIVED event
           it.hasEventType(TimelineEventType.GOAL_ARCHIVED)
             .wasActionedBy("buser_gen")
             .hasActionedByDisplayName("Bernie User")
@@ -170,7 +170,11 @@ class ArchiveGoalTest : IntegrationTestBase() {
       assertThat(goalArchivedEventProperties)
         .containsEntry("reference", goalReference.toString())
 
-      val note = noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(goalReference, EntityType.GOAL, NoteType.GOAL_ARCHIVAL).firstOrNull()
+      val note = noteRepository.findAllByEntityReferenceAndEntityTypeAndNoteType(
+        goalReference,
+        EntityType.GOAL,
+        NoteType.GOAL_ARCHIVAL,
+      ).firstOrNull()
       assertThat(note!!.content).isEqualTo(noteText)
     }
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanReviewTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateActionPlanReviewTest.kt
@@ -12,7 +12,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType.APPLICATION_JSON
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
@@ -38,7 +37,7 @@ class CreateActionPlanReviewTest : IntegrationTestBase() {
     private const val URI_TEMPLATE = "/action-plans/{prisonNumber}/reviews"
   }
 
-  private val prisonNumber = aValidPrisonNumber()
+  private val prisonNumber = randomValidPrisonNumber()
 
   @Test
   fun `should return unauthorized given no bearer token`() {
@@ -145,7 +144,7 @@ class CreateActionPlanReviewTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .hasStatus(NOT_FOUND.value())
-      .hasUserMessage("Review Schedule not found for prisoner [A1234BC]")
+      .hasUserMessage("Review Schedule not found for prisoner [$prisonNumber]")
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateEducationTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateEducationTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.MediaType
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -23,7 +22,7 @@ class CreateEducationTest : IntegrationTestBase() {
   @Test
   fun `should return unauthorized given no bearer token`() {
     webTestClient.post()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, setUpRandomPrisoner())
       .exchange()
       .expectStatus()
       .isUnauthorized
@@ -32,7 +31,7 @@ class CreateEducationTest : IntegrationTestBase() {
   @Test
   fun `should return forbidden given bearer token with view only role`() {
     webTestClient.post()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, setUpRandomPrisoner())
       .withBody(aValidCreateEducationRequest())
       .bearerToken(
         aValidTokenWithAuthority(
@@ -48,7 +47,7 @@ class CreateEducationTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to create education given no education data provided`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
 
     // When
     val response = webTestClient.post()
@@ -81,7 +80,7 @@ class CreateEducationTest : IntegrationTestBase() {
   @Test
   fun `should create a prisoner's education record given there is no education for the prisoner already`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
 
     val earliestCreateTime = OffsetDateTime.now()
 
@@ -114,7 +113,7 @@ class CreateEducationTest : IntegrationTestBase() {
   @Test
   fun `should fail to create a prisoner's education record given there is an education record for the prisoner already`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
 
     createEducation(prisonNumber)
 
@@ -138,6 +137,6 @@ class CreateEducationTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual)
       .hasStatus(409)
-      .hasUserMessage("An Education already exists for prisoner A1234BC")
+      .hasUserMessage("An Education already exists for prisoner $prisonNumber")
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalsTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CreateGoalsTest.kt
@@ -11,7 +11,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.MediaType.APPLICATION_JSON
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType
@@ -31,7 +31,7 @@ class CreateGoalsTest : IntegrationTestBase() {
   @Test
   fun `should return unauthorized given no bearer token`() {
     webTestClient.post()
-      .uri(CREATE_GOALS_URI_TEMPLATE, aValidPrisonNumber())
+      .uri(CREATE_GOALS_URI_TEMPLATE, randomValidPrisonNumber())
       .contentType(APPLICATION_JSON)
       .exchange()
       .expectStatus()
@@ -41,7 +41,7 @@ class CreateGoalsTest : IntegrationTestBase() {
   @Test
   fun `should return forbidden given bearer token with view only role`() {
     webTestClient.post()
-      .uri(CREATE_GOALS_URI_TEMPLATE, aValidPrisonNumber())
+      .uri(CREATE_GOALS_URI_TEMPLATE, randomValidPrisonNumber())
       .withBody(aValidCreateGoalsRequest())
       .bearerToken(aValidTokenWithAuthority(GOALS_RO, privateKey = keyPair.private))
       .contentType(APPLICATION_JSON)
@@ -52,7 +52,7 @@ class CreateGoalsTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to create goals given no goals provided`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val createRequest = aValidCreateGoalsRequest(goals = emptyList())
 
     // When
@@ -76,7 +76,7 @@ class CreateGoalsTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to create goals given a goal with no steps provided`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val createRequest = aValidCreateGoalsRequest(goals = listOf(aValidCreateGoalRequest(steps = emptyList())))
 
     // When
@@ -100,7 +100,7 @@ class CreateGoalsTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to create goals given null fields`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
 
     // When
     val response = webTestClient.post()
@@ -128,7 +128,7 @@ class CreateGoalsTest : IntegrationTestBase() {
   @Test
   fun `should add goal to prisoner's existing action plan`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createActionPlan(prisonNumber)
 
     val createGoalRequest = aValidCreateGoalRequest(
@@ -181,7 +181,7 @@ class CreateGoalsTest : IntegrationTestBase() {
   @Test
   fun `should add goal with only mandatory fields populated`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createActionPlan(prisonNumber)
 
     val createGoalRequest = aValidCreateGoalRequest(
@@ -238,7 +238,7 @@ class CreateGoalsTest : IntegrationTestBase() {
   @Test
   fun `should add goal with no notes`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createActionPlan(prisonNumber)
 
     val createGoalRequest = aValidCreateGoalRequest(
@@ -273,7 +273,7 @@ class CreateGoalsTest : IntegrationTestBase() {
   @Test
   fun `should add goal with notes`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createActionPlan(prisonNumber)
 
     val createGoalRequest = aValidCreateGoalRequest(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanReviewsTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanReviewsTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
@@ -26,7 +26,7 @@ class GetActionPlanReviewsTest : IntegrationTestBase() {
     private const val URI_TEMPLATE = "/action-plans/{prisonNumber}/reviews"
   }
 
-  private val prisonNumber = aValidPrisonNumber()
+  private val prisonNumber = randomValidPrisonNumber()
 
   @Test
   fun `should return unauthorized given no bearer token`() {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanSummariesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanSummariesTest.kt
@@ -3,8 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.MediaType
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
-import uk.gov.justice.digital.hmpps.domain.anotherValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
@@ -59,7 +58,7 @@ class GetActionPlanSummariesTest : IntegrationTestBase() {
   @Test
   fun `should get empty list of action plan summaries given prisoner has no action plan`() {
     // Given
-    val request = aValidGetActionPlanSummariesRequest(prisonNumbers = listOf(aValidPrisonNumber()))
+    val request = aValidGetActionPlanSummariesRequest(prisonNumbers = listOf(randomValidPrisonNumber()))
 
     // When
     val response = webTestClient.post()
@@ -80,8 +79,8 @@ class GetActionPlanSummariesTest : IntegrationTestBase() {
   @Test
   fun `should get multiple action plan summaries`() {
     // Given
-    val prisonNumber1 = aValidPrisonNumber()
-    val prisonNumber2 = anotherValidPrisonNumber()
+    val prisonNumber1 = randomValidPrisonNumber()
+    val prisonNumber2 = randomValidPrisonNumber()
     createActionPlan(prisonNumber1, aValidCreateActionPlanRequest())
     createActionPlan(prisonNumber2, aValidCreateActionPlanRequest())
     val request = aValidGetActionPlanSummariesRequest(listOf(prisonNumber1, prisonNumber2))

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetActionPlanTest.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
@@ -28,7 +28,7 @@ class GetActionPlanTest : IntegrationTestBase() {
   @Test
   fun `should return unauthorized given no bearer token`() {
     webTestClient.get()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, randomValidPrisonNumber())
       .exchange()
       .expectStatus()
       .isUnauthorized
@@ -37,7 +37,7 @@ class GetActionPlanTest : IntegrationTestBase() {
   @Test
   fun `should return forbidden given bearer token without required role`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
 
     // When
     val response = webTestClient.get()
@@ -59,7 +59,7 @@ class GetActionPlanTest : IntegrationTestBase() {
   @Test
   fun `should not get action plan given prisoner has no action plan`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
 
     // When
     val response = webTestClient.get()
@@ -80,7 +80,7 @@ class GetActionPlanTest : IntegrationTestBase() {
   @Test
   fun `should get action plan for prisoner`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val createActionPlanRequest = aValidCreateActionPlanRequest()
     createActionPlan(prisonNumber, createActionPlanRequest)
 
@@ -112,7 +112,7 @@ class GetActionPlanTest : IntegrationTestBase() {
   @Test
   fun `should get action plan with multiple goals in order`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val createActionPlanRequest = aValidCreateActionPlanRequest(
       goals = listOf(aValidCreateGoalRequest(title = "Learn German")),
     )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetEducationTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetEducationTest.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -25,7 +25,7 @@ class GetEducationTest : IntegrationTestBase() {
   @Test
   fun `should return unauthorized given no bearer token`() {
     webTestClient.get()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, randomValidPrisonNumber())
       .exchange()
       .expectStatus()
       .isUnauthorized
@@ -34,7 +34,7 @@ class GetEducationTest : IntegrationTestBase() {
   @Test
   fun `should return 404 if no education exists for prisoner yet`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
 
     // When
     val response = webTestClient.get()
@@ -55,13 +55,13 @@ class GetEducationTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()!!
     assertThat(actual)
       .hasStatus(404)
-      .hasUserMessage("Education not found for prisoner [A1234BC]")
+      .hasUserMessage("Education not found for prisoner [$prisonNumber]")
   }
 
   @Test
   fun `should get education for prisoner who has had their previous qualifications setup as part of their Induction`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
 
     val previousQualifications = aValidCreatePreviousQualificationsRequest(
       educationLevel = EducationLevel.SECONDARY_SCHOOL_TOOK_EXAMS,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetGoalTest.kt
@@ -2,9 +2,8 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.aValidReference
-import uk.gov.justice.digital.hmpps.domain.anotherValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
@@ -20,7 +19,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.asser
 class GetGoalTest : IntegrationTestBase() {
   companion object {
     private const val URI_TEMPLATE = "/action-plans/{prisonNumber}/goals/{goalReference}"
-    private val prisonNumber = aValidPrisonNumber()
+    private val prisonNumber = randomValidPrisonNumber()
   }
 
   @Test
@@ -85,7 +84,7 @@ class GetGoalTest : IntegrationTestBase() {
   @Test
   fun `should return not found given goal exists but for a different prisoner`() {
     // Given
-    val someOtherPrisonNumber = anotherValidPrisonNumber()
+    val someOtherPrisonNumber = randomValidPrisonNumber()
     createActionPlan(
       prisonNumber = someOtherPrisonNumber,
       createActionPlanRequest = aValidCreateActionPlanRequest(),

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionScheduleTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionScheduleTest.kt
@@ -2,9 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.aValidReference
-import uk.gov.justice.digital.hmpps.domain.anotherValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
@@ -24,7 +22,7 @@ import java.time.OffsetDateTime
 class GetInductionScheduleTest : IntegrationTestBase() {
   companion object {
     private const val URI_TEMPLATE = "/inductions/{prisonNumber}/induction-schedule"
-    private val prisonNumber = aValidPrisonNumber()
+    private val prisonNumber = randomValidPrisonNumber()
   }
 
   @Test
@@ -60,7 +58,7 @@ class GetInductionScheduleTest : IntegrationTestBase() {
   @Test
   fun `should return not found given induction schedule does not exist`() {
     // Given
-    val prisonNumber = anotherValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
 
     // When
     val response = webTestClient.get()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetInductionTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType.APPLICATION_JSON
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -34,7 +34,7 @@ class GetInductionTest : IntegrationTestBase() {
   @Test
   fun `should return unauthorized given no bearer token`() {
     webTestClient.get()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, randomValidPrisonNumber())
       .exchange()
       .expectStatus()
       .isUnauthorized
@@ -70,7 +70,7 @@ class GetInductionTest : IntegrationTestBase() {
   @Test
   fun `should get induction for prisoner not looking to work`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val initialDateTime = OffsetDateTime.now()
     createInduction(
       prisonNumber = prisonNumber,
@@ -120,7 +120,7 @@ class GetInductionTest : IntegrationTestBase() {
   @Test
   fun `should get induction for prisoner looking to work`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val initialDateTime = OffsetDateTime.now()
     createInduction(
       prisonNumber = prisonNumber,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/SubjectAccessRequestTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/SubjectAccessRequestTest.kt
@@ -7,8 +7,7 @@ import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.util.UriBuilder
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
-import uk.gov.justice.digital.hmpps.domain.anotherValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -33,7 +32,7 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path(URI_TEMPLATE)
-          .queryParam("prn", aValidPrisonNumber())
+          .queryParam("prn", randomValidPrisonNumber())
           .build()
       }
       .exchange()
@@ -48,7 +47,7 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path(URI_TEMPLATE)
-          .queryParam("prn", aValidPrisonNumber())
+          .queryParam("prn", randomValidPrisonNumber())
           .build()
       }
       .bearerToken(aValidTokenWithNoAuthorities(privateKey = keyPair.private))
@@ -71,7 +70,7 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path(URI_TEMPLATE)
-          .queryParam("prn", aValidPrisonNumber())
+          .queryParam("prn", randomValidPrisonNumber())
           .build()
       }.bearerToken(
         buildAccessToken(
@@ -91,7 +90,7 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path(URI_TEMPLATE)
-          .queryParam("crn", aValidPrisonNumber())
+          .queryParam("crn", randomValidPrisonNumber())
           .build()
       }.bearerToken(
         buildAccessToken(
@@ -134,7 +133,9 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
   @Test
   fun `should get induction and goals for specific prisoner without date filtering`() {
     // Given
-    val prisonNumbers = listOf(aValidPrisonNumber(), anotherValidPrisonNumber())
+    val prisoner1 = setUpRandomPrisoner()
+    val prisoner2 = setUpRandomPrisoner()
+    val prisonNumbers = listOf(prisoner1, prisoner2)
     prisonNumbers.map {
       createInduction(
         prisonNumber = it,
@@ -149,7 +150,7 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
     }
 
     // When
-    val response = webTestClient.sarRequest(aValidPrisonNumber(), null, null)
+    val response = webTestClient.sarRequest(prisoner1, null, null)
 
     // Then
     val responseBody = response
@@ -159,7 +160,7 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
 
     val content = objectMapper.convertValue(responseBody!!.content, SubjectAccessRequestContent::class.java)
     with(content) {
-      assertThat(induction?.prisonNumber).isEqualTo(aValidPrisonNumber())
+      assertThat(induction?.prisonNumber).isEqualTo(prisoner1)
       assertThat(goals).hasSize(1)
       assertThat(goals?.first()?.title).isEqualTo("Goal 1")
     }
@@ -168,7 +169,9 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
   @Test
   fun `should get induction and goals for specific prisoner with from date filtering`() {
     // Given
-    val prisonNumbers = listOf(aValidPrisonNumber(), anotherValidPrisonNumber())
+    val prisoner1 = setUpRandomPrisoner()
+    val prisoner2 = setUpRandomPrisoner()
+    val prisonNumbers = listOf(prisoner1, prisoner2)
     prisonNumbers.map {
       createInduction(
         prisonNumber = it,
@@ -183,8 +186,8 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
     }
 
     // When
-    val responseFromLastWeek = webTestClient.sarRequest(aValidPrisonNumber(), LocalDate.now().minusWeeks(1), null)
-    val responseFromTomorrow = webTestClient.sarRequest(aValidPrisonNumber(), LocalDate.now().plusDays(1), null)
+    val responseFromLastWeek = webTestClient.sarRequest(prisoner1, LocalDate.now().minusWeeks(1), null)
+    val responseFromTomorrow = webTestClient.sarRequest(prisoner2, LocalDate.now().plusDays(1), null)
 
     // Then
     val responseBody = responseFromLastWeek
@@ -194,7 +197,7 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
 
     val fromLastWeekContent = objectMapper.convertValue(responseBody!!.content, SubjectAccessRequestContent::class.java)
     with(fromLastWeekContent) {
-      assertThat(induction?.prisonNumber).isEqualTo(aValidPrisonNumber())
+      assertThat(induction?.prisonNumber).isEqualTo(prisoner1)
       assertThat(goals).hasSize(1)
       assertThat(goals?.first()?.title).isEqualTo("Goal 1")
     }
@@ -205,7 +208,9 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
   @Test
   fun `should get induction and goals for specific prisoner with to date filtering`() {
     // Given
-    val prisonNumbers = listOf(aValidPrisonNumber(), anotherValidPrisonNumber())
+    val prisoner1 = setUpRandomPrisoner()
+    val prisoner2 = setUpRandomPrisoner()
+    val prisonNumbers = listOf(prisoner1, prisoner2)
     prisonNumbers.map {
       createInduction(
         prisonNumber = it,
@@ -220,8 +225,8 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
     }
 
     // When
-    val responseToLastWeek = webTestClient.sarRequest(aValidPrisonNumber(), null, LocalDate.now().minusWeeks(1))
-    val responseToTomorrow = webTestClient.sarRequest(aValidPrisonNumber(), null, LocalDate.now().plusDays(1))
+    val responseToLastWeek = webTestClient.sarRequest(prisoner1, null, LocalDate.now().minusWeeks(1))
+    val responseToTomorrow = webTestClient.sarRequest(prisoner2, null, LocalDate.now().plusDays(1))
 
     // Then
     responseToLastWeek.expectStatus().isNoContent
@@ -233,7 +238,7 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
 
     val toTomorrowContent = objectMapper.convertValue(responseBody!!.content, SubjectAccessRequestContent::class.java)
     with(toTomorrowContent) {
-      assertThat(induction?.prisonNumber).isEqualTo(aValidPrisonNumber())
+      assertThat(induction?.prisonNumber).isEqualTo(prisoner2)
       assertThat(goals).hasSize(1)
       assertThat(goals?.first()?.title).isEqualTo("Goal 1")
     }
@@ -242,7 +247,9 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
   @Test
   fun `should get induction and goals for specific prisoner with from and to date filtering`() {
     // Given
-    val prisonNumbers = listOf(aValidPrisonNumber(), anotherValidPrisonNumber())
+    val prisoner1 = setUpRandomPrisoner()
+    val prisoner2 = setUpRandomPrisoner()
+    val prisonNumbers = listOf(prisoner1, prisoner2)
     prisonNumbers.map {
       createInduction(
         prisonNumber = it,
@@ -257,8 +264,8 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
     }
 
     // When
-    val responseThisWeek = webTestClient.sarRequest(aValidPrisonNumber(), LocalDate.now(), LocalDate.now().plusWeeks(1))
-    val responseLastWeek = webTestClient.sarRequest(aValidPrisonNumber(), LocalDate.now().minusWeeks(1), LocalDate.now())
+    val responseThisWeek = webTestClient.sarRequest(prisoner1, LocalDate.now(), LocalDate.now().plusWeeks(1))
+    val responseLastWeek = webTestClient.sarRequest(prisoner2, LocalDate.now().minusWeeks(1), LocalDate.now())
 
     // Then
     val responseBody = responseThisWeek
@@ -268,7 +275,7 @@ class SubjectAccessRequestTest : IntegrationTestBase() {
 
     val thisWeekContent = objectMapper.convertValue(responseBody!!.content, SubjectAccessRequestContent::class.java)
     with(thisWeekContent) {
-      assertThat(induction?.prisonNumber).isEqualTo(aValidPrisonNumber())
+      assertThat(induction?.prisonNumber).isEqualTo(prisoner1)
       assertThat(goals).hasSize(1)
       assertThat(goals?.first()?.title).isEqualTo("Goal 1")
     }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UnarchiveGoalTest.kt
@@ -11,8 +11,8 @@ import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.aValidReference
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType
@@ -43,10 +43,9 @@ class UnarchiveGoalTest : IntegrationTestBase() {
     private const val ARCHIVE_URI_TEMPLATE = "/action-plans/{prisonNumber}/goals/{goalReference}/archive"
   }
 
-  private val prisonNumber = aValidPrisonNumber()
-
   @Test
   fun `should return unauthorized given no bearer token`() {
+    val prisonNumber = randomValidPrisonNumber()
     webTestClient.put()
       .uri(UNARCHIVE_URI_TEMPLATE, prisonNumber, aValidReference())
       .contentType(APPLICATION_JSON)
@@ -57,6 +56,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
 
   @Test
   fun `should require the edit role`() {
+    val prisonNumber = randomValidPrisonNumber()
     webTestClient.put()
       .uri(UNARCHIVE_URI_TEMPLATE, prisonNumber, aValidReference())
       .withBody(aValidArchiveGoalRequest())
@@ -75,6 +75,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 204 and unarchive a goal and reset the reason and other text `() {
     // given
+    val prisonNumber = setUpRandomPrisoner()
     val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val reasonOther = "Because it's Monday"
     val archiveRequestWithOtherReason = aValidArchiveGoalRequest(
@@ -127,6 +128,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 204 and unarchive a goal and reset the reason and other text and archive note is deleted `() {
     // given
+    val prisonNumber = setUpRandomPrisoner()
     val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val reasonOther = "Because it's Monday"
     val archiveNote = "an archive note"
@@ -192,6 +194,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 404 if the goal isn't found`() {
     // given
+    val prisonNumber = randomValidPrisonNumber()
     val unarchiveGoalRequest = aValidUnarchiveGoalRequest()
     val goalReference = unarchiveGoalRequest.goalReference
 
@@ -211,6 +214,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 404 if the goal is for a different prisoner`() {
     // given
+    val prisonNumber = setUpRandomPrisoner()
     val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val unarchiveGoalRequest = aValidUnarchiveGoalRequest(goalReference)
     val aDifferentPrisonNumber = "Z9876YX"
@@ -230,7 +234,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
 
   @Test
   fun `should return 400 if request is malformed`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val goalReference = aValidReference()
 
     // When
@@ -264,6 +268,7 @@ class UnarchiveGoalTest : IntegrationTestBase() {
   @Test
   fun `should return 409 if goal is not archived`() {
     // given
+    val prisonNumber = setUpRandomPrisoner()
     val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
     val archiveGoalRequest = aValidUnarchiveGoalRequest(goalReference)
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusHistoryTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusHistoryTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -18,7 +18,7 @@ class UpdateActionPlanReviewStatusHistoryTest : IntegrationTestBase() {
     private const val URI_TEMPLATE = "/action-plans/{prisonNumber}/reviews/schedule-status"
   }
 
-  private val prisonNumber = aValidPrisonNumber()
+  private val prisonNumber = randomValidPrisonNumber()
 
   @Test
   fun `Test that review schedule history records are written when a schedule is exempted`() {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateActionPlanReviewStatusTest.kt
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType.APPLICATION_JSON
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -35,7 +35,7 @@ class UpdateActionPlanReviewStatusTest : IntegrationTestBase() {
     private const val URI_TEMPLATE = "/action-plans/{prisonNumber}/reviews/schedule-status"
   }
 
-  private val prisonNumber = aValidPrisonNumber()
+  private val prisonNumber = randomValidPrisonNumber()
 
   @Test
   fun `should return unauthorized given no bearer token`() {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateEductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateEductionTest.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.aValidReference
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -30,7 +30,7 @@ class UpdateEductionTest : IntegrationTestBase() {
   @Test
   fun `should return unauthorized given no bearer token`() {
     webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, randomValidPrisonNumber())
       .contentType(APPLICATION_JSON)
       .exchange()
       .expectStatus()
@@ -40,7 +40,7 @@ class UpdateEductionTest : IntegrationTestBase() {
   @Test
   fun `should return forbidden given bearer token with view only role`() {
     webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, randomValidPrisonNumber())
       .withBody(aValidUpdateEducationRequest())
       .bearerToken(
         aValidTokenWithAuthority(
@@ -56,7 +56,7 @@ class UpdateEductionTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to update education given no education data provided`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
 
     // When
     val response = webTestClient.put()
@@ -88,7 +88,7 @@ class UpdateEductionTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to update education given education record does not exist`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val reference = aValidReference()
     val updateEducationRequest = aValidUpdateEducationRequest(
       reference = reference,
@@ -96,7 +96,7 @@ class UpdateEductionTest : IntegrationTestBase() {
 
     // When
     val response = webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, prisonNumber)
       .withBody(updateEducationRequest)
       .bearerToken(
         aValidTokenWithAuthority(
@@ -119,7 +119,7 @@ class UpdateEductionTest : IntegrationTestBase() {
 
   @Test
   fun `should update education`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     val earliestExpectedCreateTime = OffsetDateTime.now()
 
     createEducation(
@@ -188,7 +188,7 @@ class UpdateEductionTest : IntegrationTestBase() {
 
     // When
     webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, prisonNumber)
       .withBody(updateEducationRequest)
       .bearerToken(
         aValidTokenWithAuthority(
@@ -252,7 +252,7 @@ class UpdateEductionTest : IntegrationTestBase() {
 
   @Test
   fun `should not update education given no changes in update request`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
 
     createEducation(
       prisonNumber = prisonNumber,
@@ -290,7 +290,7 @@ class UpdateEductionTest : IntegrationTestBase() {
 
     // When
     webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, prisonNumber)
       .withBody(updateEducationRequest)
       .bearerToken(
         aValidTokenWithAuthority(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateGoalTest.kt
@@ -11,8 +11,8 @@ import org.mockito.kotlin.secondValue
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
 import uk.gov.justice.digital.hmpps.domain.aValidReference
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.note.EntityType
@@ -40,7 +40,7 @@ class UpdateGoalTest : IntegrationTestBase() {
   @Test
   fun `should return unauthorized given no bearer token`() {
     webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
+      .uri(URI_TEMPLATE, randomValidPrisonNumber(), aValidReference())
       .contentType(APPLICATION_JSON)
       .exchange()
       .expectStatus()
@@ -50,7 +50,7 @@ class UpdateGoalTest : IntegrationTestBase() {
   @Test
   fun `should return forbidden given bearer token with view only role`() {
     webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber(), aValidReference())
+      .uri(URI_TEMPLATE, randomValidPrisonNumber(), aValidReference())
       .withBody(aValidUpdateGoalRequest())
       .bearerToken(
         aValidTokenWithAuthority(
@@ -66,7 +66,7 @@ class UpdateGoalTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to update goal given no steps provided`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val goalReference = aValidReference()
     val updateRequest = aValidUpdateGoalRequest(
       goalReference = goalReference,
@@ -99,7 +99,7 @@ class UpdateGoalTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to update goal given null fields`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val goalReference = aValidReference()
 
     // When
@@ -132,7 +132,7 @@ class UpdateGoalTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to update goal given goal does not exist`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val goalReference = aValidReference()
     val updateRequest = aValidUpdateGoalRequest(
       goalReference = goalReference,
@@ -163,7 +163,7 @@ class UpdateGoalTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to update goal given goal references in URI path and request body do not match`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val goalReference = aValidReference()
     val someOtherGoalReference = aValidReference()
     val updateRequest = aValidUpdateGoalRequest(
@@ -196,7 +196,7 @@ class UpdateGoalTest : IntegrationTestBase() {
   @Test
   fun `should update goal`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     createInduction(prisonNumber, aValidCreateInductionRequest())
     createActionPlan(
       username = "auser_gen",
@@ -319,7 +319,7 @@ class UpdateGoalTest : IntegrationTestBase() {
   @Test
   fun `should update goal and delete goal note`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     createInduction(prisonNumber, aValidCreateInductionRequest())
     createActionPlan(
       username = "auser_gen",
@@ -442,7 +442,7 @@ class UpdateGoalTest : IntegrationTestBase() {
   @Test
   fun `should update goal given the goal fields are unchanged and the only change is to add a step`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = setUpRandomPrisoner()
     createInduction(prisonNumber, aValidCreateInductionRequest())
     createActionPlan(
       username = "auser_gen",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionScheduleStatusTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionScheduleStatusTest.kt
@@ -13,7 +13,7 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType.APPLICATION_JSON
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -32,7 +32,7 @@ class UpdateInductionScheduleStatusTest : IntegrationTestBase() {
     private const val URI_TEMPLATE = "/inductions/{prisonNumber}/induction-schedule"
   }
 
-  private val prisonNumber = aValidPrisonNumber()
+  private val prisonNumber = randomValidPrisonNumber()
 
   @Test
   fun `should fail to update induction schedule status given no data provided`() {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/UpdateInductionTest.kt
@@ -12,7 +12,7 @@ import org.mockito.kotlin.isNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType.APPLICATION_JSON
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -61,7 +61,7 @@ class UpdateInductionTest : IntegrationTestBase() {
   @Test
   fun `should return unauthorized given no bearer token`() {
     webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, randomValidPrisonNumber())
       .contentType(APPLICATION_JSON)
       .exchange()
       .expectStatus()
@@ -71,7 +71,7 @@ class UpdateInductionTest : IntegrationTestBase() {
   @Test
   fun `should return forbidden given bearer token with view only role`() {
     webTestClient.put()
-      .uri(URI_TEMPLATE, aValidPrisonNumber())
+      .uri(URI_TEMPLATE, randomValidPrisonNumber())
       .withBody(aValidUpdateInductionRequest())
       .bearerToken(
         aValidTokenWithAuthority(
@@ -87,7 +87,7 @@ class UpdateInductionTest : IntegrationTestBase() {
 
   @Test
   fun `should fail to update induction given no induction data provided`() {
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
 
     // When
     val response = webTestClient.put()
@@ -149,7 +149,7 @@ class UpdateInductionTest : IntegrationTestBase() {
   @Test
   fun `should update induction for prisoner who is no longer looking to work`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val createUsername = "auser_gen"
     val createDisplayName = "Albert User"
     val updateUsername = "buser_gen"
@@ -311,7 +311,7 @@ class UpdateInductionTest : IntegrationTestBase() {
   @Test
   fun `should update induction for prisoner who is now looking to work`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     val createUsername = "auser_gen"
     val createDisplayName = "Albert User"
     val updateUsername = "buser_gen"
@@ -461,7 +461,7 @@ class UpdateInductionTest : IntegrationTestBase() {
   @Test
   fun `should update induction for prisoner who has no qualifications to start with but wants to add qualifications`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createInduction(
       prisonNumber = prisonNumber,
       createInductionRequest = aValidCreateInductionRequestForPrisonerNotLookingToWork(
@@ -529,7 +529,7 @@ class UpdateInductionTest : IntegrationTestBase() {
   @Test
   fun `should update induction for prisoner who wants to set their previous work experience as Not Relevant`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createInduction(
       prisonNumber = prisonNumber,
       createInductionRequest = aValidCreateInductionRequestForPrisonerNotLookingToWork(),
@@ -583,7 +583,7 @@ class UpdateInductionTest : IntegrationTestBase() {
   @Test
   fun `should update Induction given request that adds a qualification, removes a qualification, and updates a qualification`() {
     // Given
-    val prisonNumber = aValidPrisonNumber()
+    val prisonNumber = randomValidPrisonNumber()
     createInduction(
       username = "auser_gen",
       prisonNumber = prisonNumber,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/GetCiagInductionSummariesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/GetCiagInductionSummariesTest.kt
@@ -3,8 +3,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.ciag
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.MediaType
-import uk.gov.justice.digital.hmpps.domain.aValidPrisonNumber
-import uk.gov.justice.digital.hmpps.domain.anotherValidPrisonNumber
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithAuthority
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.aValidTokenWithNoAuthorities
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
@@ -63,7 +62,7 @@ class GetCiagInductionSummariesTest : IntegrationTestBase() {
   @Test
   fun `should get empty list of induction summaries given prisoner has no CIAG Induction`() {
     // Given
-    val request = aValidGetCiagInductionSummariesRequest(offenderIds = listOf(aValidPrisonNumber()))
+    val request = aValidGetCiagInductionSummariesRequest(offenderIds = listOf(randomValidPrisonNumber()))
 
     // When
     val response = webTestClient.post()
@@ -84,8 +83,8 @@ class GetCiagInductionSummariesTest : IntegrationTestBase() {
   @Test
   fun `should get multiple induction summaries`() {
     // Given
-    val prisonNumber1 = aValidPrisonNumber()
-    val prisonNumber2 = anotherValidPrisonNumber()
+    val prisonNumber1 = randomValidPrisonNumber()
+    val prisonNumber2 = randomValidPrisonNumber()
     createInduction(prisonNumber1, aValidCreateInductionRequestForPrisonerNotLookingToWork())
     createInduction(prisonNumber2, aValidCreateInductionRequestForPrisonerLookingToWork())
 


### PR DESCRIPTION
The previous PR (where I repeated the database clear down twice when it failed) caused additional problems where it sometimes cleared the data for the next test that was running and caused that test to fail. 

Instead of clearing the data between each test I propose this PR where all integration tests use their own prisoner.

This means that we don't need to clear the database between each test. There are a couple of tests that still need to do this - they use a specific prisoner returned via Wiremock. For these tests I've added `@Isolated ` which should make them safe. 
