### PR TITLE
RR-1464: Add PES integration tests for remaining induction-scheduling

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AssessmentEventProcessPesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/AssessmentEventProcessPesTest.kt
@@ -138,4 +138,101 @@ class AssessmentEventProcessPesTest : IntegrationTestBase() {
       .wasStatus(InductionScheduleStatusResponse.SCHEDULED)
       .hasDeadlineDate(existingDeadlineDate)
   }
+
+  @Test
+  fun `should record assessment event but not create an induction schedule given prisoner has no induction schedule`() {
+    // Given
+    val prisonNumber = "G0380GI"
+    // The prisoner has no Induction Schedule (messages out of sequence - the S&A Complete arrived before any admission)
+
+    wiremockService.stubGetPrisonerFromPrisonerSearchApi(
+      prisonNumber,
+      aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "BXI"),
+    )
+
+    val sqsMessage = SqsAssessmentEventMessage(
+      messageId = "34e2865f-1e4b-43b0-87e8-874e7e238dd9",
+      eventType = "EducationAssessmentEventCreated",
+      messageAttributes = MessageAttributes(
+        prisonNumber = prisonNumber,
+        status = EducationAssessmentStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+        statusChangeDate = LocalDate.now(),
+        detailUrl = "https://example.com/sequation-virtual-campus2-api/learnerAssessments/v2/$prisonNumber",
+        requestId = "2650ba37-a977-4fbe-9000-4715aaecadba",
+      ),
+    )
+
+    // When
+    sendAssessmentEvent(sqsMessage)
+
+    // Then
+    await untilCallTo {
+      assessmentEventQueueClient.countMessagesOnQueue(assessmentEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    // The assessment event is recorded, but no Induction Schedule is created
+    await untilAsserted {
+      val events = educationAssessmentEventRepository.findByPrisonNumber(prisonNumber)
+      assert(events.size == 1)
+    }
+    assertThat(getInductionScheduleHistory(prisonNumber)).hasNumberOfInductionScheduleVersions(0)
+  }
+
+  @Test
+  fun `should be idempotent on the induction schedule given a duplicate assessments completed message`() {
+    // Given a prisoner with a pending Induction Schedule (seeded as version 1)
+    val prisonNumber = "G0381GI"
+    val inductionScheduleReference = UUID.randomUUID()
+
+    createInductionSchedule(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS,
+      deadlineDate = LocalDate.now(),
+      createdAtPrison = "BXI",
+    )
+    createInductionScheduleHistory(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS,
+      deadlineDate = LocalDate.now(),
+      createdAtPrison = "BXI",
+    )
+
+    wiremockService.stubGetPrisonerFromPrisonerSearchApi(
+      prisonNumber,
+      aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "BXI"),
+    )
+
+    fun assessmentMessage(messageId: String, requestId: String) = SqsAssessmentEventMessage(
+      messageId = messageId,
+      eventType = "EducationAssessmentEventCreated",
+      messageAttributes = MessageAttributes(
+        prisonNumber = prisonNumber,
+        status = EducationAssessmentStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+        statusChangeDate = LocalDate.now(),
+        detailUrl = "https://example.com/sequation-virtual-campus2-api/learnerAssessments/v2/$prisonNumber",
+        requestId = requestId,
+      ),
+    )
+
+    // When the assessments-completed event is processed twice
+    sendAssessmentEvent(assessmentMessage("44e2865f-1e4b-43b0-87e8-874e7e238dd9", "3650ba37-a977-4fbe-9000-4715aaecadba"))
+    await untilCallTo {
+      assessmentEventQueueClient.countMessagesOnQueue(assessmentEventQueue.queueUrl).get()
+    } matches { it == 0 }
+    sendAssessmentEvent(assessmentMessage("55f3976g-2f5c-54c1-98f9-985f6bbfdbea", "4650ba37-a977-4fbe-9000-4715aaecadba"))
+    await untilCallTo {
+      assessmentEventQueueClient.countMessagesOnQueue(assessmentEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    // Then the Induction Schedule is scheduled exactly once (today + 10); the second message is a no-op as it is no
+    // longer pending, so no further history version is created (version 1 = seeded PENDING, version 2 = SCHEDULED)
+    await untilAsserted {
+      assertThat(getInductionScheduleHistory(prisonNumber)).hasNumberOfInductionScheduleVersions(2)
+    }
+    assertThat(getInductionSchedule(prisonNumber))
+      .wasStatus(InductionScheduleStatusResponse.SCHEDULED)
+      .hasDeadlineDate(LocalDate.now().plusDays(10))
+  }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventPesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventPesTest.kt
@@ -149,4 +149,40 @@ class PrisonerReceivedDueToAdmissionEventPesTest : IntegrationTestBase() {
         .hasDeadlineDate(LocalDate.now().plusDays(10))
     }
   }
+
+  @Test
+  fun `should create a pending induction on admission given prisoner has no Induction Schedule and their assessments are not complete`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+
+    // The prisoner has no Induction Schedule and no Screening & Assessments completion record
+
+    with(aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "MDI")) {
+      createPrisonerAPIStub(prisonNumber, this)
+    }
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RECEIVED_INTO_PRISON,
+      additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+        prisonNumber = prisonNumber,
+        reason = ADMISSION,
+      ),
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    // A new Induction Schedule is created awaiting the prisoner's Screening & Assessments
+    await untilAsserted {
+      val inductionSchedule = getInductionSchedule(prisonNumber)
+      assertThat(inductionSchedule)
+        .wasStatus(InductionScheduleStatusResponse.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS)
+    }
+  }
 }


### PR DESCRIPTION

Adds integration tests (test-only, no production change) for PES scenarios whose behaviour already works but was not yet covered end-to-end:

- Prison admission with no Induction Schedule and no S&A completion record creates a schedule with status PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS.
- S&A completed message for a prisoner with no Induction Schedule records the event but does not create a schedule (out-of-sequence messages).
- A duplicate S&A completed message is idempotent on the Induction Schedule: it is scheduled once (today + 10) and the second message is a no-op as it is no longer pending.