### PR TITLE
Set updated at prison when a goal is archived/unarchived/completed

### DIFF
--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/ArchiveGoalDto.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/ArchiveGoalDto.kt
@@ -9,6 +9,7 @@ data class ArchiveGoalDto(
   val reference: UUID,
   val reason: ReasonToArchiveGoal,
   val reasonOther: String?,
+  val prisonId: String,
 )
 
 enum class ReasonToArchiveGoal {

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/CompleteGoalDto.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/CompleteGoalDto.kt
@@ -7,4 +7,5 @@ import java.util.*
  */
 data class CompleteGoalDto(
   val reference: UUID,
+  val prisonId: String,
 )

--- a/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/UnarchiveGoalDto.kt
+++ b/domain/personallearningplan/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/UnarchiveGoalDto.kt
@@ -7,4 +7,5 @@ import java.util.*
  */
 data class UnarchiveGoalDto(
   val reference: UUID,
+  val prisonId: String,
 )

--- a/domain/personallearningplan/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/ArchiveGoalDtoBuilder.kt
+++ b/domain/personallearningplan/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/ArchiveGoalDtoBuilder.kt
@@ -6,9 +6,11 @@ fun aValidArchiveGoalDto(
   reference: UUID = UUID.randomUUID(),
   reason: ReasonToArchiveGoal = ReasonToArchiveGoal.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL,
   reasonOther: String? = null,
+  prisonId: String = "BXI",
 ): ArchiveGoalDto =
   ArchiveGoalDto(
     reference = reference,
     reason = reason,
     reasonOther = reasonOther,
+    prisonId = prisonId,
   )

--- a/domain/personallearningplan/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/UnarchiveGoalDtoBuilder.kt
+++ b/domain/personallearningplan/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/personallearningplan/dto/UnarchiveGoalDtoBuilder.kt
@@ -4,7 +4,9 @@ import java.util.*
 
 fun aValidUnarchiveGoalDto(
   reference: UUID = UUID.randomUUID(),
+  prisonId: String = "BXI",
 ): UnarchiveGoalDto =
   UnarchiveGoalDto(
     reference = reference,
+    prisonId = prisonId,
   )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ArchiveGoalTest.kt
@@ -180,6 +180,40 @@ class ArchiveGoalTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should return 204 and archive a goal and change the updatedAtPrison to WMI`() {
+    // given
+    val prisonNumber = setUpRandomPrisoner()
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
+    val reasonOther = "Because it's Monday"
+    val noteText = "no longer relevant"
+    val archiveGoalRequest = aValidArchiveGoalRequest(
+      goalReference = goalReference,
+      ReasonToArchiveGoal.OTHER,
+      reasonOther,
+      note = noteText,
+      prisonId = "WMI",
+    )
+
+    // when
+    archiveAGoal(prisonNumber, goalReference, archiveGoalRequest)
+      .expectStatus()
+      .isNoContent()
+
+    // then
+    assertThat(getActionPlan(prisonNumber))
+      .isForPrisonNumber(prisonNumber)
+      .hasNumberOfGoals(1)
+      .goal(1) { goal ->
+        goal
+          .hasStatus(GoalStatus.ARCHIVED)
+          .hasArchiveReason(ReasonToArchiveGoal.OTHER)
+          .hasArchiveReasonOther(reasonOther)
+          .wasCreatedAtPrison("BXI")
+          .wasUpdatedAtPrison("WMI")
+      }
+  }
+
+  @Test
   fun `should return 404 if the goal isn't found`() {
     // given
     val prisonNumber = randomValidPrisonNumber()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CompleteGoalTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/CompleteGoalTest.kt
@@ -167,6 +167,35 @@ class CompleteGoalTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should return 204 and complete a goal and change the updated at prison to WMI`() {
+    // given
+    val prisonNumber = setUpRandomPrisoner()
+    val goalReference = createAnActionPlanAndGetTheGoalReference(prisonNumber)
+    val noteText = "Completed the goal! "
+    val completeGoalRequest = aValidCompleteGoalRequest(
+      goalReference = goalReference,
+      note = noteText,
+      prisonId = "WMI",
+    )
+    // when
+    completeAGoal(prisonNumber, goalReference, completeGoalRequest)
+      .expectStatus()
+      .isNoContent()
+
+    // then
+    assertThat(getActionPlan(prisonNumber))
+      .isForPrisonNumber(prisonNumber)
+      .hasNumberOfGoals(1)
+      .goal(1) { goal ->
+        goal
+          .hasStatus(GoalStatus.COMPLETED)
+          .hasCompletedNote(noteText)
+          .wasUpdatedAtPrison("WMI")
+          .wasCreatedAtPrison("BXI")
+      }
+  }
+
+  @Test
   fun `should return 404 if the goal isn't found`() {
     // given
     val prisonNumber = randomValidPrisonNumber()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalResourceMapper.kt
@@ -78,12 +78,13 @@ class GoalResourceMapper(
       reference = goalReference,
       reason = toReasonToArchiveGoal(reason),
       reasonOther = reasonOther,
+      prisonId = prisonId,
     )
   }
 
-  fun fromModelToDto(unarchiveGoalRequest: UnarchiveGoalRequest): UnarchiveGoalDto = UnarchiveGoalDto(reference = unarchiveGoalRequest.goalReference)
+  fun fromModelToDto(unarchiveGoalRequest: UnarchiveGoalRequest): UnarchiveGoalDto = UnarchiveGoalDto(reference = unarchiveGoalRequest.goalReference, prisonId = unarchiveGoalRequest.prisonId)
 
-  fun fromModelToDto(completeGoalRequest: CompleteGoalRequest): CompleteGoalDto = CompleteGoalDto(reference = completeGoalRequest.goalReference)
+  fun fromModelToDto(completeGoalRequest: CompleteGoalRequest): CompleteGoalDto = CompleteGoalDto(reference = completeGoalRequest.goalReference, prisonId = completeGoalRequest.prisonId)
 
   fun toGoalStatus(status: GoalStatusApi): GoalStatusDomain = when (status) {
     GoalStatusApi.ACTIVE -> GoalStatusDomain.ACTIVE


### PR DESCRIPTION
Following the previous update to the API spec for archived/unarchived/completed goals, this PR sets the updated at prison when a goal is archived, unarchived or completed.