### PR TITLE
RR-2532 - Fix how list of previous trainings in PreviousTrainingEntity is updated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapper.kt
@@ -37,7 +37,12 @@ class PreviousTrainingEntityMapper {
   }
 
   fun updateExistingEntityFromDto(entity: PreviousTrainingEntity, dto: UpdatePreviousTrainingDto) = with(entity) {
-    trainingTypes = dto.trainingTypes.map { toTrainingType(it) }
+    val updatedTrainingTypes = dto.trainingTypes.map { toTrainingType(it) }
+    if (trainingTypes.toSet() != updatedTrainingTypes.toSet()) {
+      // Only update (replace) the training types list instance on the entity if there are any changes to be made
+      // (otherwise JPA sees the replaced list instance as a change to the entity even though there were no changes to it, so marks it as Dirty which in turn updates the updated_at fields)
+      trainingTypes = updatedTrainingTypes
+    }
     trainingTypeOther = dto.trainingTypeOther
     updatedAtPrison = dto.prisonId
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/mapper/induction/PreviousTrainingEntityMapperTest.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.induction
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidPreviousTraining
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.aValidCreatePreviousTrainingDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.aValidUpdatePreviousTrainingDto
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPreviousTrainingEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.aValidPreviousTrainingEntityWithJpaFieldsPopulated
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.assertThat
@@ -58,5 +60,58 @@ class PreviousTrainingEntityMapperTest {
 
     // Then
     assertThat(actual).isEqualTo(expectedPreviousTraining)
+  }
+
+  @Nested
+  inner class UpdateExistingEntityFromDto {
+    @Test
+    fun `should update existing entity from DTO given a change to the training types`() {
+      // Given
+      val existingTrainingTypes = mutableListOf(TrainingTypeEntity.OTHER, TrainingTypeEntity.TRADE_COURSE)
+      val entity = aValidPreviousTrainingEntity(
+        trainingTypes = existingTrainingTypes,
+        trainingTypeOther = "Kotlin course",
+        updatedAtPrison = "BXI",
+      )
+
+      val updateDto = aValidUpdatePreviousTrainingDto(
+        trainingTypes = mutableListOf(TrainingTypeDomain.OTHER),
+        trainingTypeOther = "Kotlin course",
+        prisonId = "MDI",
+      )
+
+      val expectedTrainingTypes = listOf(TrainingTypeEntity.OTHER)
+
+      // When
+      mapper.updateExistingEntityFromDto(entity, updateDto)
+
+      // Then
+      assertThat(entity.trainingTypes).isEqualTo(expectedTrainingTypes)
+      assertThat(entity.trainingTypes).isNotSameAs(existingTrainingTypes) // assert that the training types on the entity have been replaced with a new List instance
+    }
+
+    @Test
+    fun `should not update existing entity from DTO given no change to the training types`() {
+      // Given
+      val existingTrainingTypes = mutableListOf(TrainingTypeEntity.OTHER, TrainingTypeEntity.TRADE_COURSE)
+      val entity = aValidPreviousTrainingEntity(
+        trainingTypes = existingTrainingTypes,
+        trainingTypeOther = "Kotlin course",
+        updatedAtPrison = "BXI",
+      )
+
+      val updateDto = aValidUpdatePreviousTrainingDto(
+        trainingTypes = mutableListOf(TrainingTypeDomain.OTHER, TrainingTypeDomain.TRADE_COURSE),
+        trainingTypeOther = "Kotlin course",
+        prisonId = "MDI",
+      )
+
+      // When
+      mapper.updateExistingEntityFromDto(entity, updateDto)
+
+      // Then
+      // assert that the training types on the entity are the same List instance that they were before - IE. the list itself has not been replaced
+      assertThat(entity.trainingTypes).isSameAs(existingTrainingTypes)
+    }
   }
 }


### PR DESCRIPTION
PR to fix how the list of previous trainings in PreviousTrainingEntity is updated

Basically, before this change, the `trainingTypes` list instance was being replaced every time, even if there were no changes to the list of training types. Because it was a new instance of the List object, JPA saw the whole entity as dirty and updated the updated_by and updated_at fields, even though there were no changes!

This PR fixes this by comparing the contents of the existing training types list and the proposed list of training types in the DTO (it compares using a set for performance reasons)