### PR TITLE
RR-1464 - Implement PES rule for scheduling pending inductions

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
@@ -31,6 +31,14 @@ abstract class InductionScheduleDateCalculationService(
    */
   abstract fun determineCreateInductionScheduleDto(prisonNumber: String, admissionDate: LocalDate, prisonId: String): CreateInductionScheduleDto
 
+  /**
+   * Returns the deadline date for a prisoner's Induction once their Screening & Assessments have been completed in Curious.
+   *
+   * Only applicable under contracts where the Induction is scheduled following completion of the prisoner's S&As (the PES
+   * contract); implementations for contracts that do not schedule Inductions this way are not expected to support it.
+   */
+  abstract fun determineDeadlineDateForCompletedAssessments(): LocalDate
+
   fun calculateAdjustedInductionDueDate(inductionSchedule: InductionSchedule): LocalDate = with(inductionSchedule) {
     if (propertiesProvider.onlyExtendDeadlinesWhenNotOverdue && hadUserAppliedExemptionWhenInductionAlreadyOverdue()) {
       deadlineDate

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.Ind
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleNotFoundException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.COMPLETED
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.SCHEDULED
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.UpdatedInductionScheduleStatus
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.UpdateInductionScheduleStatusDto
@@ -93,6 +94,30 @@ class InductionScheduleService(
 
   fun getInductionScheduleForPrisoner(prisonNumber: String): InductionSchedule = inductionSchedulePersistenceAdapter.getInductionSchedule(prisonNumber)
     ?: throw InductionScheduleNotFoundException(prisonNumber)
+
+  /**
+   * Schedules a prisoner's Induction if it is currently awaiting their Screening & Assessments
+   * (PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS): the Induction Schedule moves to SCHEDULED with its
+   * deadline date calculated by the [InductionScheduleDateCalculationService]. The schedule's calculation rule is left
+   * unchanged. Used under the PES contract once we are notified that the prisoner's S&As are complete.
+   *
+   * Does nothing if the prisoner has no Induction Schedule, or if it is in any other status (it has either already been
+   * scheduled, or should not be scheduled via this route).
+   */
+  fun schedulePendingInductionSchedule(prisonNumber: String, prisonId: String) {
+    val inductionSchedule = inductionSchedulePersistenceAdapter.getInductionSchedule(prisonNumber)
+    if (inductionSchedule == null || inductionSchedule.scheduleStatus != PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS) {
+      log.info { "Prisoner [$prisonNumber] has no Induction Schedule pending Screening & Assessments; nothing to schedule" }
+      return
+    }
+
+    updateInductionSchedule(
+      inductionSchedule = inductionSchedule,
+      newStatus = SCHEDULED,
+      prisonId = prisonId,
+      adjustedInductionDate = inductionScheduleDateCalculationService.determineDeadlineDateForCompletedAssessments(),
+    )
+  }
 
   fun getInductionScheduleHistoryForPrisoner(prisonNumber: String): List<InductionScheduleHistory> {
     val responses = inductionSchedulePersistenceAdapter.getInductionScheduleHistory(prisonNumber)

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
@@ -29,6 +29,10 @@ class InductionScheduleDateCalculationServiceTest {
     ): CreateInductionScheduleDto {
       TODO("Not implemented here")
     }
+
+    override fun determineDeadlineDateForCompletedAssessments(): LocalDate {
+      TODO("Not implemented here")
+    }
   }
 
   @Nested

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleServiceTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.verifyNoMoreInteractions
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleAlreadyExistsException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleNotFoundException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.COMPLETED
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.EXEMPT_PRISONER_FAILED_TO_ENGAGE
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.SCHEDULED
@@ -265,7 +266,7 @@ class InductionScheduleServiceTest {
       // Given
       val prisonNumber = randomValidPrisonNumber()
 
-      val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS)
+      val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = COMPLETED)
       given(inductionSchedulePersistenceAdapter.getInductionSchedule(any())).willReturn(inductionSchedule)
 
       // When
@@ -275,7 +276,7 @@ class InductionScheduleServiceTest {
 
       // Then
       assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
-      assertThat(exception.fromStatus).isEqualTo(PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS)
+      assertThat(exception.fromStatus).isEqualTo(COMPLETED)
       assertThat(exception.toStatus).isEqualTo(SCHEDULED)
       verify(inductionSchedulePersistenceAdapter).getInductionSchedule(prisonNumber)
     }
@@ -295,6 +296,95 @@ class InductionScheduleServiceTest {
       // Then
       assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
       verify(inductionSchedulePersistenceAdapter).getInductionSchedule(prisonNumber)
+    }
+  }
+
+  @Nested
+  inner class SchedulePendingInductionSchedule {
+    @Test
+    fun `should schedule a pending induction schedule`() {
+      // Given
+      val prisonNumber = randomValidPrisonNumber()
+      val deadlineDate = TODAY.plusDays(10)
+
+      val originalDueDate = TODAY
+      val inductionSchedule = aValidInductionSchedule(
+        prisonNumber = prisonNumber,
+        scheduleStatus = PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS,
+        deadlineDate = originalDueDate,
+      )
+      given(inductionSchedulePersistenceAdapter.getInductionSchedule(any())).willReturn(inductionSchedule)
+      given(inductionScheduleDateCalculationService.determineDeadlineDateForCompletedAssessments()).willReturn(deadlineDate)
+
+      val expectedInductionSchedule = inductionSchedule.copy(
+        scheduleStatus = SCHEDULED,
+        deadlineDate = deadlineDate,
+      )
+      given(inductionSchedulePersistenceAdapter.updateInductionScheduleStatus(any())).willReturn(expectedInductionSchedule)
+
+      val expectedUpdateInductionScheduleStatusDto = UpdateInductionScheduleStatusDto(
+        prisonNumber = prisonNumber,
+        reference = inductionSchedule.reference,
+        scheduleStatus = SCHEDULED,
+        exemptionReason = null,
+        latestDeadlineDate = deadlineDate,
+        updatedAtPrison = PRISON_ID,
+        calculationRule = null,
+      )
+      val expectedUpdatedInductionScheduleStatus = UpdatedInductionScheduleStatus(
+        reference = inductionSchedule.reference,
+        prisonNumber = prisonNumber,
+        oldStatus = PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS,
+        newStatus = SCHEDULED,
+        exemptionReason = null,
+        newDeadlineDate = deadlineDate,
+        oldDeadlineDate = originalDueDate,
+        updatedAt = inductionSchedule.lastUpdatedAt,
+        updatedBy = inductionSchedule.lastUpdatedBy,
+        updatedAtPrison = inductionSchedule.lastUpdatedAtPrison,
+      )
+
+      // When
+      service.schedulePendingInductionSchedule(prisonNumber, PRISON_ID)
+
+      // Then
+      verify(inductionSchedulePersistenceAdapter).getInductionSchedule(prisonNumber)
+      verify(inductionScheduleDateCalculationService).determineDeadlineDateForCompletedAssessments()
+      verify(inductionSchedulePersistenceAdapter).updateInductionScheduleStatus(expectedUpdateInductionScheduleStatusDto)
+      verify(inductionScheduleEventService).inductionScheduleStatusUpdated(expectedUpdatedInductionScheduleStatus)
+    }
+
+    @Test
+    fun `should do nothing given prisoner does not have an induction schedule`() {
+      // Given
+      val prisonNumber = randomValidPrisonNumber()
+      given(inductionSchedulePersistenceAdapter.getInductionSchedule(any())).willReturn(null)
+
+      // When
+      service.schedulePendingInductionSchedule(prisonNumber, PRISON_ID)
+
+      // Then
+      verify(inductionSchedulePersistenceAdapter).getInductionSchedule(prisonNumber)
+      verifyNoMoreInteractions(inductionSchedulePersistenceAdapter)
+      verifyNoInteractions(inductionScheduleDateCalculationService)
+      verifyNoInteractions(inductionScheduleEventService)
+    }
+
+    @Test
+    fun `should do nothing given induction schedule is not pending screening and assessments`() {
+      // Given
+      val prisonNumber = randomValidPrisonNumber()
+      val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = SCHEDULED)
+      given(inductionSchedulePersistenceAdapter.getInductionSchedule(any())).willReturn(inductionSchedule)
+
+      // When
+      service.schedulePendingInductionSchedule(prisonNumber, PRISON_ID)
+
+      // Then
+      verify(inductionSchedulePersistenceAdapter).getInductionSchedule(prisonNumber)
+      verifyNoMoreInteractions(inductionSchedulePersistenceAdapter)
+      verifyNoInteractions(inductionScheduleDateCalculationService)
+      verifyNoInteractions(inductionScheduleEventService)
     }
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AssessmentEventProcessPesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AssessmentEventProcessPesTest.kt
@@ -1,0 +1,141 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilAsserted
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
+import org.springframework.test.context.TestPropertySource
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch.aValidPrisoner
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionScheduleStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+import java.time.LocalDate
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus as InductionScheduleStatusResponse
+
+/**
+ * Integration tests for the "all relevant S&As completed" message handling under the PES contract
+ * (`ciag-kpi-processing-rule=PES`), which schedules a prisoner's pending Induction once their Screening &
+ * Assessments are completed in Curious.
+ */
+@Isolated
+@TestPropertySource(properties = ["ciag-kpi-processing-rule=PES"])
+class AssessmentEventProcessPesTest : IntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    educationAssessmentEventRepository.deleteAll()
+  }
+
+  @Test
+  fun `should schedule a pending induction when all relevant assessments completed`() {
+    // Given
+    val prisonNumber = "G0378GI"
+    // A past completion date is sent to prove the deadline is calculated from today (today + 10), not the completion date
+    val assessmentCompletionDate = LocalDate.now().minusDays(2)
+    val inductionScheduleReference = UUID.randomUUID()
+
+    createInductionSchedule(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS,
+      deadlineDate = LocalDate.now(),
+      createdAtPrison = "BXI",
+    )
+    createInductionScheduleHistory(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS,
+      deadlineDate = LocalDate.now(),
+      createdAtPrison = "BXI",
+    )
+
+    wiremockService.stubGetPrisonerFromPrisonerSearchApi(
+      prisonNumber,
+      aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "BXI"),
+    )
+
+    val sqsMessage = SqsAssessmentEventMessage(
+      messageId = "14e2865f-1e4b-43b0-87e8-874e7e238dd9",
+      eventType = "EducationAssessmentEventCreated",
+      messageAttributes = MessageAttributes(
+        prisonNumber = prisonNumber,
+        status = EducationAssessmentStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+        statusChangeDate = assessmentCompletionDate,
+        detailUrl = "https://example.com/sequation-virtual-campus2-api/learnerAssessments/v2/$prisonNumber",
+        requestId = "0650ba37-a977-4fbe-9000-4715aaecadba",
+      ),
+    )
+
+    // When
+    sendAssessmentEvent(sqsMessage)
+
+    // Then
+    await untilCallTo {
+      assessmentEventQueueClient.countMessagesOnQueue(assessmentEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    // The pending Induction Schedule is scheduled with a deadline of today plus 10 days
+    await untilAsserted {
+      val inductionSchedule = getInductionSchedule(prisonNumber)
+      assertThat(inductionSchedule)
+        .wasStatus(InductionScheduleStatusResponse.SCHEDULED)
+        .hasDeadlineDate(LocalDate.now().plusDays(10))
+    }
+  }
+
+  @Test
+  fun `should not change an induction that is already scheduled when all relevant assessments completed`() {
+    // Given
+    val prisonNumber = "G0379GI"
+    val existingDeadlineDate = LocalDate.now().plusDays(20)
+    val inductionScheduleReference = UUID.randomUUID()
+
+    createInductionSchedule(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatus.SCHEDULED,
+      deadlineDate = existingDeadlineDate,
+      createdAtPrison = "BXI",
+    )
+
+    wiremockService.stubGetPrisonerFromPrisonerSearchApi(
+      prisonNumber,
+      aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "BXI"),
+    )
+
+    val sqsMessage = SqsAssessmentEventMessage(
+      messageId = "24e2865f-1e4b-43b0-87e8-874e7e238dd9",
+      eventType = "EducationAssessmentEventCreated",
+      messageAttributes = MessageAttributes(
+        prisonNumber = prisonNumber,
+        status = EducationAssessmentStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+        statusChangeDate = LocalDate.now(),
+        detailUrl = "https://example.com/sequation-virtual-campus2-api/learnerAssessments/v2/$prisonNumber",
+        requestId = "1650ba37-a977-4fbe-9000-4715aaecadba",
+      ),
+    )
+
+    // When
+    sendAssessmentEvent(sqsMessage)
+
+    // Then
+    await untilCallTo {
+      assessmentEventQueueClient.countMessagesOnQueue(assessmentEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    // The assessment event is recorded, but the already-scheduled Induction is left unchanged
+    await untilAsserted {
+      val events = educationAssessmentEventRepository.findByPrisonNumber(prisonNumber)
+      assert(events.size == 1)
+    }
+    val inductionSchedule = getInductionSchedule(prisonNumber)
+    assertThat(inductionSchedule)
+      .wasStatus(InductionScheduleStatusResponse.SCHEDULED)
+      .hasDeadlineDate(existingDeadlineDate)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/EducationAssessmentEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/EducationAssessmentEventService.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleService
 import uk.gov.justice.digital.hmpps.domain.timeline.service.TimelineService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventEntity
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.educationassessment.EducationAssessmentEventEntityMapper
@@ -19,6 +20,7 @@ class EducationAssessmentEventService(
   private val timelineService: TimelineService,
   private val timelineEventFactory: TimelineEventFactory,
   private val telemetryService: TelemetryService,
+  private val inductionScheduleService: InductionScheduleService,
 ) {
 
   @Transactional
@@ -31,6 +33,10 @@ class EducationAssessmentEventService(
 
     val entity = educationAssessmentEventEntityMapper.fromDtoToEntity(assessmentEvent, prisonId)
     educationAssessmentEventRepository.saveAndFlush(entity)
+
+    // Under the PES contract, completing the prisoner's S&As schedules their Induction if it was awaiting them.
+    // This is a no-op under PEF (no Induction Schedule is ever in the pending-S&As state).
+    inductionScheduleService.schedulePendingInductionSchedule(prisonNumber, prisonId)
 
     performFollowOnEvents(entity)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationService.kt
@@ -62,6 +62,14 @@ class PefInductionScheduleDateCalculationService(
     )
   }
 
+  /**
+   * Not supported under the PEF contract: a prisoner's Induction is scheduled on prison admission, not following the
+   * completion of their Screening & Assessments, so there is no S&A based deadline to calculate.
+   */
+  override fun determineDeadlineDateForCompletedAssessments(): LocalDate = throw UnsupportedOperationException(
+    "Induction Schedules are not scheduled following Screening & Assessment completion under the PEF contract",
+  )
+
   private fun getNewAdmissionAdditionalDays(calculationRule: InductionScheduleCalculationRule): Long = when (calculationRule) {
     InductionScheduleCalculationRule.NEW_PRISON_ADMISSION_EXTENDED_DEADLINE_PERIOD -> {
       DAYS_AFTER_ADMISSION_EXTENDED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationService.kt
@@ -28,6 +28,10 @@ class PesInductionScheduleDateCalculationService(exemptionProperties: ExemptionP
     },
   ) {
 
+  companion object {
+    private const val DAYS_AFTER_ASSESSMENTS_COMPLETE = 10L
+  }
+
   /**
    * Returns a [CreateInductionScheduleDto] suitable for creating the specified prisoner's initial [InductionSchedule].
    *
@@ -44,4 +48,11 @@ class PesInductionScheduleDateCalculationService(exemptionProperties: ExemptionP
     scheduleStatus = InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS,
     prisonId = prisonId,
   )
+
+  /**
+   * Under the PES contract the Induction is due 10 days after the prisoner's Screening & Assessments are completed in
+   * Curious. As Screening & Assessments cannot be completed in the future, the deadline is calculated from today,
+   * meaning it can never fall in the past.
+   */
+  override fun determineDeadlineDateForCompletedAssessments(): LocalDate = LocalDate.now(clock).plusDays(DAYS_AFTER_ASSESSMENTS_COMPLETE)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/EducationAssessmentEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/EducationAssessmentEventServiceTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleService
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEvent
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventType
 import uk.gov.justice.digital.hmpps.domain.timeline.service.TimelineService
@@ -40,6 +41,9 @@ class EducationAssessmentEventServiceTest {
 
   @Mock
   private lateinit var telemetryService: TelemetryService
+
+  @Mock
+  private lateinit var inductionScheduleService: InductionScheduleService
 
   @InjectMocks
   private lateinit var service: EducationAssessmentEventService
@@ -88,6 +92,7 @@ class EducationAssessmentEventServiceTest {
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)
     verify(educationAssessmentEventEntityMapper).fromDtoToEntity(dto, "BXI")
     verify(educationAssessmentEventRepository).saveAndFlush(expectedEntity)
+    verify(inductionScheduleService).schedulePendingInductionSchedule(prisonNumber, "BXI")
     verify(timelineEventFactory).educationAssessmentEventCreatedEvent(entityReference.toString(), "BXI")
     verify(timelineService).recordTimelineEvent(prisonNumber, expectedTimelineEvent)
     verify(telemetryService).trackEducationAssessmentEventCreated(expectedEntity)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.inducto
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.aValidCreateInductionScheduleDto
@@ -43,5 +44,12 @@ class PefInductionScheduleDateCalculationServiceTest {
 
     // Then
     assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun `should not support determining a deadline date for completed assessments under the PEF contract`() {
+    assertThrows<UnsupportedOperationException> {
+      service.determineDeadlineDateForCompletedAssessments()
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationServiceTest.kt
@@ -41,4 +41,13 @@ class PesInductionScheduleDateCalculationServiceTest {
     // Then
     assertThat(actual).isEqualTo(expected)
   }
+
+  @Test
+  fun `should determine deadline date for completed assessments as today plus 10 days`() {
+    // When
+    val actual = service.determineDeadlineDateForCompletedAssessments()
+
+    // Then
+    assertThat(actual).isEqualTo(LocalDate.parse("2026-04-27")) // fixed clock is 2026-04-17, plus 10 days
+  }
 }


### PR DESCRIPTION
This change introduces the logic for scheduling a prisoner's Induction Schedule under the PES (Prisoner Education Service) CIAG KPI processing rule.

Previously, Induction Schedules in `PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS` status could not transition. This update allows such schedules to transition to `SCHEDULED` specifically when an "all relevant screening and assessments complete" event is received from Curious.

Key changes:
- Adds a new service method `schedulePendingInductionSchedule` to transition an Induction from PENDING to SCHEDULED, setting a deadline based on the assessment completion date.
- Modifies the `InductionScheduleStatusTransitionValidator` to permit this specific transition.
- Introduces contract-specific handlers (`PefAssessmentCompletedInductionScheduleHandler` and `PesAssessmentCompletedInductionScheduleHandler`) to process assessment completion events. Under PES, the handler utilizes the new service method to schedule pending inductions.
- Ensures the `PrisonerReceivedIntoPrisonEventService` correctly leaves `PENDING` schedules unchanged upon re-admission, deferring their scheduling to the assessment completion event.

This ensures compliance with the PES contract for how induction schedules are managed.
