### PR TITLE
RR-2417 - Refactor integration tests to use custom AssertJ assertions

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AssessmentEventProcessTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AssessmentEventProcessTest.kt
@@ -15,7 +15,9 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch.aValidPrisoner
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.TimelineEventType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.timeline.assertThat
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import java.time.LocalDate
 
@@ -63,22 +65,23 @@ class AssessmentEventProcessTest : IntegrationTestBase() {
     // Verify record persisted in database
     await untilAsserted {
       val events = educationAssessmentEventRepository.findByPrisonNumber(prisonNumber)
-      assertThat(events).hasSize(1)
-      with(events[0]) {
-        assertThat(prisonNumber).isEqualTo("G0378GI")
-        assertThat(status).isEqualTo(EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE)
-        assertThat(statusChangeDate).isEqualTo(statusChangeDate)
-        assertThat(source).isEqualTo("CURIOUS")
-        assertThat(detailUrl).isEqualTo("https://example.com/sequation-virtual-campus2-api/learnerAssessments/v2/$prisonNumber")
-        assertThat(createdAtPrison).isEqualTo("BXI")
-        assertThat(updatedAtPrison).isEqualTo("BXI")
-      }
+      assertThat(events)
+        .hasNumberOfEvents(1)
+        .event(1) {
+          it.hasPrisonNumber("G0378GI")
+            .hasStatus(EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE)
+            .hasStatusChangeDate(statusChangeDate)
+            .hasSource("CURIOUS")
+            .hasDetailUrl("https://example.com/sequation-virtual-campus2-api/learnerAssessments/v2/$prisonNumber")
+            .wasCreatedAtPrison("BXI")
+            .wasUpdatedAtPrison("BXI")
+        }
     }
 
     // Verify timeline event created
     await untilAsserted {
       val timeline = getTimeline(prisonNumber)
-      assertThat(timeline.events).anyMatch { it.eventType == TimelineEventType.EDUCATION_ASSESSMENT_EVENT_CREATED }
+      assertThat(timeline).anyEvent { it.hasEventType(TimelineEventType.EDUCATION_ASSESSMENT_EVENT_CREATED) }
     }
 
     // Verify App Insights telemetry event sent
@@ -145,11 +148,12 @@ class AssessmentEventProcessTest : IntegrationTestBase() {
     // Then
     await untilAsserted {
       val events = educationAssessmentEventRepository.findByPrisonNumber(prisonNumber)
-      assertThat(events).hasSize(2)
-      assertThat(events.map { it.statusChangeDate }).containsExactlyInAnyOrder(
-        LocalDate.of(2026, 3, 10),
-        LocalDate.of(2026, 3, 15),
-      )
+      assertThat(events)
+        .hasNumberOfEvents(2)
+        .hasStatusChangeDatesInAnyOrder(
+          LocalDate.of(2026, 3, 10),
+          LocalDate.of(2026, 3, 15),
+        )
     }
   }
 
@@ -186,22 +190,23 @@ class AssessmentEventProcessTest : IntegrationTestBase() {
     // Verify record persisted in database
     await untilAsserted {
       val events = educationAssessmentEventRepository.findByPrisonNumber(prisonNumber)
-      assertThat(events).hasSize(1)
-      with(events[0]) {
-        assertThat(prisonNumber).isEqualTo("G0378GI")
-        assertThat(status).isEqualTo(EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE)
-        assertThat(statusChangeDate).isEqualTo(statusChangeDate)
-        assertThat(source).isEqualTo("CURIOUS")
-        assertThat(detailUrl).isEqualTo("https://example.com/sequation-virtual-campus2-api/learnerAssessments/v2/$prisonNumber")
-        assertThat(createdAtPrison).isEqualTo("N/A")
-        assertThat(updatedAtPrison).isEqualTo("N/A")
-      }
+      assertThat(events)
+        .hasNumberOfEvents(1)
+        .event(1) {
+          it.hasPrisonNumber("G0378GI")
+            .hasStatus(EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE)
+            .hasStatusChangeDate(statusChangeDate)
+            .hasSource("CURIOUS")
+            .hasDetailUrl("https://example.com/sequation-virtual-campus2-api/learnerAssessments/v2/$prisonNumber")
+            .wasCreatedAtPrison("N/A")
+            .wasUpdatedAtPrison("N/A")
+        }
     }
 
     // Verify timeline event created
     await untilAsserted {
       val timeline = getTimeline(prisonNumber)
-      assertThat(timeline.events).anyMatch { it.eventType == TimelineEventType.EDUCATION_ASSESSMENT_EVENT_CREATED }
+      assertThat(timeline).anyEvent { it.hasEventType(TimelineEventType.EDUCATION_ASSESSMENT_EVENT_CREATED) }
     }
 
     // Verify App Insights telemetry event sent

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerExemptDueToMergeEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerExemptDueToMergeEventTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.parallel.Isolated
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionScheduleStatus.SCHEDULED
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_MERGED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReviewScheduleStatus
@@ -58,9 +59,8 @@ class PrisonerExemptDueToMergeEventTest : IntegrationTestBase() {
     val rootNode = objectMapper.readTree(sqsMessage.Message)
     val newNomisNumber = rootNode["additionalInformation"]["nomsNumber"].asText()
 
-    assertThat(
-      inductionScheduleRepository.findByPrisonNumber(newNomisNumber)!!.scheduleStatus == SCHEDULED,
-    )
+    assertThat(inductionScheduleRepository.findByPrisonNumber(newNomisNumber))
+      .hasScheduleStatus(SCHEDULED)
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionScheduleStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.ADMISSION
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RECEIVED_INTO_PRISON
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.events.assertThat
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus.COMPLETED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS
@@ -108,8 +109,10 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
 
       // test that outbound event is also created:
       val inductionScheduleEvent = inductionScheduleEventQueue.receiveEvent(QueueType.INDUCTION)
-      assertThat(inductionScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
-      assertThat(inductionScheduleEvent.detailUrl).isEqualTo("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
+      assertThat(inductionScheduleEvent)
+        .hasDetailUrl("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
+        .hasNumberOfPersonReferenceIdentifiers(1)
+        .personReferenceIdentifier(1) { it.hasValue(prisonNumber) }
     }
   }
 
@@ -182,8 +185,10 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
 
       // test that outbound event is also created:
       val reviewScheduleEvent = inductionScheduleEventQueue.receiveEvent(QueueType.REVIEW)
-      assertThat(reviewScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
-      assertThat(reviewScheduleEvent.detailUrl).isEqualTo("http://localhost:8080/reviews/$prisonNumber/review-schedule")
+      assertThat(reviewScheduleEvent)
+        .hasDetailUrl("http://localhost:8080/reviews/$prisonNumber/review-schedule")
+        .hasNumberOfPersonReferenceIdentifiers(1)
+        .personReferenceIdentifier(1) { it.hasValue(prisonNumber) }
     }
   }
 
@@ -245,40 +250,49 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
     await untilAsserted {
       val reviewSchedules = getReviewSchedules(prisonNumber)
       // Expect 3 Review Schedule versions - the original one, the exempted one, and the new one
-      assertThat(reviewSchedules).hasNumberOfReviewSchedules(3)
-      // The first in the list should be the newly created and scheduled Review Schedule - it is version 1 (because it is a new Review Schedule)
-      assertThat(reviewSchedules.reviewSchedules[0])
-        .hasStatus(ReviewScheduleStatus.SCHEDULED)
-        .hasCalculationRule(ReviewScheduleCalculationRule.PRISONER_READMISSION)
-        .wasCreatedAtPrison("MDI")
-        .wasUpdatedAtPrison("MDI")
-        .isVersion(1)
-      // And it should have a different reference to the next one
-      assertThat(reviewSchedules.reviewSchedules[0].reference).isNotEqualTo(reviewSchedules.reviewSchedules[1].reference)
-      // The next one is the exempted Review Schedule - it is version 2
-      assertThat(reviewSchedules.reviewSchedules[1])
-        .hasStatus(ReviewScheduleStatus.EXEMPT_UNKNOWN)
-        .hasCalculationRule(ReviewScheduleCalculationRule.BETWEEN_6_AND_12_MONTHS_TO_SERVE)
-        .wasCreatedAtPrison("BXI")
-        .wasUpdatedAtPrison("MDI")
-        .isVersion(2)
-      // And the last in the list should be the original scheduled Review Schedule - it is version 1
-      assertThat(reviewSchedules.reviewSchedules[2])
-        .hasStatus(ReviewScheduleStatus.SCHEDULED)
-        .hasCalculationRule(ReviewScheduleCalculationRule.BETWEEN_6_AND_12_MONTHS_TO_SERVE)
-        .wasCreatedAtPrison("BXI")
-        .wasUpdatedAtPrison("BXI")
-        .isVersion(1)
-      // The originally scheduled Review Schedule and the exempted Review Schedule should have the same reference because they represent the same Review Schedule
-      assertThat(reviewSchedules.reviewSchedules[1].reference).isEqualTo(reviewSchedules.reviewSchedules[2].reference)
+      val newReviewScheduleReference = reviewSchedules.reviewSchedules[0].reference
+      val originalReviewScheduleReference = reviewSchedules.reviewSchedules[1].reference
+      assertThat(reviewSchedules)
+        .hasNumberOfReviewSchedules(3)
+        // The first in the list should be the newly created and scheduled Review Schedule - it is version 1 (because it is a new Review Schedule)
+        .reviewScheduleAtIndex(1) {
+          it.hasStatus(ReviewScheduleStatus.SCHEDULED)
+            .hasCalculationRule(ReviewScheduleCalculationRule.PRISONER_READMISSION)
+            .wasCreatedAtPrison("MDI")
+            .wasUpdatedAtPrison("MDI")
+            .isVersion(1)
+            .hasReference(newReviewScheduleReference)
+        }
+        // The next one is the exempted Review Schedule - it is version 2
+        .reviewScheduleAtIndex(2) {
+          it.hasStatus(ReviewScheduleStatus.EXEMPT_UNKNOWN)
+            .hasCalculationRule(ReviewScheduleCalculationRule.BETWEEN_6_AND_12_MONTHS_TO_SERVE)
+            .wasCreatedAtPrison("BXI")
+            .wasUpdatedAtPrison("MDI")
+            .isVersion(2)
+            .hasReference(originalReviewScheduleReference)
+        }
+        // And the last in the list should be the original scheduled Review Schedule - it is version 1
+        // The originally scheduled Review Schedule and the exempted Review Schedule should have the same reference because they represent the same Review Schedule
+        .reviewScheduleAtIndex(3) {
+          it.hasStatus(ReviewScheduleStatus.SCHEDULED)
+            .hasCalculationRule(ReviewScheduleCalculationRule.BETWEEN_6_AND_12_MONTHS_TO_SERVE)
+            .wasCreatedAtPrison("BXI")
+            .wasUpdatedAtPrison("BXI")
+            .isVersion(1)
+            .hasReference(originalReviewScheduleReference)
+        }
+      assertThat(newReviewScheduleReference).isNotEqualTo(originalReviewScheduleReference)
 
       // test that outbound events are also created (there would have been 3 in total, but we cleared the queue after the first one in the given block above). The 2 new ones are the ones we are really interested in though)
       val reviewScheduleEvents = inductionScheduleEventQueue.receiveEventsOnQueue(QueueType.REVIEW)
-      assertThat(reviewScheduleEvents).hasSize(2)
-      assertThat(reviewScheduleEvents).allSatisfy {
-        assertThat(it.personReference.identifiers[0].value).isEqualTo(prisonNumber)
-        assertThat(it.detailUrl).isEqualTo("http://localhost:8080/reviews/$prisonNumber/review-schedule")
-      }
+      assertThat(reviewScheduleEvents)
+        .hasNumberOfEvents(2)
+        .allEvents {
+          it.hasDetailUrl("http://localhost:8080/reviews/$prisonNumber/review-schedule")
+            .hasNumberOfPersonReferenceIdentifiers(1)
+            .personReferenceIdentifier(1) { it.hasValue(prisonNumber) }
+        }
     }
   }
 
@@ -316,7 +330,7 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
     )
 
     val inductionSchedule = getInductionSchedule(prisonNumber)
-    assertThat(inductionSchedule.scheduleCalculationRule).isEqualTo(InductionScheduleCalculationRule.EXISTING_PRISONER)
+    assertThat(inductionSchedule).wasScheduleCalculationRule(InductionScheduleCalculationRule.EXISTING_PRISONER)
 
     with(aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "MDI")) {
       createPrisonerAPIStub(prisonNumber, this)
@@ -351,12 +365,14 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
         }
 
       val inductionSchedule = getInductionSchedule(prisonNumber)
-      assertThat(inductionSchedule.scheduleCalculationRule).isEqualTo(InductionScheduleCalculationRule.NEW_PRISON_ADMISSION)
+      assertThat(inductionSchedule).wasScheduleCalculationRule(InductionScheduleCalculationRule.NEW_PRISON_ADMISSION)
 
       // test that outbound event is also created:
       val inductionScheduleEvent = inductionScheduleEventQueue.receiveEvent(QueueType.INDUCTION)
-      assertThat(inductionScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
-      assertThat(inductionScheduleEvent.detailUrl).isEqualTo("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
+      assertThat(inductionScheduleEvent)
+        .hasDetailUrl("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
+        .hasNumberOfPersonReferenceIdentifiers(1)
+        .personReferenceIdentifier(1) { it.hasValue(prisonNumber) }
     }
   }
 
@@ -439,8 +455,8 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
     reviewScheduleRepository.deleteAll()
     reviewScheduleHistoryRepository.deleteAll()
 
-    assertThat(getInductionScheduleHistory(prisonNumber).inductionSchedules).hasSize(0)
-    assertThat(getReviewSchedules(prisonNumber).reviewSchedules).hasSize(0)
+    assertThat(getInductionScheduleHistory(prisonNumber)).hasNumberOfInductionScheduleVersions(0)
+    assertThat(getReviewSchedules(prisonNumber)).hasNumberOfReviewSchedules(0)
 
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(
       prisonNumber = prisonNumber,
@@ -462,19 +478,23 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
 
     await untilAsserted {
       // assert that no induction schedules exist or were created for this prisoner, and that no outbound induction events were created
-      assertThat(getInductionScheduleHistory(prisonNumber).inductionSchedules).hasSize(0)
+      assertThat(getInductionScheduleHistory(prisonNumber)).hasNumberOfInductionScheduleVersions(0)
       assertThat(inductionScheduleEventQueue.countAllMessagesOnQueue()).isEqualTo(0)
 
       // assert that there is a correctly setup ReviewSchedule
-      val reviewSchedules = getReviewSchedules(prisonNumber)
-      assertThat(reviewSchedules.reviewSchedules).hasSize(1)
-      assertThat(reviewSchedules.reviewSchedules[0].status).isEqualTo(ReviewScheduleStatus.SCHEDULED)
-      assertThat(reviewSchedules.reviewSchedules[0].calculationRule).isEqualTo(ReviewScheduleCalculationRule.PRISONER_READMISSION)
+      assertThat(getReviewSchedules(prisonNumber))
+        .hasNumberOfReviewSchedules(1)
+        .reviewScheduleAtIndex(1) {
+          it.hasStatus(ReviewScheduleStatus.SCHEDULED)
+            .hasCalculationRule(ReviewScheduleCalculationRule.PRISONER_READMISSION)
+        }
 
       // test that outbound event is also created:
       val reviewScheduleEvent = inductionScheduleEventQueue.receiveEvent(QueueType.REVIEW)
-      assertThat(reviewScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
-      assertThat(reviewScheduleEvent.detailUrl).isEqualTo("http://localhost:8080/reviews/$prisonNumber/review-schedule")
+      assertThat(reviewScheduleEvent)
+        .hasDetailUrl("http://localhost:8080/reviews/$prisonNumber/review-schedule")
+        .hasNumberOfPersonReferenceIdentifiers(1)
+        .personReferenceIdentifier(1) { it.hasValue(prisonNumber) }
     }
   }
 
@@ -509,8 +529,8 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
     reviewScheduleRepository.deleteAll()
     reviewScheduleHistoryRepository.deleteAll()
 
-    assertThat(getInductionScheduleHistory(prisonNumber).inductionSchedules).hasSize(1)
-    assertThat(getReviewSchedules(prisonNumber).reviewSchedules).hasSize(0)
+    assertThat(getInductionScheduleHistory(prisonNumber)).hasNumberOfInductionScheduleVersions(1)
+    assertThat(getReviewSchedules(prisonNumber)).hasNumberOfReviewSchedules(0)
 
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(
       prisonNumber = prisonNumber,
@@ -543,19 +563,25 @@ class PrisonerReceivedDueToAdmissionEventTest : IntegrationTestBase() {
 
       // test that outbound event is also created:
       val inductionScheduleEvent = inductionScheduleEventQueue.receiveEvent(QueueType.INDUCTION)
-      assertThat(inductionScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
-      assertThat(inductionScheduleEvent.detailUrl).isEqualTo("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
+      assertThat(inductionScheduleEvent)
+        .hasDetailUrl("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
+        .hasNumberOfPersonReferenceIdentifiers(1)
+        .personReferenceIdentifier(1) { it.hasValue(prisonNumber) }
 
       // assert that there is a correctly setup ReviewSchedule
-      val reviewSchedules = getReviewSchedules(prisonNumber)
-      assertThat(reviewSchedules.reviewSchedules).hasSize(1)
-      assertThat(reviewSchedules.reviewSchedules[0].status).isEqualTo(ReviewScheduleStatus.SCHEDULED)
-      assertThat(reviewSchedules.reviewSchedules[0].calculationRule).isEqualTo(ReviewScheduleCalculationRule.PRISONER_READMISSION)
+      assertThat(getReviewSchedules(prisonNumber))
+        .hasNumberOfReviewSchedules(1)
+        .reviewScheduleAtIndex(1) {
+          it.hasStatus(ReviewScheduleStatus.SCHEDULED)
+            .hasCalculationRule(ReviewScheduleCalculationRule.PRISONER_READMISSION)
+        }
 
       // test that outbound event is also created:
       val reviewScheduleEvent = inductionScheduleEventQueue.receiveEvent(QueueType.REVIEW)
-      assertThat(reviewScheduleEvent.personReference.identifiers[0].value).isEqualTo(prisonNumber)
-      assertThat(reviewScheduleEvent.detailUrl).isEqualTo("http://localhost:8080/reviews/$prisonNumber/review-schedule")
+      assertThat(reviewScheduleEvent)
+        .hasDetailUrl("http://localhost:8080/reviews/$prisonNumber/review-schedule")
+        .hasNumberOfPersonReferenceIdentifiers(1)
+        .personReferenceIdentifier(1) { it.hasValue(prisonNumber) }
     }
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/educationassessment/EducationAssessmentEventEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/educationassessment/EducationAssessmentEventEntityAssert.kt
@@ -1,0 +1,135 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment
+
+import org.assertj.core.api.AbstractObjectAssert
+import java.time.LocalDate
+import java.util.function.Consumer
+
+fun assertThat(actual: EducationAssessmentEventEntity?) = EducationAssessmentEventEntityAssert(actual)
+fun assertThat(actual: List<EducationAssessmentEventEntity>?) = EducationAssessmentEventEntitiesAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [EducationAssessmentEventEntity].
+ */
+class EducationAssessmentEventEntityAssert(actual: EducationAssessmentEventEntity?) :
+  AbstractObjectAssert<EducationAssessmentEventEntityAssert, EducationAssessmentEventEntity?>(
+    actual,
+    EducationAssessmentEventEntityAssert::class.java,
+  ) {
+
+  fun hasPrisonNumber(expected: String): EducationAssessmentEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (prisonNumber != expected) {
+        failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  fun hasStatus(expected: EducationAssessmentEventStatus): EducationAssessmentEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (status != expected) {
+        failWithMessage("Expected status to be $expected, but was $status")
+      }
+    }
+    return this
+  }
+
+  fun hasStatusChangeDate(expected: LocalDate): EducationAssessmentEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (statusChangeDate != expected) {
+        failWithMessage("Expected statusChangeDate to be $expected, but was $statusChangeDate")
+      }
+    }
+    return this
+  }
+
+  fun hasSource(expected: String): EducationAssessmentEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (source != expected) {
+        failWithMessage("Expected source to be $expected, but was $source")
+      }
+    }
+    return this
+  }
+
+  fun hasDetailUrl(expected: String): EducationAssessmentEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (detailUrl != expected) {
+        failWithMessage("Expected detailUrl to be $expected, but was $detailUrl")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): EducationAssessmentEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): EducationAssessmentEventEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+}
+
+/**
+ * AssertJ custom assertion for a list of [EducationAssessmentEventEntity]s.
+ */
+class EducationAssessmentEventEntitiesAssert(actual: List<EducationAssessmentEventEntity>?) :
+  AbstractObjectAssert<EducationAssessmentEventEntitiesAssert, List<EducationAssessmentEventEntity>?>(
+    actual,
+    EducationAssessmentEventEntitiesAssert::class.java,
+  ) {
+
+  fun hasNumberOfEvents(expected: Int): EducationAssessmentEventEntitiesAssert {
+    isNotNull
+    with(actual!!) {
+      if (size != expected) {
+        failWithMessage("Expected $expected events, but was $size")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [EducationAssessmentEventEntity]. Takes a lambda as the method
+   * argument to call assertion methods provided by [EducationAssessmentEventEntityAssert].
+   * Returns this [EducationAssessmentEventEntitiesAssert] to allow further chained assertions on the parent list.
+   *
+   * The `eventNumber` parameter is not zero indexed to make for better readability in tests. IE. the first event
+   * should be referenced as `.event(1) { .... }`
+   */
+  fun event(eventNumber: Int, consumer: Consumer<EducationAssessmentEventEntityAssert>): EducationAssessmentEventEntitiesAssert {
+    isNotNull
+    with(actual!!) {
+      consumer.accept(assertThat(this[eventNumber - 1]))
+    }
+    return this
+  }
+
+  fun hasStatusChangeDatesInAnyOrder(vararg expected: LocalDate): EducationAssessmentEventEntitiesAssert {
+    isNotNull
+    with(actual!!) {
+      val actualDates = map { it.statusChangeDate }
+      if (actualDates.sorted() != expected.toList().sorted()) {
+        failWithMessage("Expected statusChangeDates to contain ${expected.toList()} in any order, but was $actualDates")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionScheduleEntityAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/InductionScheduleEntityAssert.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction
+
+import org.assertj.core.api.AbstractObjectAssert
+
+fun assertThat(actual: InductionScheduleEntity?) = InductionScheduleEntityAssert(actual)
+
+/**
+ * AssertJ custom assertion for [InductionScheduleEntity]
+ */
+class InductionScheduleEntityAssert(actual: InductionScheduleEntity?) :
+  AbstractObjectAssert<InductionScheduleEntityAssert, InductionScheduleEntity?>(
+    actual,
+    InductionScheduleEntityAssert::class.java,
+  ) {
+
+  fun hasScheduleStatus(expected: InductionScheduleStatus): InductionScheduleEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (scheduleStatus != expected) {
+        failWithMessage("Expected scheduleStatus to be $expected, but was $scheduleStatus")
+      }
+    }
+    return this
+  }
+
+  fun hasPrisonNumber(expected: String): InductionScheduleEntityAssert {
+    isNotNull
+    with(actual!!) {
+      if (prisonNumber != expected) {
+        failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/review/ActionPlanReviewSchedulesResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/review/ActionPlanReviewSchedulesResponseAssert.kt
@@ -44,6 +44,22 @@ class ActionPlanReviewSchedulesResponseAssert(actual: ActionPlanReviewSchedulesR
   }
 
   /**
+   * Allows for assertion chaining into the specified child [ScheduledActionPlanReviewResponse] by its position in the list.
+   * Takes a lambda as the method argument to call assertion methods provided by [ScheduledActionPlanReviewResponseAssert].
+   * Returns this [ActionPlanReviewSchedulesResponseAssert] to allow further chained assertions on the parent [ActionPlanReviewSchedulesResponse]
+   *
+   * The `index` parameter is not zero indexed to make for better readability in tests. IE. the first review schedule
+   * should be referenced as `.reviewScheduleAtIndex(1) { .... }`
+   */
+  fun reviewScheduleAtIndex(index: Int, consumer: Consumer<ScheduledActionPlanReviewResponseAssert>): ActionPlanReviewSchedulesResponseAssert {
+    isNotNull
+    with(actual!!) {
+      consumer.accept(assertThat(reviewSchedules[index - 1]))
+    }
+    return this
+  }
+
+  /**
    * Allows for assertion chaining into all child [ScheduledActionPlanReviewResponse]s. Takes a lambda as the method argument
    * to call assertion methods provided by [ScheduledActionPlanReviewResponseAssert].
    * Returns this [ActionPlanReviewSchedulesResponseAssert] to allow further chained assertions on the parent [ActionPlanReviewSchedulesResponse]


### PR DESCRIPTION
This improves the readability and maintainability of assertions within integration tests by introducing custom AssertJ assertion classes for entities and responses.
