### PR TITLE
Revert "RR-2652 - add bucket name for postgresDatabaseRestore (#939)"

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -20,8 +20,6 @@ generic-service:
         DB_USER_PREPROD: "database_username"
         DB_PASS_PREPROD: "database_password"
         DB_HOST_PREPROD: "rds_instance_address"
-      s3-db-restore-bucket:
-        BUCKET_NAME: "bucket_name"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
PR to revert the commit that added the bucket name config to the `postgresDatabaseRestore` helm job.
At the time of adding this the helm chart `generic-service/postgresDatabaseRestore` required it as a mandatory parameter. That chart has since been updated to make it optional, so I am removing it from LWP's config

This reverts commit 02c3c47d53e9416235e9b400689bf803332cb1cc.