### PR TITLE
RR-2532 - Update version of FutureWorkInterestsEntity and PreviousWorkExperiencesEntity when child is updated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/FutureWorkInterestsEntity.kt
@@ -22,6 +22,7 @@ import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.annotation.Version
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.util.UUID
@@ -66,9 +67,9 @@ data class FutureWorkInterestsEntity(
   @LastModifiedBy
   var updatedBy: String? = null
 
-  fun childEntityUpdated() {
-    this.updatedAt = Instant.now()
-  }
+  @Column
+  @Version
+  var version: Long = 0
 
   fun addChildren(newChildren: List<WorkInterestEntity>) {
     newChildren.forEach {
@@ -135,8 +136,8 @@ data class WorkInterestEntity(
   @PrePersist
   @PreUpdate
   @PreRemove
-  fun onChange() {
-    parent?.childEntityUpdated()
+  fun onChangeTouchParentToUpdateItsTimestamp() {
+    parent?.run { ++version } // Increment the parent's version field which will dirty the entity, forcing JPA to update the updated_at timestamp of the parent entity
   }
 
   fun associateWithParent(parent: FutureWorkInterestsEntity) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/entity/induction/PreviousWorkExperiencesEntity.kt
@@ -22,6 +22,7 @@ import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.annotation.Version
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.util.UUID
@@ -75,9 +76,9 @@ data class PreviousWorkExperiencesEntity(
   @LastModifiedBy
   var updatedBy: String? = null
 
-  fun childEntityUpdated() {
-    this.updatedAt = Instant.now()
-  }
+  @Column
+  @Version
+  var version: Long = 0
 
   fun addChildren(newChildren: List<WorkExperienceEntity>) {
     newChildren.forEach {
@@ -147,8 +148,8 @@ data class WorkExperienceEntity(
   @PrePersist
   @PreUpdate
   @PreRemove
-  fun onChange() {
-    parent?.childEntityUpdated()
+  fun onChangeTouchParentToUpdateItsTimestamp() {
+    parent?.run { ++version } // Increment the parent's version field which will dirty the entity, forcing JPA to update the updated_at timestamp of the parent entity
   }
 
   fun associateWithParent(parent: PreviousWorkExperiencesEntity) {

--- a/src/main/resources/db/migration/common/V2026.05.28.0001__add_version_columns.sql
+++ b/src/main/resources/db/migration/common/V2026.05.28.0001__add_version_columns.sql
@@ -1,0 +1,15 @@
+--- Add version columns to future_work_interests table
+
+ALTER TABLE future_work_interests
+    ADD COLUMN version INTEGER;
+UPDATE future_work_interests
+    SET version = 1;
+ALTER TABLE future_work_interests
+    ALTER COLUMN version SET NOT NULL;
+
+ALTER TABLE previous_work_experiences
+    ADD COLUMN version INTEGER;
+UPDATE previous_work_experiences
+SET version = 1;
+ALTER TABLE previous_work_experiences
+    ALTER COLUMN version SET NOT NULL;


### PR DESCRIPTION
PR to refactor how `FutureWorkInterestsEntity` and `PreviousWorkExperiencesEntity` get their updated_at field updated when the collection in their one-to-many relationship (ie. child entities) is updated (ie. a child is added/removed/updated)

After an awful lot of googling and experimentation, I could not find a standard JPA way of doing this. 
The problem we are trying to solve is that we have a parent entity (eg: `FutureWorkInterestsEntity`) which has a one-to-many relationship with it's child entities. This is modelled in the code as a Collection of child entity type, with the various JPA annotations to define the relationship.
When the collection or its elements are modified (ie. add new entity, remove existing entity, or update existing entity), we want the parent entity to be considered dirty so that JPA will update it's `updated_at` and `updated_by` fields via the annotations on those fields.

I could not find a standard JPA way to get this working.

Clearly we've been here before, because the child entities have a pre-persist hook (`@PrePersist`, `@PreUpdate`, `@PreRemove` annotations) that call a method on the parent which updates the `updated_at` field with `Instant.now()`

This works, but the objective of this whole story is to use a `Clock` in all calls to `.now()`. We cannot inject the `Clock` into entity classes, so the current approach needs rethinking/refactoring.

Because I could not find a standard JPA way of doing this, I think we will have to stay with the pre-persist hook on the child entities. 
But instead of it updating the `updated_at` field of the parent (which uses `.now()`), I've added a standard `version` field (which arguably we should have had before? 🤷‍♂️ ), and the pre-persist hook now increments the version instead.
This has the desired effect. Because the parent has been modified (via it's `version` field), JPA considers it dirty, and will persist it, including updating the updated_at/by fields via the annotations. And because these are the Spring annotations rather than the hibernate ones, the timestamp set is generated by the `DateTimeProvider` bean, which in turn uses the `Clock`

Phew! 😁 
