### PR TITLE
Fix the cron schedule for the queue housekeeping job in dev and preprod

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -34,4 +34,4 @@ generic-data-analytics-extractor:
   cronJobSchedule: '00 7 * * 1-5' # Start at 7am UTC Monday-Friday to allow for the fact that we terminate the resources (inc. RDS) overnight and all weekend in the dev env (see scheduledDowntime above)
 
 queueHousekeeping:
-  cronJobSchedule: "*/10 07-21 * * 1-5" # Every 10 minutes between 7am and 9pm UTC Monday-Friday to allow for the fact that we terminate the resources overnight and all weekend in the dev env (see scheduledDowntime above)
+  cronJobSchedule: "*/10 07-20 * * 1-5" # Every 10 minutes between 7am and 8:59pm UTC Monday-Friday to allow for the fact that we terminate the resources overnight and all weekend in the dev env (see scheduledDowntime above)

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -30,4 +30,4 @@ generic-data-analytics-extractor:
   cronJobSchedule: '00 7 * * 1-5' # Start at 7am UTC Monday-Friday to allow for the fact that we terminate the resources (inc. RDS) overnight and all weekend in the preprod env (see scheduledDowntime above)
 
 queueHousekeeping:
-  cronJobSchedule: "*/10 07-21 * * 1-5" # Every 10 minutes between 7am and 9pm UTC Monday-Friday to allow for the fact that we terminate the resources overnight and all weekend in the preprod env (see scheduledDowntime above)
+  cronJobSchedule: "*/10 07-20 * * 1-5" # Every 10 minutes between 7am and 8:59pm UTC Monday-Friday to allow for the fact that we terminate the resources overnight and all weekend in the preprod env (see scheduledDowntime above)


### PR DESCRIPTION
PR to correct the cron schedule for the queue housekeeping job in dev and preprod, which should fix the k8s pod errors we see.

The problem is that we shutdown the resources at 9pm, and start them again at 06:30 mon-fri:
```
  scheduledDowntime:
    enabled: true
    startup: '30 6 * * 1-5' # Start at 6.30am UTC Monday-Friday
    shutdown: '00 21 * * 1-5' # Stop at 9.00pm UTC Monday-Friday
```
The cron for the shutdown says it will shutdown at 9pm:
![Screenshot 2025-07-01 at 16 47 24](https://github.com/user-attachments/assets/abc77f0d-d92d-4665-ade3-b3dbbaa8843b)

We then had the cron for the housekeeping job. The idea is that it would run every 10 minutes during the "up" time, IE. between 07:00 (to allow the resources a little time to start up) and 9pm:
```
queueHousekeeping:
  cronJobSchedule: "*/10 07-21 * * 1-5" # Every 10 minutes between 7am and 9pm UTC Monday-Friday to allow for the fact that we terminate the resources overnight and all weekend in the dev env (see scheduledDowntime above)
```
... but .... that cron resolves to ending at 9:59pm, not 9:00pm:
![Screenshot 2025-07-01 at 16 47 57](https://github.com/user-attachments/assets/247c66ed-ccf6-4e82-ae12-09874dd2a9d8)

Changing the cron to be an hour less should fix it:
```
queueHousekeeping:
  cronJobSchedule: "*/10 07-20 * * 1-5" # Every 10 minutes between 7am and 8:59pm UTC Monday-Friday to allow for the fact that we terminate the resources overnight and all weekend in the dev env (see scheduledDowntime above)
```
![Screenshot 2025-07-01 at 16 48 09](https://github.com/user-attachments/assets/c1b005b9-68df-4ed1-bf33-4a78da112472)

