### PR TITLE
removed unnecessary config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,9 +50,6 @@ spring:
 
   jpa:
     open-in-view: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
     show-sql: false
     generate-ddl: false
     hibernate:


### PR DESCRIPTION
fix to remove this warning 

HHH90000025: PostgreSQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)