### PR TITLE
RR-1245 - Enable & configure postgresDatabaseRestore job

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -5,6 +5,22 @@ generic-service:
   ingress:
     host: learningandworkprogress-api.hmpps.service.justice.gov.uk
 
+  postgresDatabaseRestore:
+    jobName: lwp-prod-to-preprod-restore
+    enabled: true
+    timeout: 900
+    namespace_secrets:
+      rds-postgresql-instance-output:
+        DB_NAME: "database_name"
+        DB_USER: "database_username"
+        DB_PASS: "database_password"
+        DB_HOST: "rds_instance_address"
+      rds-postgresql-instance-output-preprod:
+        DB_NAME_PREPROD: "database_name"
+        DB_USER_PREPROD: "database_username"
+        DB_PASS_PREPROD: "database_password"
+        DB_HOST_PREPROD: "rds_instance_address"
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:


### PR DESCRIPTION
PR to enable & configure the `postgresDatabaseRestore` job to perform a regular clone of the LWP `prod` database back to the `preprod` environment.
