### PR TITLE
added message publisher for induction messages

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ScheduleEtlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ScheduleEtlController.kt
@@ -68,11 +68,22 @@ class ScheduleEtlController(
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize(HAS_EDIT_REVIEWS)
   @Transactional
-  fun generateMessages(
+  fun generateReviewMessages(
     @RequestBody prisonNumbersRequest: PrisonNumbersRequest,
   ) {
     val reviewPrisonNumbers = prisonNumbersRequest.prisonNumbers.distinct()
     reviewPrisonNumbers.forEach(eventPublisher::createAndPublishReviewScheduleEvent)
+  }
+
+  @PostMapping("/action-plans/schedules/publish-induction-messages")
+  @ResponseStatus(HttpStatus.CREATED)
+  @PreAuthorize(HAS_EDIT_REVIEWS)
+  @Transactional
+  fun generateInductionMessages(
+    @RequestBody prisonNumbersRequest: PrisonNumbersRequest,
+  ) {
+    val inductionPrisonNumbers = prisonNumbersRequest.prisonNumbers.distinct()
+    inductionPrisonNumbers.forEach(eventPublisher::createAndPublishInductionEvent)
   }
 
   private fun prisonersWithAnySchedule(prisoners: List<Prisoner>): List<String> {


### PR DESCRIPTION
Probably won't need this one very often but this is an endpoint to generate induction schedule messages in the event we have to manually adjust data that has gone out of sync. 