### PR TITLE
RR-2646 - Remove redundant parameters from Induction Schedule DTO creation

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
@@ -29,7 +29,7 @@ abstract class InductionScheduleDateCalculationService(
    * Known implementations at this time are those for the CIAG PEF and PES contracts, where a prisoner's initial Induction Schedule
    * is created differently under those contracts.
    */
-  abstract fun determineCreateInductionScheduleDto(prisonNumber: String, admissionDate: LocalDate, prisonId: String, newAdmission: Boolean = true, releaseDate: LocalDate? = null): CreateInductionScheduleDto
+  abstract fun determineCreateInductionScheduleDto(prisonNumber: String, admissionDate: LocalDate, prisonId: String): CreateInductionScheduleDto
 
   fun calculateAdjustedInductionDueDate(inductionSchedule: InductionSchedule): LocalDate = with(inductionSchedule) {
     if (propertiesProvider.onlyExtendDeadlinesWhenNotOverdue && hadUserAppliedExemptionWhenInductionAlreadyOverdue()) {

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
@@ -32,8 +32,6 @@ class InductionScheduleService(
     prisonNumber: String,
     prisonerAdmissionDate: LocalDate,
     prisonId: String,
-    newAdmission: Boolean = true,
-    releaseDate: LocalDate? = null,
   ): InductionSchedule {
     // Check for an existing Induction Schedule
     val inductionSchedule = runCatching {
@@ -48,8 +46,6 @@ class InductionScheduleService(
       prisonNumber = prisonNumber,
       admissionDate = prisonerAdmissionDate,
       prisonId = prisonId,
-      newAdmission = newAdmission,
-      releaseDate = releaseDate,
     )
     return inductionSchedulePersistenceAdapter.createInductionSchedule(createInductionScheduleDto)
       .also {
@@ -70,7 +66,6 @@ class InductionScheduleService(
     prisonNumber: String,
     prisonerAdmissionDate: LocalDate,
     prisonId: String,
-    releaseDate: LocalDate?,
     calculationRule: InductionScheduleCalculationRule? = null,
   ): InductionSchedule {
     val inductionSchedule = inductionSchedulePersistenceAdapter.getInductionSchedule(prisonNumber)
@@ -85,7 +80,6 @@ class InductionScheduleService(
         prisonNumber = prisonNumber,
         admissionDate = prisonerAdmissionDate,
         prisonId = prisonId,
-        releaseDate = releaseDate,
       )
       updateInductionSchedule(
         inductionSchedule = this,

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
@@ -26,8 +26,6 @@ class InductionScheduleDateCalculationServiceTest {
       prisonNumber: String,
       admissionDate: LocalDate,
       prisonId: String,
-      newAdmission: Boolean,
-      releaseDate: LocalDate?,
     ): CreateInductionScheduleDto {
       TODO("Not implemented here")
     }

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleServiceTest.kt
@@ -9,7 +9,6 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -155,7 +154,7 @@ class InductionScheduleServiceTest {
       given(inductionSchedulePersistenceAdapter.getInductionSchedule(any())).willReturn(null)
 
       val createInductionScheduleDto = aValidCreateInductionScheduleDto(prisonNumber = prisonNumber)
-      given(inductionScheduleDateCalculationService.determineCreateInductionScheduleDto(any(), any(), any(), any(), anyOrNull())).willReturn(createInductionScheduleDto)
+      given(inductionScheduleDateCalculationService.determineCreateInductionScheduleDto(any(), any(), any())).willReturn(createInductionScheduleDto)
 
       val expectedInductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber)
       given(inductionSchedulePersistenceAdapter.createInductionSchedule(any())).willReturn(expectedInductionSchedule)
@@ -166,7 +165,7 @@ class InductionScheduleServiceTest {
       // Then
       assertThat(actual).isEqualTo(expectedInductionSchedule)
       verify(inductionSchedulePersistenceAdapter).getInductionSchedule(prisonNumber)
-      verify(inductionScheduleDateCalculationService).determineCreateInductionScheduleDto(prisonNumber, admissionDate, prisonId, true, null)
+      verify(inductionScheduleDateCalculationService).determineCreateInductionScheduleDto(prisonNumber, admissionDate, prisonId)
       verify(inductionSchedulePersistenceAdapter).createInductionSchedule(createInductionScheduleDto)
       verify(inductionScheduleEventService).inductionScheduleCreated(actual)
     }
@@ -215,7 +214,7 @@ class InductionScheduleServiceTest {
       given(inductionSchedulePersistenceAdapter.getInductionSchedule(any())).willReturn(inductionSchedule)
 
       val expectedDueDate = prisonerAdmissionDate.plusDays(20)
-      given(inductionScheduleDateCalculationService.determineCreateInductionScheduleDto(any(), any(), any(), any(), anyOrNull())).willReturn(
+      given(inductionScheduleDateCalculationService.determineCreateInductionScheduleDto(any(), any(), any())).willReturn(
         aValidCreateInductionScheduleDto(
           prisonNumber = prisonNumber,
           deadlineDate = expectedDueDate,
@@ -251,12 +250,12 @@ class InductionScheduleServiceTest {
       )
 
       // When
-      val actual = service.reschedulePrisonersInductionSchedule(prisonNumber, prisonerAdmissionDate, PRISON_ID, null)
+      val actual = service.reschedulePrisonersInductionSchedule(prisonNumber, prisonerAdmissionDate, PRISON_ID)
 
       // Then
       assertThat(actual).isEqualTo(expectedInductionSchedule)
       verify(inductionSchedulePersistenceAdapter).getInductionSchedule(prisonNumber)
-      verify(inductionScheduleDateCalculationService).determineCreateInductionScheduleDto(prisonNumber, prisonerAdmissionDate, PRISON_ID, true)
+      verify(inductionScheduleDateCalculationService).determineCreateInductionScheduleDto(prisonNumber, prisonerAdmissionDate, PRISON_ID)
       verify(inductionSchedulePersistenceAdapter).updateInductionScheduleStatus(expectedUpdateInductionScheduleStatusDto)
       verify(inductionScheduleEventService).inductionScheduleStatusUpdated(expectedUpdatedInductionScheduleStatus)
     }
@@ -271,7 +270,7 @@ class InductionScheduleServiceTest {
 
       // When
       val exception = catchThrowableOfType(InvalidInductionScheduleStatusException::class.java) {
-        service.reschedulePrisonersInductionSchedule(prisonNumber, TODAY, PRISON_ID, null)
+        service.reschedulePrisonersInductionSchedule(prisonNumber, TODAY, PRISON_ID)
       }
 
       // Then
@@ -290,7 +289,7 @@ class InductionScheduleServiceTest {
 
       // When
       val exception = catchThrowableOfType(InductionScheduleNotFoundException::class.java) {
-        service.reschedulePrisonersInductionSchedule(prisonNumber, TODAY, PRISON_ID, null)
+        service.reschedulePrisonersInductionSchedule(prisonNumber, TODAY, PRISON_ID)
       }
 
       // Then

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
@@ -108,7 +108,6 @@ class PrisonerReceivedIntoPrisonEventService(
         prisonNumber = nomsNumber,
         prisonerAdmissionDate = prisonerAdmissionDate,
         prisonId = prisonId,
-        releaseDate = prisoner.releaseDate,
       )
     } catch (e: InductionScheduleAlreadyExistsException) {
       // Prisoner already has an Induction Schedule
@@ -125,7 +124,6 @@ class PrisonerReceivedIntoPrisonEventService(
             nomsNumber,
             prisonerAdmissionDate = prisonerAdmissionDate,
             prisonId = prisonId,
-            releaseDate = prisoner.releaseDate,
             calculationRule = NEW_PRISON_ADMISSION,
           )
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationService.kt
@@ -51,22 +51,12 @@ class PefInductionScheduleDateCalculationService(
     prisonNumber: String,
     admissionDate: LocalDate,
     prisonId: String,
-    newAdmission: Boolean,
-    releaseDate: LocalDate?,
-  ): CreateInductionScheduleDto = if (newAdmission) {
+  ): CreateInductionScheduleDto {
     val calculationRule = getNewAdmissionCalculationRule()
-    CreateInductionScheduleDto(
+    return CreateInductionScheduleDto(
       prisonNumber = prisonNumber,
       deadlineDate = latestOf(admissionDate, LocalDate.now(clock)).plusDays(getNewAdmissionAdditionalDays(calculationRule)),
       scheduleCalculationRule = calculationRule,
-      scheduleStatus = InductionScheduleStatus.SCHEDULED,
-      prisonId = prisonId,
-    )
-  } else {
-    CreateInductionScheduleDto(
-      prisonNumber = prisonNumber,
-      deadlineDate = calculateDeadlineDate(releaseDate),
-      scheduleCalculationRule = InductionScheduleCalculationRule.EXISTING_PRISONER,
       scheduleStatus = InductionScheduleStatus.SCHEDULED,
       prisonId = prisonId,
     )
@@ -94,16 +84,6 @@ class PefInductionScheduleDateCalculationService(
       InductionScheduleCalculationRule.NEW_PRISON_ADMISSION_EXTENDED_DEADLINE_PERIOD
     } else {
       InductionScheduleCalculationRule.NEW_PRISON_ADMISSION
-    }
-  }
-
-  private fun calculateDeadlineDate(releaseDate: LocalDate?): LocalDate {
-    val sixMonthsAfterBase = baseScheduleDate().plusMonths(6)
-
-    return when {
-      releaseDate == null -> sixMonthsAfterBase
-      releaseDate.isBefore(sixMonthsAfterBase) -> releaseDate.minusDays(7)
-      else -> sixMonthsAfterBase
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationService.kt
@@ -37,7 +37,7 @@ class PesInductionScheduleDateCalculationService(exemptionProperties: ExemptionP
    * Once the S&A's have been completed in Curious the [InductionSchedule] has it's status set to SCHEDULED and the
    * deadline date correctly set (via a listener on the event sent from Curious)
    */
-  override fun determineCreateInductionScheduleDto(prisonNumber: String, admissionDate: LocalDate, prisonId: String, newAdmission: Boolean, releaseDate: LocalDate?): CreateInductionScheduleDto = CreateInductionScheduleDto(
+  override fun determineCreateInductionScheduleDto(prisonNumber: String, admissionDate: LocalDate, prisonId: String): CreateInductionScheduleDto = CreateInductionScheduleDto(
     prisonNumber = prisonNumber,
     deadlineDate = LocalDate.now(clock),
     scheduleCalculationRule = InductionScheduleCalculationRule.NEW_PRISON_ADMISSION,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
@@ -110,7 +110,6 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
       prisonNumber,
       prisonerAdmissionDate,
       prisonId,
-      releaseDate = prisoner.releaseDate,
     )
     verifyNoInteractions(reviewScheduleService)
     verifyNoInteractions(scheduleAdapter)
@@ -181,7 +180,7 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = COMPLETED)
     given(inductionScheduleService.getInductionScheduleForPrisoner(prisonNumber)).willReturn(inductionSchedule)
 
-    given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any(), anyOrNull())).willThrow(
+    given(inductionScheduleService.createInductionSchedule(any(), any(), any())).willThrow(
       InductionScheduleAlreadyExistsException(inductionSchedule),
     )
 
@@ -205,7 +204,6 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
       prisonNumber,
       prisonerAdmissionDate,
       prisonId,
-      releaseDate = prisoner.releaseDate,
     )
     verify(reviewScheduleService).getActiveReviewScheduleForPrisoner(prisonNumber)
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)
@@ -239,7 +237,7 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = COMPLETED)
     given(inductionScheduleService.getInductionScheduleForPrisoner(prisonNumber)).willReturn(inductionSchedule)
 
-    given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any(), anyOrNull())).willThrow(
+    given(inductionScheduleService.createInductionSchedule(any(), any(), any())).willThrow(
       InductionScheduleAlreadyExistsException(inductionSchedule),
     )
 
@@ -263,7 +261,6 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
       prisonNumber,
       prisonerAdmissionDate,
       prisonId,
-      releaseDate = prisoner.releaseDate,
     )
     verify(reviewScheduleService).getActiveReviewScheduleForPrisoner(prisonNumber)
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)
@@ -295,7 +292,7 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
     given(inductionService.getInductionForPrisoner(prisonNumber)).willThrow(InductionNotFoundException(prisonNumber))
 
     val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = SCHEDULED)
-    given(inductionScheduleService.createInductionSchedule(any(), any(), any(), any(), anyOrNull())).willThrow(
+    given(inductionScheduleService.createInductionSchedule(any(), any(), any())).willThrow(
       InductionScheduleAlreadyExistsException(inductionSchedule),
     )
 
@@ -307,13 +304,11 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
       prisonNumber,
       prisonerAdmissionDate,
       prisonId,
-      releaseDate = prisoner.releaseDate,
     )
     verify(inductionScheduleService).reschedulePrisonersInductionSchedule(
       prisonNumber,
       prisonerAdmissionDate,
       prisonId,
-      releaseDate = prisoner.releaseDate,
       InductionScheduleCalculationRule.NEW_PRISON_ADMISSION,
     )
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)


### PR DESCRIPTION
Simplify the `determineCreateInductionScheduleDto` method in `InductionScheduleDateCalculationService` and its implementations.