### PR TITLE
Demo prisoner-search-api bug

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/PrisonerSearchApiClientTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/PrisonerSearchApiClientTest.kt
@@ -1,0 +1,93 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app
+
+import mu.KotlinLogging
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.RepeatedTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch.Prisoner
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch.PrisonerSearchApiClient
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.LocalStackContainer
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.LocalStackContainer.setLocalStackProperties
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.PostgresContainer
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Test class to demonstrate possible problem with prisoner-search-api when calling it with paged requests
+ */
+@SpringBootTest
+@ActiveProfiles("demo-prisoner-search-api-paging-bug")
+class PrisonerSearchApiClientTest {
+
+  companion object {
+    private const val PRISON_ID = "WDI"
+
+    private val postgresContainer = PostgresContainer.instance
+
+    private val localStackContainer = LocalStackContainer.instance
+
+    @JvmStatic
+    @DynamicPropertySource
+    fun configureTestContainers(registry: DynamicPropertyRegistry) {
+      postgresContainer?.run {
+        registry.add("spring.datasource.url", postgresContainer::getJdbcUrl)
+        registry.add("spring.datasource.username", postgresContainer::getUsername)
+        registry.add("spring.datasource.password", postgresContainer::getPassword)
+        registry.add("spring.datasource.placeholders.database_update_password", postgresContainer::getPassword)
+        registry.add("spring.datasource.placeholders.database_read_only_password", postgresContainer::getPassword)
+        registry.add("spring.flyway.url", postgresContainer::getJdbcUrl)
+        registry.add("spring.flyway.user", postgresContainer::getUsername)
+        registry.add("spring.flyway.password", postgresContainer::getPassword)
+      }
+      localStackContainer?.also { setLocalStackProperties(it, registry) }
+    }
+  }
+
+  @Autowired
+  private lateinit var prisonerSearchApiClient: PrisonerSearchApiClient
+
+  @Disabled
+  @RepeatedTest(100)
+  fun `test paged operation`() {
+    // First call prisoner-search-api to get all prisoners in BXI as a single page
+    val allPrisonersInOneCall = getAllPrisonersInPrison(PRISON_ID, 9999).map { it.prisonerNumber }
+
+    assertThat(allPrisonersInOneCall.size)
+      .describedAs { "The number of elements in the returned list should equal the number of elements when turning the list into a set, proving a unique set of prisoners being returned" }
+      .isEqualTo(allPrisonersInOneCall.toSet().size)
+
+    // Now get all prisoners via a series of paged calls
+    val allPrisonersViaPagedCall = getAllPrisonersInPrison(PRISON_ID, 250).map { it.prisonerNumber }
+
+    assertThat(allPrisonersViaPagedCall.size).isEqualTo(allPrisonersInOneCall.size)
+
+    assertThat(allPrisonersViaPagedCall.size)
+      .describedAs { "The number of elements in the returned list should equal the number of elements when turning the list into a set, proving a unique set of prisoners being returned" }
+      .isEqualTo(allPrisonersViaPagedCall.toSet().size)
+  }
+
+  private fun getAllPrisonersInPrison(prisonId: String, pageSize: Int): List<Prisoner> {
+    var page = 0
+
+    val prisoners = mutableListOf<Prisoner>()
+
+    do {
+      val apiResponse = prisonerSearchApiClient.getPrisonersByPrisonId(
+        prisonId = prisonId,
+        page = page++,
+        pageSize = pageSize,
+      )
+      prisoners.addAll(apiResponse.content)
+    } while (apiResponse.last != true)
+
+    return prisoners.toList()
+      .also {
+        log.info { "Returned ${it.size} prisoners for prison $prisonId from $page calls to Prisoner Search API" }
+      }
+  }
+}

--- a/src/integrationTest/resources/application-demo-prisoner-search-api-paging-bug.yml
+++ b/src/integrationTest/resources/application-demo-prisoner-search-api-paging-bug.yml
@@ -1,0 +1,86 @@
+prisoner-search-api:
+  client:
+    id: < prisoner-search-api-id >
+    secret: < prisoner-search-api-secret >
+
+hmpps:
+  auth:
+    url: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+
+apis:
+  prisoner-search-api:
+    url: https://prisoner-search-dev.prison.service.justice.gov.uk
+  prison-api:
+    url: http://localhost:9093
+  manage-users-api:
+    url: http://localhost:9093
+
+
+
+
+server:
+  shutdown: immediate
+
+management.endpoint:
+  health.cache.time-to-live: 0
+  info.cache.time-to-live: 0
+
+spring:
+  jpa:
+    show-sql: true
+  datasource:
+    url: 'jdbc:postgresql://${DB_SERVER}/${DB_NAME}?sslmode=disable'
+
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          public-key-location: classpath:local-public-key.pub
+
+hmpps.sqs:
+  enabled: true
+  provider: localstack
+  queues:
+    educationandworkplan:
+      queueName: education-and-work-plan-queue
+      subscribeFilter: "{\"eventType\":[\"prison-offender-events.prisoner.received\", \"prison-offender-events.prisoner.released\"]}"
+      dlqName: education-and-work-plan-dead-letter-queue
+      subscribeTopicId: domainevents
+      dlqMaxReceiveCount: 1
+      visibilityTimeout: 1
+    inductionscheduleeventqueue:
+      queueName: induction-schedule-event-queue
+      subscribeFilter: "{\"eventType\":[\"plp.induction-schedule.updated\"]}"
+      dlqName: test-induction-event-queue-dlq
+      subscribeTopicId: domainevents
+      dlqMaxReceiveCount: 1
+      visibilityTimeout: 1
+    reviewscheduleeventqueue:
+      queueName: review-schedule-event-queue
+      subscribeFilter: "{\"eventType\":[\"plp.review-schedule.updated\"]}"
+      dlqName: test-review-event-queue-dlq
+      subscribeTopicId: domainevents
+      dlqMaxReceiveCount: 1
+      visibilityTimeout: 1
+    domaineventsqueue:
+      queueName: domainevents-queue
+      subscribeTopicId: domainevents
+  topics:
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents-topic
+
+prison-api:
+  client:
+    id: prison-api-client-id
+    secret: client-secret
+
+manage-users-api:
+  client:
+    id: manage-users-api-client-id
+    secret: client-secret
+
+
+ciag-kpi-processing-rule: PEF
+
+
+service.base-url: http://localhost:8080


### PR DESCRIPTION
## Background
PR to demo the apparent bug in prisoner-search-api when calling the `/prisoner-search/prison/$prisonId` endpoint as a paged operation.

## Context
We need to call prisoner-search-api to get a list of all prisoners in a given prison. We previously called the API endpoint with a page size of 250 as it felt like an appropriate balance between number of requests vs. response data size vs. "spamming" prisoner-search-api
We found intermittent problems with this and after a bit of debugging in our client and service methods felt that the problem was with prisoner-search-api not returning the correct prisoners when calling it as a paged operation.
[This PR](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/pull/607) worked around it for us, in that we changed our call to a single non-paged call, but this from the description explains our thinking:

> Given the prisoners A, B, C, D, E, F, G, H, I and J; if you were to call the paged API with a page size of 3 you might expect responses:
> 1: [A, B, C]
> 2: [D, E, F]
> 3: [G, H, I]
> 4: [J]
> The order is irrelevant, just as long as you get all records, and they are only represented once.
>
> What we suspect is happening is that we get back responses such as:
> 1: [A, J, D]
> 2: [E, D, F]
> 3: [B, C, I]
> 4: [H]
> where D is returned twice, and G is not returned at all.

## Failing test
This PR adds a test that demonstrates the problem.
To run the test:
* Uncomment the test annotation `@Disabled` (it is disabled because other wise it would run as part of the CI checks for the branch and would fail!)
* Add an appropriate client ID and secret for in `application