### PR TITLE
Updated search client to only return certain fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PrisonerSearchApiClient.kt
@@ -16,6 +16,19 @@ class PrisonerSearchApiClient(
   companion object {
     const val FIRST_PAGE = 0
     const val DEFAULT_PAGE_SIZE = 9999
+    val RESPONSE_FIELDS = listOf(
+      "prisonerNumber",
+      "legalStatus",
+      "releaseDate",
+      "prisonId",
+      "indeterminateSentence",
+      "recall",
+      "lastName",
+      "firstName",
+      "dateOfBirth",
+      "cellLocation",
+      "nonDtoReleaseDateType",
+    )
   }
 
   /**
@@ -30,6 +43,7 @@ class PrisonerSearchApiClient(
       it.path("/prisoner-search/prison/$prisonId")
         .queryParam("page", page)
         .queryParam("size", pageSize)
+        .queryParam("responseFields", RESPONSE_FIELDS)
         .build()
     }
     .headers {


### PR DESCRIPTION
updated search API client to only return the fields we require: 

prisonerNumber
legalStatus,
releaseDate,
prisonId,
indeterminateSentence,
recall,
lastName,
firstName,
dateOfBirth,
cellLocation,
nonDtoReleaseDateType,

