### PR TITLE
RR-1464 - Schedule pending Induction on prison admission when S&As complete (PES)

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventPesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventPesTest.kt
@@ -1,0 +1,102 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilAsserted
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
+import org.springframework.test.context.TestPropertySource
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch.aValidPrisoner
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.ADMISSION
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RECEIVED_INTO_PRISON
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+import java.time.LocalDate
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionScheduleStatus as InductionScheduleStatusEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus as InductionScheduleStatusResponse
+
+/**
+ * Integration tests for prison-admission handling under the PES contract (`ciag-kpi-processing-rule=PES`), where a
+ * prisoner who already has an Induction Schedule pending their Curious Screening & Assessments is scheduled on
+ * admission if their S&As have since been completed.
+ */
+@Isolated
+@TestPropertySource(properties = ["ciag-kpi-processing-rule=PES"])
+class PrisonerReceivedDueToAdmissionEventPesTest : IntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    educationAssessmentEventRepository.deleteAll()
+  }
+
+  @Test
+  fun `should schedule pending induction on admission given the prisoner's assessments are complete`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val inductionScheduleReference = UUID.randomUUID()
+
+    createInductionSchedule(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatusEntity.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS,
+      deadlineDate = LocalDate.now(),
+      createdAtPrison = "BXI",
+    )
+    createInductionScheduleHistory(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatusEntity.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS,
+      deadlineDate = LocalDate.now(),
+      createdAtPrison = "BXI",
+    )
+
+    // The prisoner's Screening & Assessments have been completed in Curious
+    educationAssessmentEventRepository.save(
+      EducationAssessmentEventEntity(
+        reference = UUID.randomUUID(),
+        prisonNumber = prisonNumber,
+        status = EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+        statusChangeDate = LocalDate.now().minusDays(2),
+        source = "CURIOUS",
+        detailUrl = null,
+        createdAtPrison = "BXI",
+        updatedAtPrison = "BXI",
+      ),
+    )
+
+    with(aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "MDI")) {
+      createPrisonerAPIStub(prisonNumber, this)
+    }
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RECEIVED_INTO_PRISON,
+      additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+        prisonNumber = prisonNumber,
+        reason = ADMISSION,
+      ),
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    await untilAsserted {
+      val inductionSchedule = getInductionSchedule(prisonNumber)
+      assertThat(inductionSchedule)
+        .wasStatus(InductionScheduleStatusResponse.SCHEDULED)
+        .hasDeadlineDate(LocalDate.now().plusDays(10))
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/EducationAssessmentEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/database/jpa/repository/EducationAssessmentEventRepository.kt
@@ -3,9 +3,12 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.re
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventStatus
 import java.util.UUID
 
 @Repository
 interface EducationAssessmentEventRepository : JpaRepository<EducationAssessmentEventEntity, UUID> {
   fun findByPrisonNumber(prisonNumber: String): List<EducationAssessmentEventEntity>
+
+  fun existsByPrisonNumberAndStatus(prisonNumber: String, status: EducationAssessmentEventStatus): Boolean
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.Ind
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.COMPLETED
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.EXEMPT_PRISONER_RELEASE
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.ReviewScheduleNoReleaseDateForSentenceTypeException
@@ -23,6 +24,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.Additi
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.TEMPORARY_ABSENCE_RETURN
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.TRANSFERRED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.review.CreateInitialReviewScheduleMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.EducationAssessmentEventService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.PrisonerSearchApiService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ScheduleAdapter
 import java.time.Clock
@@ -45,6 +47,7 @@ class PrisonerReceivedIntoPrisonEventService(
   private val reviewService: ReviewService,
   private val actionPlanService: ActionPlanService,
   private val scheduleAdapter: ScheduleAdapter,
+  private val educationAssessmentEventService: EducationAssessmentEventService,
   private val clock: Clock,
 ) {
   fun process(
@@ -115,6 +118,14 @@ class PrisonerReceivedIntoPrisonEventService(
         COMPLETED -> {
           // The Induction was completed so we need to reschedule their active Review Schedule if they have one, or create a new Review Schedule.
           rescheduleOrCreatePrisonersReviewSchedule(prisoner, prisonId)
+        }
+
+        PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS -> {
+          // PES: the Induction is awaiting the prisoner's Screening & Assessments. If they are now complete, schedule it;
+          // otherwise leave it pending and wait for the Curious "S&As completed" message.
+          if (educationAssessmentEventService.hasCompletedAllAssessments(nomsNumber)) {
+            inductionScheduleService.schedulePendingInductionSchedule(nomsNumber, prisonId)
+          }
         }
 
         else -> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/EducationAssessmentEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/EducationAssessmentEventService.kt
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleService
 import uk.gov.justice.digital.hmpps.domain.timeline.service.TimelineService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.educationassessment.EducationAssessmentEventEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.EducationAssessmentEventRepository
 
@@ -42,6 +43,15 @@ class EducationAssessmentEventService(
 
     log.info { "Saved education assessment event [${entity.reference}] for prisoner [$prisonNumber]" }
   }
+
+  /**
+   * Returns true if the prisoner has completed all of their relevant Education Screening & Assessments (i.e. we have
+   * received an "all relevant assessments complete" event for them from the external assessment system).
+   */
+  fun hasCompletedAllAssessments(prisonNumber: String): Boolean = educationAssessmentEventRepository.existsByPrisonNumberAndStatus(
+    prisonNumber,
+    EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+  )
 
   @Async
   fun performFollowOnEvents(entity: EducationAssessmentEventEntity) = with(entity) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.given
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -19,6 +20,7 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.Ind
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleNotFoundException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.COMPLETED
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.SCHEDULED
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aFullyPopulatedInduction
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidInductionSchedule
@@ -39,6 +41,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.Additi
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.ADMISSION
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation.Reason.TRANSFERRED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.review.CreateInitialReviewScheduleMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.EducationAssessmentEventService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.PrisonerSearchApiService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ScheduleAdapter
 import java.time.Clock
@@ -74,6 +77,9 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
 
   @Mock
   private lateinit var scheduleAdapter: ScheduleAdapter
+
+  @Mock
+  private lateinit var educationAssessmentEventService: EducationAssessmentEventService
 
   @Mock
   private lateinit var clock: Clock
@@ -312,6 +318,78 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
       InductionScheduleCalculationRule.NEW_PRISON_ADMISSION,
     )
     verify(prisonerSearchApiService).getPrisoner(prisonNumber)
+  }
+
+  @Test
+  fun `should schedule pending induction given prisoner admission and prisoner already has a PENDING Induction Schedule and their assessments are complete`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val prisonerAdmissionDate = LocalDate.now()
+    val prisonId = "MDI"
+
+    val prisoner = aValidPrisoner(prisonerNumber = prisonNumber, prisonId = prisonId)
+    given(prisonerSearchApiService.getPrisoner(any())).willReturn(prisoner)
+
+    val additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+      prisonNumber = prisonNumber,
+      reason = ADMISSION,
+      prisonId = "BXI",
+    )
+    val inboundEvent = anInboundEvent(
+      additionalInformation = additionalInformation,
+      eventOccurredAt = prisonerAdmissionDate.atTime(11, 47, 32).toInstant(ZoneOffset.UTC),
+    )
+
+    given(inductionService.getInductionForPrisoner(prisonNumber)).willThrow(InductionNotFoundException(prisonNumber))
+
+    val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS)
+    given(inductionScheduleService.createInductionSchedule(any(), any(), any())).willThrow(
+      InductionScheduleAlreadyExistsException(inductionSchedule),
+    )
+    given(educationAssessmentEventService.hasCompletedAllAssessments(prisonNumber)).willReturn(true)
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(inductionScheduleService).schedulePendingInductionSchedule(prisonNumber, prisonId)
+    verify(inductionScheduleService, never()).reschedulePrisonersInductionSchedule(any(), any(), any(), anyOrNull())
+  }
+
+  @Test
+  fun `should leave induction pending given prisoner admission and prisoner already has a PENDING Induction Schedule and their assessments are not complete`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val prisonerAdmissionDate = LocalDate.now()
+    val prisonId = "MDI"
+
+    val prisoner = aValidPrisoner(prisonerNumber = prisonNumber, prisonId = prisonId)
+    given(prisonerSearchApiService.getPrisoner(any())).willReturn(prisoner)
+
+    val additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+      prisonNumber = prisonNumber,
+      reason = ADMISSION,
+      prisonId = "BXI",
+    )
+    val inboundEvent = anInboundEvent(
+      additionalInformation = additionalInformation,
+      eventOccurredAt = prisonerAdmissionDate.atTime(11, 47, 32).toInstant(ZoneOffset.UTC),
+    )
+
+    given(inductionService.getInductionForPrisoner(prisonNumber)).willThrow(InductionNotFoundException(prisonNumber))
+
+    val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber, scheduleStatus = PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS)
+    given(inductionScheduleService.createInductionSchedule(any(), any(), any())).willThrow(
+      InductionScheduleAlreadyExistsException(inductionSchedule),
+    )
+    given(educationAssessmentEventService.hasCompletedAllAssessments(prisonNumber)).willReturn(false)
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(inductionScheduleService, never()).schedulePendingInductionSchedule(any(), any())
+    verify(inductionScheduleService, never()).reschedulePrisonersInductionSchedule(any(), any(), any(), anyOrNull())
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/EducationAssessmentEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/EducationAssessmentEventServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -143,5 +144,35 @@ class EducationAssessmentEventServiceTest {
     verify(timelineEventFactory).educationAssessmentEventCreatedEvent(entityReference.toString(), "N/A")
     verify(timelineService).recordTimelineEvent(prisonNumber, expectedTimelineEvent)
     verify(telemetryService).trackEducationAssessmentEventCreated(expectedEntity)
+  }
+
+  @Test
+  fun `should return true given prisoner has completed all relevant assessments`() {
+    // Given
+    val prisonNumber = "G0378GI"
+    given(
+      educationAssessmentEventRepository.existsByPrisonNumberAndStatus(
+        prisonNumber,
+        EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+      ),
+    ).willReturn(true)
+
+    // When / Then
+    assertThat(service.hasCompletedAllAssessments(prisonNumber)).isTrue()
+  }
+
+  @Test
+  fun `should return false given prisoner has not completed all relevant assessments`() {
+    // Given
+    val prisonNumber = "G0378GI"
+    given(
+      educationAssessmentEventRepository.existsByPrisonNumberAndStatus(
+        prisonNumber,
+        EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+      ),
+    ).willReturn(false)
+
+    // When / Then
+    assertThat(service.hasCompletedAllAssessments(prisonNumber)).isFalse()
   }
 }


### PR DESCRIPTION
Handles the prison-admission side of the PES rule for a prisoner who already has
an Induction Schedule awaiting their Screening & Assessments
(PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS). On admission, if their
S&As are now complete (an "all relevant assessments complete" record exists), the
Induction is scheduled (today + 10 days); otherwise it is left pending to await the
Curious "S&As completed" message.

Reuses InductionScheduleService.schedulePendingInductionSchedule (added previously)
and adds EducationAssessmentEventService.hasCompletedAllAssessments. Dormant under
PEF: only PES ever produces PENDING schedules, so the new branch never fires in
prod until the PES rule is enabled.