### PR TITLE
removed the additional calls to work on release

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/InductionSummary.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/InductionSummary.kt
@@ -10,7 +10,6 @@ import java.util.UUID
 data class InductionSummary(
   val reference: UUID,
   val prisonNumber: String,
-  val workOnRelease: WorkOnRelease,
   val createdBy: String,
   val createdAt: Instant,
   val lastUpdatedBy: String,

--- a/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/InductionSummaryBuilder.kt
+++ b/domain/learningandworkprogress/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/InductionSummaryBuilder.kt
@@ -6,7 +6,6 @@ import java.util.UUID
 fun aValidInductionSummary(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  workOnRelease: WorkOnRelease = aValidWorkOnRelease(),
   createdBy: String = "asmith_gen",
   createdAt: Instant = Instant.now(),
   lastUpdatedBy: String = "bjones_gen",
@@ -15,7 +14,6 @@ fun aValidInductionSummary(
   InductionSummary(
     reference = reference,
     prisonNumber = prisonNumber,
-    workOnRelease = workOnRelease,
     createdBy = createdBy,
     createdAt = createdAt,
     lastUpdatedBy = lastUpdatedBy,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/GetCiagInductionSummariesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ciag/GetCiagInductionSummariesTest.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionSummaryListResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork.NO
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork.YES
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequestForPrisonerLookingToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidCreateInductionRequestForPrisonerNotLookingToWork
@@ -100,8 +99,8 @@ class GetCiagInductionSummariesTest : IntegrationTestBase() {
         ),
         aValidCiagInductionSummaryResponse(
           offenderId = prisonNumber2,
-          desireToWork = true,
-          hopingToGetWork = YES,
+          desireToWork = false,
+          hopingToGetWork = NO,
           createdBy = "auser_gen",
           modifiedBy = "auser_gen",
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionSummaryProjection.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionSummaryProjection.kt
@@ -6,7 +6,6 @@ import java.util.UUID
 data class InductionSummaryProjection(
   val reference: UUID,
   val prisonNumber: String,
-  val workOnRelease: WorkOnReleaseEntity,
   val createdAt: Instant,
   val createdBy: String,
   val updatedAt: Instant,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionSummaryProjectionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionSummaryProjectionEntity.kt
@@ -1,13 +1,9 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
 
-import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.Immutable
@@ -32,10 +28,6 @@ data class InductionSummaryProjectionEntity(
 
   @Column(updatable = false)
   val prisonNumber: String,
-
-  @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "work_on_release_id")
-  val workOnRelease: WorkOnReleaseEntity,
 
   @Column(updatable = false)
   val conductedBy: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapper.kt
@@ -84,7 +84,6 @@ class InductionEntityMapper(
     InductionSummary(
       reference = it.reference,
       prisonNumber = it.prisonNumber,
-      workOnRelease = workOnReleaseEntityMapper.fromEntityToDomain(it.workOnRelease),
       createdBy = it.createdBy,
       createdAt = it.createdAt,
       lastUpdatedBy = it.updatedBy,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInductionResponseMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInductionResponseMapper.kt
@@ -4,8 +4,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionSummary
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CiagInductionSummaryResponse
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.HopingToWork as HopingToWorkDomain
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork as HopingToWorkApi
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork
 
 @Component
 class CiagInductionResponseMapper(private val instantMapper: InstantMapper) {
@@ -13,19 +12,12 @@ class CiagInductionResponseMapper(private val instantMapper: InstantMapper) {
     with(inductionSummary) {
       CiagInductionSummaryResponse(
         offenderId = prisonNumber,
-        desireToWork = when (workOnRelease.hopingToWork) {
-          HopingToWorkDomain.YES -> true
-          else -> false
-        },
-        hopingToGetWork = HopingToWorkApi.valueOf(workOnRelease.hopingToWork.name),
+        desireToWork = false,
+        hopingToGetWork = HopingToWork.NO,
         createdBy = createdBy,
         createdDateTime = instantMapper.toOffsetDateTime(createdAt)!!,
-        // The main Induction domain object is immutable (the data that can be changed belongs in associated "child"
-        // objects). However, the CIAG API stores details regarding a prisoner's work aspirations at the root level,
-        // which means that any changes to these values needs to be reflected in the "modified" fields of the root
-        // Induction in the response.
-        modifiedBy = workOnRelease.lastUpdatedBy!!,
-        modifiedDateTime = instantMapper.toOffsetDateTime(workOnRelease.lastUpdatedAt)!!,
+        modifiedBy = inductionSummary.lastUpdatedBy,
+        modifiedDateTime = instantMapper.toOffsetDateTime(inductionSummary.lastUpdatedAt)!!,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/InductionEntityMapperTest.kt
@@ -246,15 +246,10 @@ class InductionEntityMapperTest {
     val summaryProjection1 = aValidInductionSummaryProjection(prisonNumber = randomValidPrisonNumber())
     val summaryProjection2 = aValidInductionSummaryProjection(prisonNumber = randomValidPrisonNumber())
 
-    val workOnRelease1 = aValidWorkOnRelease()
-    val workOnRelease2 = aValidWorkOnRelease()
-    given(workOnReleaseEntityMapper.fromEntityToDomain(any())).willReturn(workOnRelease1, workOnRelease2)
-
     val expected = listOf(
       aValidInductionSummary(
         prisonNumber = summaryProjection1.prisonNumber,
         reference = summaryProjection1.reference,
-        workOnRelease = workOnRelease1,
         createdBy = summaryProjection1.createdBy,
         createdAt = summaryProjection1.createdAt,
         lastUpdatedBy = summaryProjection1.updatedBy,
@@ -263,7 +258,6 @@ class InductionEntityMapperTest {
       aValidInductionSummary(
         prisonNumber = summaryProjection2.prisonNumber,
         reference = summaryProjection2.reference,
-        workOnRelease = workOnRelease2,
         createdBy = summaryProjection2.createdBy,
         createdAt = summaryProjection2.createdAt,
         lastUpdatedBy = summaryProjection2.updatedBy,
@@ -277,7 +271,5 @@ class InductionEntityMapperTest {
     // Then
     assertThat(actual).hasSize(2)
     assertThat(actual).isEqualTo(expected)
-    verify(workOnReleaseEntityMapper).fromEntityToDomain(summaryProjection1.workOnRelease)
-    verify(workOnReleaseEntityMapper).fromEntityToDomain(summaryProjection2.workOnRelease)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInductionResponseMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/induction/ciag/CiagInductionResponseMapperTest.kt
@@ -8,14 +8,11 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
-import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidInductionSummary
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidWorkOnRelease
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.ciag.aValidCiagInductionSummaryResponse
 import java.time.OffsetDateTime
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.HopingToWork as HopingToWorkDomain
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.HopingToWork as HopingToWorkApi
 
 @ExtendWith(MockitoExtension::class)
@@ -32,15 +29,9 @@ class CiagInductionResponseMapperTest {
     // Given
     val summary1 = aValidInductionSummary(
       prisonNumber = randomValidPrisonNumber(),
-      workOnRelease = aValidWorkOnRelease(
-        hopingToWork = HopingToWorkDomain.YES,
-      ),
     )
     val summary2 = aValidInductionSummary(
       prisonNumber = randomValidPrisonNumber(),
-      workOnRelease = aValidWorkOnRelease(
-        hopingToWork = HopingToWorkDomain.NO,
-      ),
     )
 
     val now = OffsetDateTime.now()
@@ -49,8 +40,8 @@ class CiagInductionResponseMapperTest {
     val expected = listOf(
       aValidCiagInductionSummaryResponse(
         offenderId = summary1.prisonNumber,
-        hopingToGetWork = HopingToWorkApi.YES,
-        desireToWork = true,
+        hopingToGetWork = HopingToWorkApi.NO,
+        desireToWork = false,
         createdBy = summary1.createdBy,
         createdDateTime = now,
         modifiedBy = summary1.lastUpdatedBy,
@@ -73,9 +64,5 @@ class CiagInductionResponseMapperTest {
     // Then
     assertThat(actual).hasSize(2)
     assertThat(actual).isEqualTo(expected)
-    verify(instantMapper).toOffsetDateTime(summary1.createdAt)
-    verify(instantMapper).toOffsetDateTime(summary1.workOnRelease.lastUpdatedAt)
-    verify(instantMapper).toOffsetDateTime(summary2.createdAt)
-    verify(instantMapper).toOffsetDateTime(summary2.workOnRelease.lastUpdatedAt)
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionSummaryProjectionBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionSummaryProjectionBuilder.kt
@@ -6,7 +6,6 @@ import java.util.UUID
 fun aValidInductionSummaryProjection(
   reference: UUID = UUID.randomUUID(),
   prisonNumber: String = "A1234BC",
-  workOnRelease: WorkOnReleaseEntity = aValidWorkOnReleaseEntity(),
   createdBy: String = "asmith_gen",
   createdAt: Instant = Instant.now(),
   updatedBy: String = "bjones_gen",
@@ -14,7 +13,6 @@ fun aValidInductionSummaryProjection(
 ): InductionSummaryProjection = InductionSummaryProjection(
   reference = reference,
   prisonNumber = prisonNumber,
-  workOnRelease = workOnRelease,
   createdBy = createdBy,
   createdAt = createdAt,
   updatedBy = updatedBy,


### PR DESCRIPTION
This endpoint is causing problems in production due to the additional hibernate calls to work on release. While it may be possible to influence hibernate to do these calls in a oneer it turns out that the front end doesn't do anything with the work on release information. It basically uses the presence of a returned prisonerId as the indicator that the person has an induction or not. 

So I've removed the additional calls to other entities outside of the main induction. 