### PR TITLE
Schedule adapter updates

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.Additi
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.TRANSFERRED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.review.CreateInitialReviewScheduleMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.PrisonerSearchApiService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ScheduleAdapter
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -65,6 +66,9 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
 
   @Mock
   private lateinit var actionPlanService: ActionPlanService
+
+  @Mock
+  private lateinit var scheduleAdapter: ScheduleAdapter
 
   private val objectMapper = ObjectMapper()
 
@@ -101,6 +105,7 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
       releaseDate = prisoner.releaseDate,
     )
     verifyNoInteractions(reviewScheduleService)
+    verifyNoInteractions(scheduleAdapter)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/UpdateGoalRequestReferenceConstraintValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/validator/UpdateGoalRequestReferenceConstraintValidatorTest.kt
@@ -15,7 +15,7 @@ class UpdateGoalRequestReferenceConstraintValidatorTest {
   private val validatorFactory = Validation.buildDefaultValidatorFactory()
   private val validator = validatorFactory.validator.forExecutables()
 
-  private val goalController = GoalController(mock(), mock(), mock())
+  private val goalController = GoalController(mock(), mock(), mock(), mock())
   private val updateGoalMethod = GoalController::class.java.getMethod(
     "updateGoal",
     UpdateGoalRequest::class.java,


### PR DESCRIPTION
There have been numerous discrepancies found in the production data which suggest that we don't always get the inbound ADMISSION message. This means that we don't create the induction/review schedules for people that have previously been in LWP.  While that is a problem that needs solving there are some things we can do to prevent people from ending up in a stuck state. 

This PR will check the the presence of schedules when a goal is added - thus providing a way that users can unstuck a person. ie by creating a dummy goal. 

And also create schedules when a person is transferred - transfers happen frequently especially after a new admission. So if we don't get the message for a new admission then we will get one for a transfer. 