### PR TITLE
RR-2586 - Don't attempt to map Administrative movement events into the timeline

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiMapper.kt
@@ -9,6 +9,10 @@ import java.time.format.DateTimeFormatter
 
 @Component
 class PrisonApiMapper {
+  companion object {
+    private const val ADMINISTRATIVE = "Administrative"
+  }
+
   fun toPrisonMovementEvents(
     prisonerNumber: String,
     prisonerInPrisonSummary: PrisonerInPrisonSummary,
@@ -27,14 +31,16 @@ class PrisonApiMapper {
 
   private fun buildAdmissionsAndReleases(movements: List<SignificantMovement>): List<PrisonMovementEvent> {
     val admissionsAndReleases = mutableListOf<PrisonMovementEvent>()
-    movements.forEach {
-      if (isAdmissionIntoPrison(it)) {
-        admissionsAndReleases.add(toPrisonAdmissionEvent(it))
+    movements
+      .filter { it.isNotAnAdministrativeRecord() }
+      .forEach {
+        if (isAdmissionIntoPrison(it)) {
+          admissionsAndReleases.add(toPrisonAdmissionEvent(it))
+        }
+        if (isReleaseFromPrison(it)) {
+          admissionsAndReleases.add(toPrisonReleaseEvent(it))
+        }
       }
-      if (isReleaseFromPrison(it)) {
-        admissionsAndReleases.add(toPrisonReleaseEvent(it))
-      }
-    }
 
     return admissionsAndReleases
   }
@@ -69,4 +75,6 @@ class PrisonApiMapper {
   private fun isReleaseFromPrison(it: SignificantMovement) = it.outwardType == SignificantMovement.OutwardType.REL
 
   private fun String?.toLocalDate() = LocalDate.parse(this, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+
+  private fun SignificantMovement.isNotAnAdministrativeRecord(): Boolean = this.reasonInToPrison != ADMINISTRATIVE
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiMapperTest.kt
@@ -287,4 +287,162 @@ class PrisonApiMapperTest {
     // Then
     assertThat(actual).isEqualTo(expected)
   }
+
+  @Test
+  fun `should map to PrisonMovementEvents given a booking includes both Administrative and non-Administrative movements`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+
+    val objectMapper = ObjectMapper()
+    val prisonApiResponse = """
+{
+  "prisonerNumber": "$prisonNumber",
+  "prisonPeriod": [
+    {
+      "bookNumber": "55332F",
+      "bookingId": 2875329,
+      "bookingSequence": 1,
+      "entryDate": "2023-09-29T17:30:15",
+      "movementDates": [
+        {
+          "reasonInToPrison": "Imprisonment Without Option",
+          "dateInToPrison": "2023-09-29T17:30:15",
+          "inwardType": "ADM",
+          "reasonOutOfPrison": "CONDITIONAL RELEASE",
+          "dateOutOfPrison": "2024-03-05T11:11:36",
+          "outwardType": "REL",
+          "admittedIntoPrisonId": "WWI",
+          "releaseFromPrisonId": "BXI"
+        },
+        {
+          "reasonInToPrison": "Unconvicted Remand",
+          "dateInToPrison": "2024-06-12T19:08:57",
+          "inwardType": "ADM",
+          "reasonOutOfPrison": "Medical/Dental Outpatient Appointment",
+          "dateOutOfPrison": "2024-11-21T09:50:04",
+          "outwardType": "TAP",
+          "admittedIntoPrisonId": "TSI",
+          "releaseFromPrisonId": "BXI"
+        },
+        {
+          "reasonInToPrison": "Medical/Dental Outpatient Appointment",
+          "dateInToPrison": "2024-11-21T15:57:47",
+          "inwardType": "TAP",
+          "reasonOutOfPrison": "CONDITIONAL RELEASE",
+          "dateOutOfPrison": "2025-02-20T17:38:47",
+          "outwardType": "REL",
+          "admittedIntoPrisonId": "BXI",
+          "releaseFromPrisonId": "BXI"
+        },
+        {
+          "reasonInToPrison": "Administrative",
+          "dateInToPrison": "2018-09-13T00:00:00",
+          "inwardType": "ADM",
+          "reasonOutOfPrison": "Administrative Release due to Merge",
+          "dateOutOfPrison": "2018-09-19T00:00:00",
+          "outwardType": "REL"
+        },
+        {
+          "reasonInToPrison": "Unconvicted Remand",
+          "dateInToPrison": "2026-03-03T20:16:54",
+          "inwardType": "ADM",
+          "admittedIntoPrisonId": "TSI"
+        }
+      ],
+      "transfers": [
+        {
+          "dateOutOfPrison": "2023-11-01T14:47:00",
+          "dateInToPrison": "2023-11-01T15:41:02",
+          "transferReason": "Normal Transfer",
+          "fromPrisonId": "WWI",
+          "toPrisonId": "BXI"
+        },
+        {
+          "dateOutOfPrison": "2024-07-03T09:18:00",
+          "dateInToPrison": "2024-07-03T15:25:02",
+          "transferReason": "TRANSFER VIA COURT",
+          "fromPrisonId": "TSI",
+          "toPrisonId": "WWI"
+        },
+        {
+          "dateOutOfPrison": "2024-11-18T13:17:00",
+          "dateInToPrison": "2024-11-18T15:20:27",
+          "transferReason": "Normal Transfer",
+          "fromPrisonId": "WWI",
+          "toPrisonId": "BXI"
+        },
+        {
+          "dateOutOfPrison": "2026-04-07T13:48:00",
+          "dateInToPrison": "2026-04-07T17:00:08",
+          "transferReason": "Normal Transfer",
+          "fromPrisonId": "TSI",
+          "toPrisonId": "ONI"
+        }
+      ],
+      "prisons": [
+        "WWI",
+        "BXI",
+        "TSI",
+        "ONI"
+      ]
+    }
+  ]
+}
+    """.trimIndent()
+    val prisonSummary = objectMapper.readValue(prisonApiResponse, PrisonerInPrisonSummary::class.java)
+
+    val expected = aValidPrisonMovementEvents(
+      prisonNumber = prisonNumber,
+      prisonBookings = mapOf(
+        2875329L to listOf( // Booking ID 2875329 contains a mix of Administrative and non-Administrative movements, but only the non-Administrative movements are mapped and expected
+          aValidAdmissionPrisonMovementEvent(
+            date = LocalDate.parse("2023-09-29"),
+            toPrisonId = "WWI",
+          ),
+          aValidReleasePrisonMovementEvent(
+            date = LocalDate.parse("2024-03-05"),
+            fromPrisonId = "BXI",
+          ),
+          aValidAdmissionPrisonMovementEvent(
+            date = LocalDate.parse("2024-06-12"),
+            toPrisonId = "TSI",
+          ),
+          aValidReleasePrisonMovementEvent(
+            date = LocalDate.parse("2025-02-20"),
+            fromPrisonId = "BXI",
+          ),
+          aValidAdmissionPrisonMovementEvent(
+            date = LocalDate.parse("2026-03-03"),
+            toPrisonId = "TSI",
+          ),
+          aValidTransferPrisonMovementEvent(
+            date = LocalDate.parse("2023-11-01"),
+            fromPrisonId = "WWI",
+            toPrisonId = "BXI",
+          ),
+          aValidTransferPrisonMovementEvent(
+            date = LocalDate.parse("2024-07-03"),
+            fromPrisonId = "TSI",
+            toPrisonId = "WWI",
+          ),
+          aValidTransferPrisonMovementEvent(
+            date = LocalDate.parse("2024-11-18"),
+            fromPrisonId = "WWI",
+            toPrisonId = "BXI",
+          ),
+          aValidTransferPrisonMovementEvent(
+            date = LocalDate.parse("2026-04-07"),
+            fromPrisonId = "TSI",
+            toPrisonId = "ONI",
+          ),
+        ),
+      ),
+    )
+
+    // When
+    val actual = mapper.toPrisonMovementEvents(prisonNumber, prisonSummary)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiMapperTest.kt
@@ -2,19 +2,17 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonap
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
-import org.mockito.junit.jupiter.MockitoExtension
+import tools.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
+import uk.gov.justice.digital.hmpps.prisonapi.resource.model.PrisonerInPrisonSummary
+import java.time.LocalDate
 
-@ExtendWith(MockitoExtension::class)
 class PrisonApiMapperTest {
 
-  @InjectMocks
-  private lateinit var mapper: PrisonApiMapper
+  private var mapper = PrisonApiMapper()
 
   @Test
-  fun `should convert to PrisonMovementEvents`() {
+  fun `should map to PrisonMovementEvents`() {
     // Given
     val prisonNumber = randomValidPrisonNumber()
     val prisonSummary = aValidPrisonerInPrisonSummary()
@@ -44,7 +42,7 @@ class PrisonApiMapperTest {
   }
 
   @Test
-  fun `should convert to PrisonMovementEvents given empty prison periods`() {
+  fun `should map to PrisonMovementEvents given empty prison periods`() {
     // Given
     val prisonNumber = randomValidPrisonNumber()
     val prisonSummary = aValidPrisonerInPrisonSummary(
@@ -61,7 +59,7 @@ class PrisonApiMapperTest {
   }
 
   @Test
-  fun `should convert to PrisonMovementEvents given empty prison bookings`() {
+  fun `should map to PrisonMovementEvents given empty prison bookings`() {
     // Given
     val prisonNumber = randomValidPrisonNumber()
     val prisonSummary = aValidPrisonerInPrisonSummary(
@@ -77,6 +75,209 @@ class PrisonApiMapperTest {
       prisonNumber = prisonNumber,
       prisonBookings = mapOf(
         1L to emptyList(),
+      ),
+    )
+
+    // When
+    val actual = mapper.toPrisonMovementEvents(prisonNumber, prisonSummary)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should map to PrisonMovementEvents given bookings including Administrative movements`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+
+    val objectMapper = ObjectMapper()
+    val prisonApiResponse = """
+{
+  "prisonerNumber": "$prisonNumber",
+  "prisonPeriod": [
+    {
+      "bookNumber": "15361B",
+      "bookingId": 1473439,
+      "bookingSequence": 8,
+      "entryDate": "2018-01-06T15:13:08",
+      "releaseDate": "2018-01-12T10:12:20",
+      "movementDates": [
+        {
+          "reasonInToPrison": "Convicted Unsentenced",
+          "dateInToPrison": "2018-01-06T15:13:08",
+          "inwardType": "ADM",
+          "reasonOutOfPrison": "NON CUSTODIAL SENTENCE",
+          "dateOutOfPrison": "2018-01-12T10:12:20",
+          "outwardType": "REL",
+          "admittedIntoPrisonId": "WWI",
+          "releaseFromPrisonId": "WWI"
+        }
+      ],
+      "transfers": [],
+      "prisons": [
+        "WWI"
+      ]
+    },
+    {
+      "bookNumber": "78401B",
+      "bookingId": 2405001,
+      "bookingSequence": 7,
+      "entryDate": "2018-09-13T00:00:00",
+      "releaseDate": "2018-09-19T00:00:00",
+      "movementDates": [
+        {
+          "reasonInToPrison": "Administrative",
+          "dateInToPrison": "2018-09-13T00:00:00",
+          "inwardType": "ADM",
+          "reasonOutOfPrison": "Administrative Release due to Merge",
+          "dateOutOfPrison": "2018-09-19T00:00:00",
+          "outwardType": "REL"
+        }
+      ],
+      "transfers": [],
+      "prisons": []
+    },
+    {
+      "bookNumber": "55332F",
+      "bookingId": 2875329,
+      "bookingSequence": 1,
+      "entryDate": "2023-09-29T17:30:15",
+      "movementDates": [
+        {
+          "reasonInToPrison": "Imprisonment Without Option",
+          "dateInToPrison": "2023-09-29T17:30:15",
+          "inwardType": "ADM",
+          "reasonOutOfPrison": "CONDITIONAL RELEASE",
+          "dateOutOfPrison": "2024-03-05T11:11:36",
+          "outwardType": "REL",
+          "admittedIntoPrisonId": "WWI",
+          "releaseFromPrisonId": "BXI"
+        },
+        {
+          "reasonInToPrison": "Unconvicted Remand",
+          "dateInToPrison": "2024-06-12T19:08:57",
+          "inwardType": "ADM",
+          "reasonOutOfPrison": "Medical/Dental Outpatient Appointment",
+          "dateOutOfPrison": "2024-11-21T09:50:04",
+          "outwardType": "TAP",
+          "admittedIntoPrisonId": "TSI",
+          "releaseFromPrisonId": "BXI"
+        },
+        {
+          "reasonInToPrison": "Medical/Dental Outpatient Appointment",
+          "dateInToPrison": "2024-11-21T15:57:47",
+          "inwardType": "TAP",
+          "reasonOutOfPrison": "CONDITIONAL RELEASE",
+          "dateOutOfPrison": "2025-02-20T17:38:47",
+          "outwardType": "REL",
+          "admittedIntoPrisonId": "BXI",
+          "releaseFromPrisonId": "BXI"
+        },
+        {
+          "reasonInToPrison": "Unconvicted Remand",
+          "dateInToPrison": "2026-03-03T20:16:54",
+          "inwardType": "ADM",
+          "admittedIntoPrisonId": "TSI"
+        }
+      ],
+      "transfers": [
+        {
+          "dateOutOfPrison": "2023-11-01T14:47:00",
+          "dateInToPrison": "2023-11-01T15:41:02",
+          "transferReason": "Normal Transfer",
+          "fromPrisonId": "WWI",
+          "toPrisonId": "BXI"
+        },
+        {
+          "dateOutOfPrison": "2024-07-03T09:18:00",
+          "dateInToPrison": "2024-07-03T15:25:02",
+          "transferReason": "TRANSFER VIA COURT",
+          "fromPrisonId": "TSI",
+          "toPrisonId": "WWI"
+        },
+        {
+          "dateOutOfPrison": "2024-11-18T13:17:00",
+          "dateInToPrison": "2024-11-18T15:20:27",
+          "transferReason": "Normal Transfer",
+          "fromPrisonId": "WWI",
+          "toPrisonId": "BXI"
+        },
+        {
+          "dateOutOfPrison": "2026-04-07T13:48:00",
+          "dateInToPrison": "2026-04-07T17:00:08",
+          "transferReason": "Normal Transfer",
+          "fromPrisonId": "TSI",
+          "toPrisonId": "ONI"
+        }
+      ],
+      "prisons": [
+        "WWI",
+        "BXI",
+        "TSI",
+        "ONI"
+      ]
+    }
+  ]
+}
+    """.trimIndent()
+    val prisonSummary = objectMapper.readValue(prisonApiResponse, PrisonerInPrisonSummary::class.java)
+
+    val expected = aValidPrisonMovementEvents(
+      prisonNumber = prisonNumber,
+      prisonBookings = mapOf(
+        1473439L to listOf(
+          aValidAdmissionPrisonMovementEvent(
+            date = LocalDate.parse("2018-01-06"),
+            toPrisonId = "WWI",
+          ),
+          aValidReleasePrisonMovementEvent(
+            date = LocalDate.parse("2018-01-12"),
+            fromPrisonId = "WWI",
+          ),
+        ),
+        2405001L to emptyList(), // Booking ID 2405001 contains only Administrative movements so is mapped to an empty list
+        2875329L to listOf(
+          aValidAdmissionPrisonMovementEvent(
+            date = LocalDate.parse("2023-09-29"),
+            toPrisonId = "WWI",
+          ),
+          aValidReleasePrisonMovementEvent(
+            date = LocalDate.parse("2024-03-05"),
+            fromPrisonId = "BXI",
+          ),
+          aValidAdmissionPrisonMovementEvent(
+            date = LocalDate.parse("2024-06-12"),
+            toPrisonId = "TSI",
+          ),
+          aValidReleasePrisonMovementEvent(
+            date = LocalDate.parse("2025-02-20"),
+            fromPrisonId = "BXI",
+          ),
+          aValidAdmissionPrisonMovementEvent(
+            date = LocalDate.parse("2026-03-03"),
+            toPrisonId = "TSI",
+          ),
+          aValidTransferPrisonMovementEvent(
+            date = LocalDate.parse("2023-11-01"),
+            fromPrisonId = "WWI",
+            toPrisonId = "BXI",
+          ),
+          aValidTransferPrisonMovementEvent(
+            date = LocalDate.parse("2024-07-03"),
+            fromPrisonId = "TSI",
+            toPrisonId = "WWI",
+          ),
+          aValidTransferPrisonMovementEvent(
+            date = LocalDate.parse("2024-11-18"),
+            fromPrisonId = "WWI",
+            toPrisonId = "BXI",
+          ),
+          aValidTransferPrisonMovementEvent(
+            date = LocalDate.parse("2026-04-07"),
+            fromPrisonId = "TSI",
+            toPrisonId = "ONI",
+          ),
+        ),
       ),
     )
 


### PR DESCRIPTION
PR to filter out / skip "administrative" prisoner movement events (from prison-api) when producing the timeline.

Administrative events look as follows, and don't have a "from" or "to" prisonId (in the case of merges - other admin event types might be different). Not having a "from" or "to" prison causes our code to NPE because we try to map those fields into non-nullable fields.

```
                {
                    "reasonInToPrison": "Administrative",
                    "dateInToPrison": "2018-09-13T00:00:00",
                    "inwardType": "ADM",
                    "reasonOutOfPrison": "Administrative Release due to Merge",
                    "dateOutOfPrison": "2018-09-19T00:00:00",
                    "outwardType": "REL"
                }
```