### PR TITLE
RR-2532 - Update timestamp of FutureWorkInterestsEntity and PreviousWorkExperiencesEntity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
@@ -12,6 +12,9 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreRemove
+import jakarta.persistence.PreUpdate
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
 import org.hibernate.annotations.UuidGenerator
@@ -62,6 +65,10 @@ data class FutureWorkInterestsEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null
+
+  fun childEntityUpdated() {
+    this.updatedAt = Instant.now()
+  }
 
   fun addChildren(newChildren: List<WorkInterestEntity>) {
     newChildren.forEach {
@@ -124,6 +131,13 @@ data class WorkInterestEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null
+
+  @PrePersist
+  @PreUpdate
+  @PreRemove
+  fun onChange() {
+    parent?.childEntityUpdated()
+  }
 
   fun associateWithParent(parent: FutureWorkInterestsEntity) {
     this.parent = parent

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
@@ -12,6 +12,9 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreRemove
+import jakarta.persistence.PreUpdate
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
 import org.hibernate.annotations.UuidGenerator
@@ -71,6 +74,10 @@ data class PreviousWorkExperiencesEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null
+
+  fun childEntityUpdated() {
+    this.updatedAt = Instant.now()
+  }
 
   fun addChildren(newChildren: List<WorkExperienceEntity>) {
     newChildren.forEach {
@@ -136,6 +143,13 @@ data class WorkExperienceEntity(
   @Column
   @LastModifiedBy
   var updatedBy: String? = null
+
+  @PrePersist
+  @PreUpdate
+  @PreRemove
+  fun onChange() {
+    parent?.childEntityUpdated()
+  }
 
   fun associateWithParent(parent: PreviousWorkExperiencesEntity) {
     this.parent = parent


### PR DESCRIPTION
PR to update timestamp of FutureWorkInterestsEntity and PreviousWorkExperiencesEntityorkExperiencesEntity with Instant.now() when child is updated

This is a temporary change, reverting this process back to what it originally did with `Instant.now()` so that we can do a production release for some other changes.
Ultimately we are trying to remove uses of `.now()` within entity classes, so we will need to look at this again.
