### PR TITLE
RR-1414 - Added prisonId to request body objects for archive, un-archive and complete goal APIs

### DIFF
--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Education and Work Plan API
-  version: '1.21.3'
+  version: '1.22.0'
   description: Education and Work Plan API
   contact:
     name: Learning and Work Progress team
@@ -2101,9 +2101,12 @@ components:
         note:
           type: string
           description: An optional note to accompany the archive
+        prisonId:
+          $ref: '#/components/schemas/PrisonId'
       required:
         - goalReference
         - reason
+        - prisonId
 
     CompleteGoalRequest:
       title: CompleteGoalRequest
@@ -2118,8 +2121,12 @@ components:
         note:
           type: string
           description: An optional note to accompany the completion
+        prisonId:
+          $ref: '#/components/schemas/PrisonId'
+
       required:
         - goalReference
+        - prisonId
 
     NoteResponse:
       title: NoteResponse
@@ -2174,8 +2181,11 @@ components:
           format: uuid
           description: The Goal's unique reference. This is used as an identifier to unarchive the required Goal.
           example: c88a6c48-97e2-4c04-93b5-98619966447b
+        prisonId:
+          $ref: '#/components/schemas/PrisonId'
       required:
         - goalReference
+        - prisonId
 
     GoalStatus:
       title: GoalStatus

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/ArchiveGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/ArchiveGoalRequestBuilder.kt
@@ -10,9 +10,11 @@ fun aValidArchiveGoalRequest(
   reason: ReasonToArchiveGoal = ReasonToArchiveGoal.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL,
   reasonOther: String? = null,
   note: String? = null,
+  prisonId: String = "BXI",
 ): ArchiveGoalRequest = ArchiveGoalRequest(
   goalReference = goalReference,
   reason = reason,
   reasonOther = reasonOther,
   note = note,
+  prisonId = prisonId,
 )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/CompleteGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/CompleteGoalRequestBuilder.kt
@@ -7,7 +7,9 @@ import java.util.*
 fun aValidCompleteGoalRequest(
   goalReference: UUID = aValidReference(),
   note: String? = null,
+  prisonId: String = "BXI",
 ): CompleteGoalRequest = CompleteGoalRequest(
   goalReference = goalReference,
   note = note,
+  prisonId = prisonId,
 )

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/UnarchiveGoalRequestBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/actionplan/UnarchiveGoalRequestBuilder.kt
@@ -6,6 +6,8 @@ import java.util.*
 
 fun aValidUnarchiveGoalRequest(
   goalReference: UUID = aValidReference(),
+  prisonId: String = "BXI",
 ): UnarchiveGoalRequest = UnarchiveGoalRequest(
   goalReference = goalReference,
+  prisonId = prisonId,
 )


### PR DESCRIPTION
This PR updates the swagger spec to add the `prisonId` field to the request bodies for the API operations `archiveGoal`, `unarchiveGoal` and `completeGoal`.
Because the corresponding generated classes now have a new mandatory property (ie: `prisonId`), I've also had to update the test data builders for these classes.

All this PR does is introduce the new `prisonId` field to the request bodies. At the moment there is no further processing of these new properties, and any values passed by the client are essentially ignored (for now)

Subsequent PRs will implement the logic to update the `Goal` entity by setting the `updatedAtPrison` field with the passed `prisonId` value; but that can wait for now.