### PR TITLE
RR-1398 fix induction schedules

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Induc
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus.SCHEDULED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequestForPrisonerNotLookingToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.assertThat
@@ -350,9 +351,9 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
       assertThat(inductionSchedule.scheduleCalculationRule).isEqualTo(InductionScheduleCalculationRule.NEW_PRISON_ADMISSION)
 
       // test that outbound event is also created:
-      val reviewScheduleEvent = inductionScheduleEventQueue.receiveEvent(QueueType.INDUCTION)
-      assertThat(reviewScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
-      assertThat(reviewScheduleEvent.detailUrl).isEqualTo("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
+      val inductionScheduleEvent = inductionScheduleEventQueue.receiveEvent(QueueType.INDUCTION)
+      assertThat(inductionScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
+      assertThat(inductionScheduleEvent.detailUrl).isEqualTo("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
     }
   }
 
@@ -407,6 +408,70 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
 
       // test that no outbound events were created
       assertThat(inductionScheduleEventQueue.countAllMessagesOnQueue()).isEqualTo(0)
+    }
+  }
+
+  // Re-offending prisoner. Prisoner previously had a PLP Induction + Goals from long before the Reviews process, and therefore does not have an Induction Schedule or Review Schedule in any state.
+  @Test
+  fun `should create Review Schedule instead of Induction Schedule given prisoner that already has a PLP Induction and Goals but does not have an Induction Schedule or Review Schedule`() {
+    // Given
+    // prisoner has a PLP Action Plan (Induction + at least 1 Goal), but no Induction Schedule or Review Schedules
+    val prisonNumber = randomValidPrisonNumber()
+
+    with(aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "MDI")) {
+      createPrisonerAPIStub(prisonNumber, this)
+    }
+
+    createInduction(prisonNumber, aValidCreateInductionRequest())
+    createActionPlan(prisonNumber)
+
+    // The above calls set the data up but they will also generate events so clear these out before starting the test.
+    // Even though this test is simulating prisoners with an Action Plan (Induction + Goal(s)) but without an Induction or Review Schedule (ie. a prisoner from before Reviews),
+    // the above calls will have created the initial ReviewSchedule
+    // Before clearing the queues though we need to wait until the first "plp.review-schedule.updated" event on the REVIEW queue is received.
+    await untilCallTo {
+      reviewScheduleEventQueue.countAllMessagesOnQueue()
+    } matches { it != null && it > 0 }
+    clearQueues()
+    reviewScheduleRepository.deleteAll()
+    reviewScheduleHistoryRepository.deleteAll()
+
+    assertThat(getInductionScheduleHistory(prisonNumber).inductionSchedules).hasSize(0)
+    assertThat(getReviewSchedules(prisonNumber).reviewSchedules).hasSize(0)
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RECEIVED_INTO_PRISON,
+      additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+        prisonNumber = prisonNumber,
+        reason = ADMISSION,
+      ),
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    await untilAsserted {
+      // assert that no induction schedules exist or were created for this prisoner, and that no outbound induction events were created
+      assertThat(getInductionScheduleHistory(prisonNumber).inductionSchedules).hasSize(0)
+      assertThat(inductionScheduleEventQueue.countAllMessagesOnQueue()).isEqualTo(0)
+
+      // assert that there is a correctly setup ReviewSchedule
+      val reviewSchedules = getReviewSchedules(prisonNumber)
+      assertThat(reviewSchedules.reviewSchedules).hasSize(1)
+      assertThat(reviewSchedules.reviewSchedules[0].status).isEqualTo(ReviewScheduleStatus.SCHEDULED)
+      assertThat(reviewSchedules.reviewSchedules[0].calculationRule).isEqualTo(ReviewScheduleCalculationRule.PRISONER_READMISSION)
+
+      // test that outbound event is also created:
+      val reviewScheduleEvent = inductionScheduleEventQueue.receiveEvent(QueueType.REVIEW)
+      assertThat(reviewScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
+      assertThat(reviewScheduleEvent.detailUrl).isEqualTo("http://localhost:8080/reviews/$prisonNumber/review-schedule")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
@@ -13,18 +13,24 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.verifyNoMoreInteractions
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionNotFoundException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleAlreadyExistsException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleCalculationRule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleNotFoundException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.COMPLETED
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.SCHEDULED
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aFullyPopulatedInduction
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidInductionSchedule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNotFoundException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidReviewSchedule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.aValidCreateInitialReviewScheduleDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewScheduleService
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidActionPlan
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.service.ActionPlanService
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch.aValidPrisoner
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
@@ -54,10 +60,16 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
   @Mock
   private lateinit var createInitialReviewScheduleMapper: CreateInitialReviewScheduleMapper
 
+  @Mock
+  private lateinit var inductionService: InductionService
+
+  @Mock
+  private lateinit var actionPlanService: ActionPlanService
+
   private val objectMapper = ObjectMapper()
 
   @Test
-  fun `should process event given reason is prisoner admission and prisoner does not already have an Induction Schedule`() {
+  fun `should process event given reason is prisoner admission and prisoner does not already have an Induction and Induction Schedule`() {
     // Given
     val prisonNumber = randomValidPrisonNumber()
     val prisonerAdmissionDate = LocalDate.now()
@@ -74,13 +86,63 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     )
 
     val prisoner = aValidPrisoner(prisonNumber)
+    given(prisonerSearchApiService.getPrisoner(prisonNumber)).willReturn(prisoner)
+
+    given(inductionService.getInductionForPrisoner(prisonNumber)).willThrow(InductionNotFoundException(prisonNumber))
+
     // When
-    whenever(prisonerSearchApiService.getPrisoner(prisonNumber)).thenReturn(prisoner)
     eventService.process(inboundEvent, additionalInformation)
 
     // Then
-    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId, releaseDate = prisoner.releaseDate)
+    verify(inductionScheduleService).createInductionSchedule(
+      prisonNumber,
+      prisonerAdmissionDate,
+      prisonId,
+      releaseDate = prisoner.releaseDate,
+    )
     verifyNoInteractions(reviewScheduleService)
+  }
+
+  @Test
+  fun `should process event given reason is prisoner admission and prisoner already has an Induction and Action Plan but no Induction Schedule`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val prisonerAdmissionDate = LocalDate.now()
+    val prisonId = "BXI"
+
+    val additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+      prisonNumber = prisonNumber,
+      reason = ADMISSION,
+      prisonId = prisonId,
+    )
+    val inboundEvent = anInboundEvent(
+      additionalInformation = additionalInformation,
+      eventOccurredAt = prisonerAdmissionDate.atTime(11, 47, 32).toInstant(ZoneOffset.UTC),
+    )
+
+    val prisoner = aValidPrisoner(prisonNumber)
+    given(prisonerSearchApiService.getPrisoner(prisonNumber)).willReturn(prisoner)
+
+    given(inductionService.getInductionForPrisoner(prisonNumber)).willReturn(aFullyPopulatedInduction(prisonNumber = prisonNumber))
+    given(actionPlanService.getActionPlan(prisonNumber)).willReturn(aValidActionPlan(prisonNumber = prisonNumber))
+    given(inductionScheduleService.getInductionScheduleForPrisoner(prisonNumber)).willThrow(
+      InductionScheduleNotFoundException(prisonNumber),
+    )
+
+    val createReviewScheduleDto = aValidCreateInitialReviewScheduleDto()
+    given(createInitialReviewScheduleMapper.fromPrisonerToDomain(any(), any(), any())).willReturn(
+      createReviewScheduleDto,
+    )
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verifyNoMoreInteractions(inductionScheduleService)
+    verify(reviewScheduleService).getActiveReviewScheduleForPrisoner(prisonNumber)
+    verify(prisonerSearchApiService).getPrisoner(prisonNumber)
+    verify(createInitialReviewScheduleMapper).fromPrisonerToDomain(prisoner, isTransfer = false, isReadmission = true)
+    verify(reviewScheduleService).createInitialReviewSchedule(createReviewScheduleDto)
   }
 
   @Test
@@ -100,7 +162,12 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
       eventOccurredAt = prisonerAdmissionDate.atTime(11, 47, 32).toInstant(ZoneOffset.UTC),
     )
 
+    given(inductionService.getInductionForPrisoner(prisonNumber)).willReturn(aFullyPopulatedInduction(prisonNumber = prisonNumber))
+    given(actionPlanService.getActionPlan(prisonNumber)).willReturn(aValidActionPlan(prisonNumber = prisonNumber))
+
     val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = COMPLETED)
+    given(inductionScheduleService.getInductionScheduleForPrisoner(prisonNumber)).willReturn(inductionSchedule)
+
     given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any(), anyOrNull(), any())).willThrow(
       InductionScheduleAlreadyExistsException(inductionSchedule),
     )
@@ -113,13 +180,20 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     given(prisonerSearchApiService.getPrisoner(prisonNumber)).willReturn(prisoner)
 
     val createReviewScheduleDto = aValidCreateInitialReviewScheduleDto()
-    given(createInitialReviewScheduleMapper.fromPrisonerToDomain(any(), any(), any())).willReturn(createReviewScheduleDto)
+    given(createInitialReviewScheduleMapper.fromPrisonerToDomain(any(), any(), any())).willReturn(
+      createReviewScheduleDto,
+    )
 
     // When
     eventService.process(inboundEvent, additionalInformation)
 
     // Then
-    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId, releaseDate = prisoner.releaseDate)
+    verify(inductionScheduleService).createInductionSchedule(
+      prisonNumber,
+      prisonerAdmissionDate,
+      prisonId,
+      releaseDate = prisoner.releaseDate,
+    )
     verify(reviewScheduleService).getActiveReviewScheduleForPrisoner(prisonNumber)
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)
     verify(createInitialReviewScheduleMapper).fromPrisonerToDomain(prisoner, isTransfer = false, isReadmission = true)
@@ -146,25 +220,38 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
       eventOccurredAt = prisonerAdmissionDate.atTime(11, 47, 32).toInstant(ZoneOffset.UTC),
     )
 
+    given(inductionService.getInductionForPrisoner(prisonNumber)).willReturn(aFullyPopulatedInduction(prisonNumber = prisonNumber))
+    given(actionPlanService.getActionPlan(prisonNumber)).willReturn(aValidActionPlan(prisonNumber = prisonNumber))
+
     val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = COMPLETED)
+    given(inductionScheduleService.getInductionScheduleForPrisoner(prisonNumber)).willReturn(inductionSchedule)
+
     given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any(), anyOrNull(), any())).willThrow(
       InductionScheduleAlreadyExistsException(inductionSchedule),
     )
 
-    val reviewSchedule = aValidReviewSchedule(prisonNumber = prisonNumber, scheduleStatus = ReviewScheduleStatus.SCHEDULED)
+    val reviewSchedule =
+      aValidReviewSchedule(prisonNumber = prisonNumber, scheduleStatus = ReviewScheduleStatus.SCHEDULED)
     given(reviewScheduleService.getActiveReviewScheduleForPrisoner(any())).willReturn(reviewSchedule)
 
     val prisoner = aValidPrisoner(prisonNumber)
     given(prisonerSearchApiService.getPrisoner(prisonNumber)).willReturn(prisoner)
 
     val createReviewScheduleDto = aValidCreateInitialReviewScheduleDto()
-    given(createInitialReviewScheduleMapper.fromPrisonerToDomain(any(), any(), any())).willReturn(createReviewScheduleDto)
+    given(createInitialReviewScheduleMapper.fromPrisonerToDomain(any(), any(), any())).willReturn(
+      createReviewScheduleDto,
+    )
 
     // When
     eventService.process(inboundEvent, additionalInformation)
 
     // Then
-    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId, releaseDate = prisoner.releaseDate)
+    verify(inductionScheduleService).createInductionSchedule(
+      prisonNumber,
+      prisonerAdmissionDate,
+      prisonId,
+      releaseDate = prisoner.releaseDate,
+    )
     verify(reviewScheduleService).getActiveReviewScheduleForPrisoner(prisonNumber)
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)
     verify(reviewScheduleService).exemptActiveReviewScheduleStatusDueToUnknownReason(prisonNumber, prisonId)
@@ -192,7 +279,12 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
       eventOccurredAt = prisonerAdmissionDate.atTime(11, 47, 32).toInstant(ZoneOffset.UTC),
     )
 
+    given(inductionService.getInductionForPrisoner(prisonNumber)).willReturn(aFullyPopulatedInduction(prisonNumber = prisonNumber))
+    given(actionPlanService.getActionPlan(prisonNumber)).willReturn(aValidActionPlan(prisonNumber = prisonNumber))
+
     val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = SCHEDULED)
+    given(inductionScheduleService.getInductionScheduleForPrisoner(prisonNumber)).willReturn(inductionSchedule)
+
     given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any(), anyOrNull(), any())).willThrow(
       InductionScheduleAlreadyExistsException(inductionSchedule),
     )
@@ -201,8 +293,19 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     eventService.process(inboundEvent, additionalInformation)
 
     // Then
-    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId, releaseDate = prisoner.releaseDate)
-    verify(inductionScheduleService).reschedulePrisonersInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId, releaseDate = prisoner.releaseDate, InductionScheduleCalculationRule.NEW_PRISON_ADMISSION)
+    verify(inductionScheduleService).createInductionSchedule(
+      prisonNumber,
+      prisonerAdmissionDate,
+      prisonId,
+      releaseDate = prisoner.releaseDate,
+    )
+    verify(inductionScheduleService).reschedulePrisonersInductionSchedule(
+      prisonNumber,
+      prisonerAdmissionDate,
+      prisonId,
+      releaseDate = prisoner.releaseDate,
+      InductionScheduleCalculationRule.NEW_PRISON_ADMISSION,
+    )
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)
   }
 
@@ -227,7 +330,9 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
 
   @ParameterizedTest
   @CsvSource(value = ["TEMPORARY_ABSENCE_RETURN", "RETURN_FROM_COURT"])
-  fun `should process event but not call service given reason is not a prisoner admission reason that we should process`(reason: Reason) {
+  fun `should process event but not call service given reason is not a prisoner admission reason that we should process`(
+    reason: Reason,
+  ) {
     // Given
     val additionalInformation = aValidPrisonerReceivedAdditionalInformation(reason = reason)
     val inboundEvent = anInboundEvent(additionalInformation)


### PR DESCRIPTION
end point to fix prisoners who have inductions and action plan but their induction_schedule is stuck at SCHEDULED. 

The SQL to identify prisoners stuck in this situation is: 

```WITH scheduled_prisoners AS (
    SELECT prison_number
    FROM induction_schedule
    WHERE schedule_status = 'SCHEDULED'
),
     induction_prisoners AS (
         SELECT DISTINCT prison_number
         FROM induction
         WHERE prison_number IN (SELECT prison_number FROM scheduled_prisoners)
     ),
     goal_prisons AS (
         SELECT DISTINCT a.prison_number
         FROM goal g
                  JOIN action_plan a ON g.action_plan_id = a.id
         WHERE a.prison_number IN (SELECT prison_number FROM scheduled_prisoners)
     ),
     common_prisoners AS (
         SELECT gp.prison_number
         FROM goal_prisons gp
                  JOIN induction_prisoners ip ON gp.prison_number = ip.prison_number
     )
SELECT prison_number
FROM common_prisoners;```