### PR TITLE
RR-2532 - Use spring annotations on entities for date auditing to allow AuditingHandler to work

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/GoalEntity.kt
@@ -12,11 +12,11 @@ import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.time.LocalDate
@@ -64,7 +64,7 @@ data class GoalEntity(
   var id: UUID? = null
 
   @Column(updatable = false)
-  @CreationTimestamp
+  @CreatedDate
   var createdAt: Instant? = null
 
   @Column(updatable = false)
@@ -72,7 +72,7 @@ data class GoalEntity(
   var createdBy: String? = null
 
   @Column
-  @UpdateTimestamp
+  @LastModifiedDate
   var updatedAt: Instant? = null
 
   @Column

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/StepEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/actionplan/StepEntity.kt
@@ -12,11 +12,11 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.util.UUID
@@ -45,7 +45,7 @@ data class StepEntity(
   var id: UUID? = null
 
   @Column(updatable = false)
-  @CreationTimestamp
+  @CreatedDate
   var createdAt: Instant? = null
 
   @Column(updatable = false)
@@ -53,7 +53,7 @@ data class StepEntity(
   var createdBy: String? = null
 
   @Column
-  @UpdateTimestamp
+  @LastModifiedDate
   var updatedAt: Instant? = null
 
   @Column

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionEntity.kt
@@ -11,11 +11,11 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.time.LocalDate
@@ -80,7 +80,7 @@ data class InductionEntity(
   var id: UUID? = null
 
   @Column(updatable = false)
-  @CreationTimestamp
+  @CreatedDate
   var createdAt: Instant? = null
 
   @Column(updatable = false)
@@ -88,7 +88,7 @@ data class InductionEntity(
   var createdBy: String? = null
 
   @Column
-  @UpdateTimestamp
+  @LastModifiedDate
   var updatedAt: Instant? = null
 
   @Column


### PR DESCRIPTION
PR to fix a problem with the recent addition of the use of spring's `AuditingHandler` to mark entities as dirty.
Through testing I found it only works if the annotations on the entity are the spring ones.
This PR changes the creation/updated date annotations on InductionEntity, GoalEntity and StepEntity to be the spring ones. Those classes were already using the spring annotations for created/updated by (ie. the user), but the hibernate ones for the dates.
It looks like for it to work properly/in all cases you need to use the spring annotations for everything, which we were going to do anyway.

I have tested this locally by using one of our existing integration tests, adding a couple of breakpoints, and (visually) asserting the timestamp has changed 👍 It consistently didnt work before the annotation change. It now consistently works 👍 

It's not easy at the moment to write a reliable test for this though. The test I mentioned above is a suitable test, but it only proves the change when I run it in debug in the IDE with breakpoints that effectively add time between creation and update.
When the same test runs in CI the results will be variable due to the fact that the time between entity creation and update is negligible (the precision on the timestamp in the DB is not granular enough)

In a subsequent PR, where we replace all of the hibernate date audit annotations with the spring ones, I plan to also introduce a "ticking" clock for the integration tests, where each call to the clock to get a timestamp results in a millisecond tick. Therefore every date will always be different (sequential), no matter how fast the tests run. At that point I can update the test above to reliably assert the date has changed.