### PR TITLE
added workaround for app insights issue

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -28,7 +28,7 @@ generic-service:
     JAVA_OPTS: "-Xmx512m"
     SERVER_PORT: "8080"
     SPRING_PROFILES_ACTIVE: "logstash"
-    APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
+    APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     PRISON_API_URL: https://prison-api.prison.service.justice.gov.uk


### PR DESCRIPTION
As discussed in [here](https://mojdt.slack.com/archives/CTLQ5TCNN/p1739353601712389) there is an issue with [App insights java](https://github.com/microsoft/ApplicationInsights-Java/issues/4079) which causes this error to be displayed in the logs. This will be fixed at some point but they recommend putting the full connection details and not just the instrumentation key - which is the change in this PR. 