### PR TITLE
update to handle Temp absence return

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/IntegrationTestBase.kt
@@ -63,6 +63,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.GOALS_R
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.INDUCTIONS_RO
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.INDUCTIONS_RW
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.REVIEWS_RO
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.REVIEWS_RW
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.TIMELINE_RO
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.LocalStackContainer
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.testcontainers.LocalStackContainer.setLocalStackProperties
@@ -82,6 +83,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Induc
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionSchedulesResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateReviewScheduleStatusRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalsRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.aValidCreateEducationRequest
@@ -110,6 +112,7 @@ abstract class IntegrationTestBase {
     const val GET_ACTION_PLAN_URI_TEMPLATE = "/action-plans/{prisonNumber}"
     const val GET_ACTION_PLAN_REVIEWS_URI_TEMPLATE = "/action-plans/{prisonNumber}/reviews"
     const val GET_REVIEW_SCHEDULES_URI_TEMPLATE = "/action-plans/{prisonNumber}/reviews/review-schedules"
+    const val UPDATE_REVIEW_SCHEDULE_STATUS_URI_TEMPLATE = "/action-plans/{prisonNumber}/reviews/schedule-status"
     const val GET_TIMELINE_URI_TEMPLATE = "/timelines/{prisonNumber}"
     const val INDUCTION_URI_TEMPLATE = "/inductions/{prisonNumber}"
     const val EDUCATION_URI_TEMPLATE = "/person/{prisonNumber}/education"
@@ -369,6 +372,27 @@ abstract class IntegrationTestBase {
       .exchange()
       .expectStatus()
       .isCreated()
+  }
+
+  fun updateReviewStatus(
+    prisonNumber: String,
+    updateReviewScheduleStatusRequest: UpdateReviewScheduleStatusRequest,
+    username: String = "auser_gen",
+  ) {
+    webTestClient.put()
+      .uri(UPDATE_REVIEW_SCHEDULE_STATUS_URI_TEMPLATE, prisonNumber)
+      .withBody(updateReviewScheduleStatusRequest)
+      .bearerToken(
+        aValidTokenWithAuthority(
+          REVIEWS_RW,
+          privateKey = keyPair.private,
+          username = username,
+        ),
+      )
+      .contentType(APPLICATION_JSON)
+      .exchange()
+      .expectStatus()
+      .isNoContent
   }
 
   fun getInduction(prisonNumber: String): InductionResponse = webTestClient.get()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventDueToTempAbsenceInductionScheduleTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventDueToTempAbsenceInductionScheduleTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.Additi
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RECEIVED_INTO_PRISON
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus.COMPLETED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus.EXEMPT_PRISON_REGIME_CIRCUMSTANCES
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus.EXEMPT_TEMP_ABSENCE
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus.SCHEDULED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
@@ -122,6 +123,51 @@ class PrisonerReceivedEventDueToTempAbsenceInductionScheduleTest : IntegrationTe
     }
   }
 
+  @Test
+  fun `should not update Induction Schedule and send outbound message given 'prisoner received' (temp absence) event for prisoner that has manual exempt induction`() {
+    // Given
+    // an induction Schedule exists
+    val prisonNumber = randomValidPrisonNumber()
+    val earliestDateTime = OffsetDateTime.now()
+
+    createInductionSchedule(prisonNumber, status = InductionScheduleStatus.EXEMPT_PRISON_REGIME_CIRCUMSTANCES)
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RECEIVED_INTO_PRISON,
+      additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+        prisonNumber = prisonNumber,
+        reason = TEMPORARY_ABSENCE_RETURN,
+      ),
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    val inductionSchedule = getInductionSchedule(prisonNumber)
+    assertThat(inductionSchedule)
+      .wasCreatedAtOrAfter(earliestDateTime)
+      .wasUpdatedAtOrAfter(earliestDateTime)
+      .wasCreatedBy("system")
+      .wasCreatedByDisplayName("system")
+      .wasUpdatedBy("system")
+      .wasUpdatedByDisplayName("system")
+      .wasScheduleCalculationRule(InductionScheduleCalculationRule.NEW_PRISON_ADMISSION)
+      .wasStatus(EXEMPT_PRISON_REGIME_CIRCUMSTANCES)
+
+    await.untilAsserted {
+      val inductionScheduleHistories = getInductionScheduleHistory(prisonNumber)
+      assertThat(inductionScheduleHistories.inductionSchedules.size).isEqualTo(0)
+      assertThat(inductionScheduleEventQueue.countAllMessagesOnQueue()).isEqualTo(0)
+    }
+  }
+
   // NOTE: this test is to test the scenario where we did not get the admission message for this person.
   // so for all intents and purposes this is the admission message
   @Test
@@ -171,6 +217,60 @@ class PrisonerReceivedEventDueToTempAbsenceInductionScheduleTest : IntegrationTe
 
     await.untilAsserted {
       assertThat(inductionScheduleEvents).hasSize(3)
+      assertThat(inductionScheduleEvents).allSatisfy {
+        assertThat(it.personReference.identifiers[0].value).isEqualTo(prisonNumber)
+        assertThat(it.detailUrl).isEqualTo("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
+      }
+    }
+  }
+
+  @Test
+  fun `should update Induction Schedule and send outbound message given 'prisoner received' (temp absence) event for prisoner that has an active Induction Schedule and status is EXEMPT_PRISONER_RELEASE`() {
+    // Given
+    // an induction Schedule exists
+    val prisonNumber = randomValidPrisonNumber()
+    val earliestDateTime = OffsetDateTime.now()
+
+    createInductionSchedule(prisonNumber, status = InductionScheduleStatus.EXEMPT_PRISONER_RELEASE, deadlineDate = LocalDate.now().plusDays(1))
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RECEIVED_INTO_PRISON,
+      additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+        prisonNumber = prisonNumber,
+        reason = TEMPORARY_ABSENCE_RETURN,
+      ),
+    )
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    val inductionSchedule = getInductionSchedule(prisonNumber)
+    assertThat(inductionSchedule)
+      .wasCreatedAtOrAfter(earliestDateTime)
+      .wasUpdatedAtOrAfter(earliestDateTime)
+      .wasCreatedBy("system")
+      .wasCreatedByDisplayName("system")
+      .wasUpdatedBy("system")
+      .wasUpdatedByDisplayName("system")
+      .wasScheduleCalculationRule(InductionScheduleCalculationRule.NEW_PRISON_ADMISSION)
+      .hasDeadlineDate(LocalDate.now().plusDays(5))
+      .wasStatus(SCHEDULED)
+
+    val inductionScheduleHistories = getInductionScheduleHistory(prisonNumber)
+    assertThat(inductionScheduleHistories.inductionSchedules.size).isEqualTo(2)
+    assertThat(inductionScheduleHistories.inductionSchedules[1].scheduleStatus).isEqualTo(EXEMPT_TEMP_ABSENCE)
+    assertThat(inductionScheduleHistories.inductionSchedules[0].scheduleStatus).isEqualTo(SCHEDULED)
+
+    val inductionScheduleEvents = inductionScheduleEventQueue.receiveEventsOnQueue(QueueType.INDUCTION)
+
+    await.untilAsserted {
+      assertThat(inductionScheduleEvents).hasSize(2)
       assertThat(inductionScheduleEvents).allSatisfy {
         assertThat(it.personReference.identifiers[0].value).isEqualTo(prisonNumber)
         assertThat(it.detailUrl).isEqualTo("http://localhost:8080/inductions/$prisonNumber/induction-schedule")


### PR DESCRIPTION
Seems that the previous version of this processing for TAP returns was a bit overzealous. 

Unbeknown to me at the time of writing the previous version there are prisoners who come and go to and from prison every single day. These people are referred as 'out workers' or similar and they are usually marked as exempt due to EXEMPT_PRISON_REGIME_CIRCUMSTANCES but they could have any of the manual exemptions. 

So this PR will check to see if the person is either RELEASED or SCHEDULED (or the edge case where they have no schedule) before applying the TAP rules. 

I've added lots of tests too. 