### PR TITLE
added extra logging for when the person has no release date

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleDateCalculationService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleDateCalculationService.kt
@@ -59,8 +59,10 @@ class ReviewScheduleDateCalculationService {
         CONVICTED_UNSENTENCED -> PRISONER_UN_SENTENCED
         INDETERMINATE_SENTENCE -> ReviewScheduleCalculationRule.INDETERMINATE_SENTENCE
         else -> if (releaseDate != null) {
+          log.info("release date was {$releaseDate} for prison number $prisonNumber using calculation rule based on time left to serve.")
           reviewScheduleCalculationRuleBasedOnTimeLeftToServe(releaseDate)
         } else {
+          log.info("release date was null for prison number $prisonNumber using calculation rule INDETERMINATE_SENTENCE")
           ReviewScheduleCalculationRule.INDETERMINATE_SENTENCE
         }
       }


### PR DESCRIPTION
Investigating a bug where a new review was generated even though the release date was in the next week. The review should have been completed and marked as pre_release = true rather than creating a new release with a due date of 1 year in the future. 

I think - although I can't confirm - that the release date was set after the review was complete. The calculation rule was set to INDETERMINATE_SENTENCE which can only happen when there is no release date. 

This PR adds more logging so that the next time this happens we can be sure if the release date was set or not. 