### PR TITLE
Allow toPrisonId to be null

### DIFF
--- a/src/main/resources/static/openapi/PrisonApi.json
+++ b/src/main/resources/static/openapi/PrisonApi.json
@@ -28988,9 +28988,6 @@
         "description": "A movement IN and OUT range"
       },
       "TransferDetail": {
-        "required": [
-          "toPrisonId"
-        ],
         "type": "object",
         "properties": {
           "dateOutOfPrison": {


### PR DESCRIPTION
Sometimes the toPrisonId is null in the response from prisonAPI despite it being required in their schema 🤷🏻‍♂️ This blows up the prisoner timeline endpoint. 

This PR is to make toPrisonId not mandatory. 