### PR TITLE
Timeline filter fixes RR-1321 and RR-1322

### DIFF
--- a/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/service/TimelineServiceFilterTest.kt
+++ b/domain/timeline/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/service/TimelineServiceFilterTest.kt
@@ -32,6 +32,16 @@ class TimelineServiceFilterTest {
   }
 
   @Test
+  fun `should get timeline events for prisoner`() {
+    // Given
+    setUpEvents()
+    // When
+    val actual = service.getTimelineForPrisoner(PRISON_NUMBER)
+    // Then
+    assertThat(actual.events.size).isEqualTo(42)
+  }
+
+  @Test
   fun `should get timeline review events for prisoner`() {
     // Given
     setUpEvents()
@@ -89,9 +99,9 @@ class TimelineServiceFilterTest {
     // Given
     setUpEvents()
     // When
-    val actual = service.getTimelineForPrisoner(PRISON_NUMBER, reviews = true, prisonId = "PRISON2")
+    val actual = service.getTimelineForPrisoner(PRISON_NUMBER, prisonId = "PRISON2")
     // Then
-    assertThat(actual.events.size).isEqualTo(3)
+    assertThat(actual.events.size).isEqualTo(21)
   }
 
   @Test
@@ -99,7 +109,7 @@ class TimelineServiceFilterTest {
     // Given
     setUpEvents()
     // When
-    val actual = service.getTimelineForPrisoner(PRISON_NUMBER, reviews = true, prisonId = "PRISON3")
+    val actual = service.getTimelineForPrisoner(PRISON_NUMBER, prisonId = "PRISON3")
     // Then
     assertThat(actual.events.size).isEqualTo(0)
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -139,7 +139,7 @@ abstract class IntegrationTestBase {
   init {
     // set awaitility defaults
     Awaitility.setDefaultPollInterval(500, MILLISECONDS)
-    Awaitility.setDefaultTimeout(30, SECONDS)
+    Awaitility.setDefaultTimeout(5, SECONDS)
   }
 
   @Autowired

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetTimelineTest.kt
@@ -538,6 +538,62 @@ class GetTimelineTest : IntegrationTestBase() {
     }
   }
 
+  @Test
+  fun `should get filtered timeline filtered on prisonId`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    setUpAPersonWithLotsOfEvents(prisonNumber)
+
+    // Then
+    await.untilAsserted {
+      val response = webTestClient.get()
+        .uri("${URI_TEMPLATE}?prisonId=BXI", prisonNumber)
+        .bearerToken(
+          aValidTokenWithAuthority(
+            TIMELINE_RO,
+            privateKey = keyPair.private,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(TimelineResponse::class.java)
+
+      val actual = response.responseBody.blockFirst()!!
+      assertThat(actual)
+        .isForPrisonNumber(prisonNumber)
+        .hasNumberOfEvents(8)
+    }
+  }
+
+  @Test
+  fun `should get filtered timeline filtered on prisonId no results`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    setUpAPersonWithLotsOfEvents(prisonNumber)
+
+    // Then
+    await.untilAsserted {
+      val response = webTestClient.get()
+        .uri("${URI_TEMPLATE}?prisonId=XXX", prisonNumber)
+        .bearerToken(
+          aValidTokenWithAuthority(
+            TIMELINE_RO,
+            privateKey = keyPair.private,
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(TimelineResponse::class.java)
+
+      val actual = response.responseBody.blockFirst()!!
+      assertThat(actual)
+        .isForPrisonNumber(prisonNumber)
+        .hasNumberOfEvents(0)
+    }
+  }
+
   private fun setUpAPersonWithLotsOfEvents(prisonNumber: String) {
     createInduction(prisonNumber, aFullyPopulatedCreateInductionRequest())
 


### PR DESCRIPTION
Basically was trying to be too smart for my own good with the original version. The prisonId or eventsSince filters didn't work unless there was one of the boolean filters (goals, reviews etc) set.

Went back to the drawingboard and the process is now:

If eventSince is set then create a list of all events after that date otherwise include all. 
if prisonId is set then filter the previous list on prisonId
lastly apply the boolean filters. 

Also added specific tests for the conditions that were failing. 

This code can probably be refined further but I quite like the do this then this then this logic rather than some complex filters that can easily miss conditions if the testing isn't 100%. 