### PR TITLE
RR-2532 - Refactor how GoalEntity has it's modified timestamp updated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa
 
 import mu.KotlinLogging
+import org.springframework.data.auditing.AuditingHandler
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanNotFoundException
@@ -27,6 +28,7 @@ class JpaGoalPersistenceAdapter(
   private val goalRepository: GoalRepository,
   private val actionPlanRepository: ActionPlanRepository,
   private val goalMapper: GoalEntityMapper,
+  private val auditingHandler: AuditingHandler,
 ) : GoalPersistenceAdapter {
 
   @Transactional
@@ -75,6 +77,7 @@ class JpaGoalPersistenceAdapter(
     val goalEntity = getGoalEntityByPrisonNumberAndGoalReference(prisonNumber, updatedGoalDto.reference)
     return if (goalEntity != null) {
       goalMapper.updateEntityFromDto(goalEntity, updatedGoalDto)
+      auditingHandler.markModified(goalEntity) // force the Goal's JPA managed fields to update
       val persistedEntity = goalRepository.saveAndFlush(goalEntity)
       goalMapper.fromEntityToDomain(persistedEntity)
     } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/GoalEntity.kt
@@ -79,10 +79,6 @@ data class GoalEntity(
   @LastModifiedBy
   var updatedBy: String? = null
 
-  fun childEntityUpdated() {
-    updatedAt = Instant.now()
-  }
-
   fun addChildren(newChildren: List<StepEntity>) {
     newChildren.forEach {
       it.associateWithParent(this)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/StepEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/StepEntity.kt
@@ -10,9 +10,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
-import jakarta.persistence.PrePersist
-import jakarta.persistence.PreRemove
-import jakarta.persistence.PreUpdate
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
@@ -66,13 +63,6 @@ data class StepEntity(
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "goal_id")
   var parent: GoalEntity? = null
-
-  @PrePersist
-  @PreUpdate
-  @PreRemove
-  fun onChange() {
-    parent?.childEntityUpdated()
-  }
 
   fun associateWithParent(parent: GoalEntity) {
     this.parent = parent

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/JpaGoalPersistenceAdapterTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
+import org.springframework.data.auditing.AuditingHandler
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidGoal
@@ -46,6 +47,9 @@ class JpaGoalPersistenceAdapterTest {
 
   @Mock
   private lateinit var goalMapper: GoalEntityMapper
+
+  @Mock
+  private lateinit var auditingHandler: AuditingHandler
 
   @Nested
   inner class CreateGoals {
@@ -213,6 +217,7 @@ class JpaGoalPersistenceAdapterTest {
       verify(goalRepository).saveAndFlush(goalEntity)
       verify(goalMapper).updateEntityFromDto(goalEntity, goalWithProposedUpdates)
       verify(goalMapper).fromEntityToDomain(persistedGoalEntity)
+      verify(auditingHandler).markModified(goalEntity)
     }
 
     @Test
@@ -234,6 +239,7 @@ class JpaGoalPersistenceAdapterTest {
       assertThat(actual).isNull()
       verify(actionPlanRepository).findByPrisonNumber(prisonNumber)
       verifyNoInteractions(goalMapper)
+      verifyNoMoreInteractions(auditingHandler)
     }
 
     @Test
@@ -253,6 +259,7 @@ class JpaGoalPersistenceAdapterTest {
       assertThat(actual).isNull()
       verify(actionPlanRepository).findByPrisonNumber(prisonNumber)
       verifyNoInteractions(goalMapper)
+      verifyNoMoreInteractions(auditingHandler)
     }
   }
 


### PR DESCRIPTION
PR to change how the `GoalEntity` gets it's updated_at field updated.

Under normal circumstances, where JPA has updated the `GoalEntity` (and the entity is therefore dirty), fields like `updated_at` will automatically get updated by virtue of the hibernate lifecycle annotation on the field (eg: `@UpdateTimestamp`)

There are scenarios though where the child entity `StepEntity` is updated. When the `StepEntity` is persisted by JPA we also need the parent `GoalEntity` to have it's `updated_at` field is updated. This is because even though they are all separate entities, as far as the business is concerned they are all part of the Goal, and we need to track when the Goal was updated.

Until now this was done via a method on the `GoalEntity` that updates the `updated_at` field with `Instant.now()`, and that method was called as part of the JPA lifecycle methods of the `StepEntity` being updated
```
  fun childEntityUpdated() {
    updatedAt = Instant.now()
  }
```

We are moving to use a `Clock` instance in all calls to `.now()` ... and injecting a `Clock` bean into an entity class is not possible. So we have to use a different approach to update this entity.

This approach that this PR implements is actually a much better solution - not sure why we didnt do it this way first time! 🤣 

This PR injects the spring `AuditingHandler` into the persistence adapter, and then uses that to mark the `GoalEntity` as dirty (instead of calling the `childEntityUpdated()` method). The `childEntityUpdated()` method is deleted.
This all works by virtue of marking the entity as dirty. JPA will commit the entity because it is dirty. And as part of committing it, it will update the `updated_at` field via the `@UpdateTimestamp` annotation 👍 
