### PR TITLE
RR-1464 - Schedule Induction on admission when assessments already complete (PES)

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventPesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventPesTest.kt
@@ -99,4 +99,54 @@ class PrisonerReceivedDueToAdmissionEventPesTest : IntegrationTestBase() {
         .hasDeadlineDate(LocalDate.now().plusDays(10))
     }
   }
+
+  @Test
+  fun `should create and schedule induction on admission given prisoner has no Induction Schedule but their assessments are already complete`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+
+    // The prisoner's Screening & Assessments have been completed in Curious, but they have no Induction Schedule yet
+    // (the assessments-complete message arrived before this admission)
+    educationAssessmentEventRepository.save(
+      EducationAssessmentEventEntity(
+        reference = UUID.randomUUID(),
+        prisonNumber = prisonNumber,
+        status = EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+        statusChangeDate = LocalDate.now().minusDays(2),
+        source = "CURIOUS",
+        detailUrl = null,
+        createdAtPrison = "BXI",
+        updatedAtPrison = "BXI",
+      ),
+    )
+
+    with(aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "MDI")) {
+      createPrisonerAPIStub(prisonNumber, this)
+    }
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RECEIVED_INTO_PRISON,
+      additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+        prisonNumber = prisonNumber,
+        reason = ADMISSION,
+      ),
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    // A new Induction Schedule is created and immediately scheduled (today + 10 days) rather than left pending
+    await untilAsserted {
+      val inductionSchedule = getInductionSchedule(prisonNumber)
+      assertThat(inductionSchedule)
+        .wasStatus(InductionScheduleStatusResponse.SCHEDULED)
+        .hasDeadlineDate(LocalDate.now().plusDays(10))
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
@@ -112,6 +112,9 @@ class PrisonerReceivedIntoPrisonEventService(
         prisonerAdmissionDate = prisonerAdmissionDate,
         prisonId = prisonId,
       )
+      // PES: the Induction is created awaiting the prisoner's Screening & Assessments. If they have already been
+      // completed (e.g. the Curious message arrived before this admission), schedule the Induction straight away.
+      schedulePendingInductionScheduleIfAssessmentsComplete(nomsNumber, prisonId)
     } catch (e: InductionScheduleAlreadyExistsException) {
       // Prisoner already has an Induction Schedule
       when (e.inductionSchedule.scheduleStatus) {
@@ -123,9 +126,7 @@ class PrisonerReceivedIntoPrisonEventService(
         PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS -> {
           // PES: the Induction is awaiting the prisoner's Screening & Assessments. If they are now complete, schedule it;
           // otherwise leave it pending and wait for the Curious "S&As completed" message.
-          if (educationAssessmentEventService.hasCompletedAllAssessments(nomsNumber)) {
-            inductionScheduleService.schedulePendingInductionSchedule(nomsNumber, prisonId)
-          }
+          schedulePendingInductionScheduleIfAssessmentsComplete(nomsNumber, prisonId)
         }
 
         else -> {
@@ -139,6 +140,17 @@ class PrisonerReceivedIntoPrisonEventService(
           )
         }
       }
+    }
+  }
+
+  /**
+   * Schedules the prisoner's Induction if it is awaiting their Screening & Assessments and those S&As have already been
+   * completed in Curious. No-op otherwise (under the PEF contract the Induction is never in the pending-S&As state, so
+   * this never does anything).
+   */
+  private fun schedulePendingInductionScheduleIfAssessmentsComplete(nomsNumber: String, prisonId: String) {
+    if (educationAssessmentEventService.hasCompletedAllAssessments(nomsNumber)) {
+      inductionScheduleService.schedulePendingInductionSchedule(nomsNumber, prisonId)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
@@ -122,6 +122,66 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
   }
 
   @Test
+  fun `should schedule induction on admission given prisoner has no Induction Schedule and their assessments are already complete`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val prisonerAdmissionDate = LocalDate.now()
+    val prisonId = "BXI"
+
+    val additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+      prisonNumber = prisonNumber,
+      reason = ADMISSION,
+      prisonId = prisonId,
+    )
+    val inboundEvent = anInboundEvent(
+      additionalInformation = additionalInformation,
+      eventOccurredAt = prisonerAdmissionDate.atTime(11, 47, 32).toInstant(ZoneOffset.UTC),
+    )
+
+    val prisoner = aValidPrisoner(prisonNumber)
+    given(prisonerSearchApiService.getPrisoner(prisonNumber)).willReturn(prisoner)
+    given(inductionService.getInductionForPrisoner(prisonNumber)).willThrow(InductionNotFoundException(prisonNumber))
+    given(educationAssessmentEventService.hasCompletedAllAssessments(prisonNumber)).willReturn(true)
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId)
+    verify(inductionScheduleService).schedulePendingInductionSchedule(prisonNumber, prisonId)
+  }
+
+  @Test
+  fun `should not schedule induction on admission given prisoner has no Induction Schedule and their assessments are not complete`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val prisonerAdmissionDate = LocalDate.now()
+    val prisonId = "BXI"
+
+    val additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+      prisonNumber = prisonNumber,
+      reason = ADMISSION,
+      prisonId = prisonId,
+    )
+    val inboundEvent = anInboundEvent(
+      additionalInformation = additionalInformation,
+      eventOccurredAt = prisonerAdmissionDate.atTime(11, 47, 32).toInstant(ZoneOffset.UTC),
+    )
+
+    val prisoner = aValidPrisoner(prisonNumber)
+    given(prisonerSearchApiService.getPrisoner(prisonNumber)).willReturn(prisoner)
+    given(inductionService.getInductionForPrisoner(prisonNumber)).willThrow(InductionNotFoundException(prisonNumber))
+    given(educationAssessmentEventService.hasCompletedAllAssessments(prisonNumber)).willReturn(false)
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(inductionScheduleService).createInductionSchedule(prisonNumber, prisonerAdmissionDate, prisonId)
+    verify(inductionScheduleService, never()).schedulePendingInductionSchedule(any(), any())
+  }
+
+  @Test
   fun `should process event given reason is prisoner admission and prisoner already has an Induction and Action Plan but no Induction Schedule`() {
     // Given
     val prisonNumber = randomValidPrisonNumber()


### PR DESCRIPTION
Closes the out-of-order gap where a prisoner's "all relevant S&As completed"
message is received before they have any Induction Schedule. Previously that
message no-op'd (no schedule to update), and a later admission created a PENDING
schedule that would never be scheduled.

Now, on admission, after creating the Induction Schedule we schedule it straight
away if the prisoner's S&As are already complete (today + 10 days); otherwise it
is left pending as before. The same check is applied via a shared helper for both
the newly-created and the existing-PENDING schedule cases. Dormant under PEF.
