### PR TITLE
RR-1464: Re-gate automatically-exempt Induction on the prisoner's S&As on admission (PES)

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/InductionSchedule.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/InductionSchedule.kt
@@ -73,4 +73,13 @@ enum class InductionScheduleStatus(
   ;
 
   fun isExemptionOrExclusion(): Boolean = isExemption || isExclusion
+
+  /**
+   * True for exemptions applied automatically by the system in response to a prisoner lifecycle event - i.e.
+   * EXEMPT_PRISONER_TRANSFER, EXEMPT_TEMP_ABSENCE, EXEMPT_PRISONER_RELEASE, EXEMPT_PRISONER_RELEASE_HOSPITAL,
+   * EXEMPT_PRISONER_DEATH and EXEMPT_PRISONER_MERGE - as opposed to exemptions a user applies manually.
+   * Used to decide whether, on re-admission under the PES contract, the Induction should be re-gated on the
+   * prisoner's Screening & Assessments.
+   */
+  fun isAutomaticExemption(): Boolean = isExemptionOrExclusion() && !canBeSetByUserAction
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventPesTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedDueToAdmissionEventPesTest.kt
@@ -185,4 +185,122 @@ class PrisonerReceivedDueToAdmissionEventPesTest : IntegrationTestBase() {
         .wasStatus(InductionScheduleStatusResponse.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS)
     }
   }
+
+  @Test
+  fun `should set induction back to pending on admission given an automatically exempt Induction Schedule and assessments are not complete`() {
+    // Given
+    // A prisoner with an Induction Schedule that was automatically exempted (e.g. previously released), and no
+    // Screening & Assessments completion record - i.e. a re-admission / transfer scenario.
+    val prisonNumber = randomValidPrisonNumber()
+    val inductionScheduleReference = UUID.randomUUID()
+
+    createInductionSchedule(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatusEntity.EXEMPT_PRISONER_RELEASE,
+      deadlineDate = LocalDate.now(),
+      createdAtPrison = "BXI",
+    )
+    createInductionScheduleHistory(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatusEntity.EXEMPT_PRISONER_RELEASE,
+      deadlineDate = LocalDate.now(),
+      createdAtPrison = "BXI",
+    )
+
+    with(aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "MDI")) {
+      createPrisonerAPIStub(prisonNumber, this)
+    }
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RECEIVED_INTO_PRISON,
+      additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+        prisonNumber = prisonNumber,
+        reason = ADMISSION,
+      ),
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    // The Induction Schedule is set back to pending, awaiting the prisoner's Screening & Assessments
+    await untilAsserted {
+      val inductionSchedule = getInductionSchedule(prisonNumber)
+      assertThat(inductionSchedule)
+        .wasStatus(InductionScheduleStatusResponse.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS)
+    }
+  }
+
+  @Test
+  fun `should schedule induction on admission given an automatically exempt Induction Schedule and assessments are complete`() {
+    // Given
+    // A prisoner with an Induction Schedule that was automatically exempted (e.g. previously released), whose
+    // Screening & Assessments have since been completed in Curious - i.e. a re-admission / transfer scenario.
+    val prisonNumber = randomValidPrisonNumber()
+    val inductionScheduleReference = UUID.randomUUID()
+
+    createInductionSchedule(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatusEntity.EXEMPT_PRISONER_RELEASE,
+      deadlineDate = LocalDate.now(),
+      createdAtPrison = "BXI",
+    )
+    createInductionScheduleHistory(
+      reference = inductionScheduleReference,
+      prisonNumber = prisonNumber,
+      status = InductionScheduleStatusEntity.EXEMPT_PRISONER_RELEASE,
+      deadlineDate = LocalDate.now(),
+      createdAtPrison = "BXI",
+    )
+
+    educationAssessmentEventRepository.save(
+      EducationAssessmentEventEntity(
+        reference = UUID.randomUUID(),
+        prisonNumber = prisonNumber,
+        status = EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+        statusChangeDate = LocalDate.now().minusDays(2),
+        source = "CURIOUS",
+        detailUrl = null,
+        createdAtPrison = "BXI",
+        updatedAtPrison = "BXI",
+      ),
+    )
+
+    with(aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "MDI")) {
+      createPrisonerAPIStub(prisonNumber, this)
+    }
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = PRISONER_RECEIVED_INTO_PRISON,
+      additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+        prisonNumber = prisonNumber,
+        reason = ADMISSION,
+      ),
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    // The Induction Schedule is scheduled (today + 10 days) rather than left exempt or pending
+    await untilAsserted {
+      val inductionSchedule = getInductionSchedule(prisonNumber)
+      assertThat(inductionSchedule)
+        .wasStatus(InductionScheduleStatusResponse.SCHEDULED)
+        .hasDeadlineDate(LocalDate.now().plusDays(10))
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
 
 import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleAlreadyExistsException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleCalculationRule.NEW_PRISON_ADMISSION
@@ -49,7 +50,10 @@ class PrisonerReceivedIntoPrisonEventService(
   private val scheduleAdapter: ScheduleAdapter,
   private val educationAssessmentEventService: EducationAssessmentEventService,
   private val clock: Clock,
+  @param:Value("\${ciag-kpi-processing-rule:PEF}") private val ciagKpiProcessingRule: String,
 ) {
+  private val isPesContract: Boolean get() = ciagKpiProcessingRule == "PES"
+
   fun process(
     inboundEvent: InboundEvent,
     additionalInformation: PrisonerReceivedAdditionalInformation,
@@ -130,14 +134,25 @@ class PrisonerReceivedIntoPrisonEventService(
         }
 
         else -> {
-          // The Induction was not completed so need to reschedule it with a new deadline date
-          // and update the calculation rule to be NEW_ADMISSION.
-          inductionScheduleService.reschedulePrisonersInductionSchedule(
-            nomsNumber,
-            prisonerAdmissionDate = prisonerAdmissionDate,
-            prisonId = prisonId,
-            calculationRule = NEW_PRISON_ADMISSION,
-          )
+          if (isPesContract && e.inductionSchedule.scheduleStatus.isAutomaticExemption()) {
+            // PES re-admission/transfer of an automatically-exempt Induction: re-gate it on the prisoner's S&As.
+            // Set it back to pending, then schedule it immediately if their S&As are already complete.
+            inductionScheduleService.updateInductionSchedule(
+              inductionSchedule = e.inductionSchedule,
+              newStatus = PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS,
+              prisonId = prisonId,
+            )
+            schedulePendingInductionScheduleIfAssessmentsComplete(nomsNumber, prisonId)
+          } else {
+            // The Induction was not completed so need to reschedule it with a new deadline date
+            // and update the calculation rule to be NEW_ADMISSION.
+            inductionScheduleService.reschedulePrisonersInductionSchedule(
+              nomsNumber,
+              prisonerAdmissionDate = prisonerAdmissionDate,
+              prisonId = prisonId,
+              calculationRule = NEW_PRISON_ADMISSION,
+            )
+          }
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -51,7 +51,6 @@ import java.time.ZoneOffset
 
 @ExtendWith(MockitoExtension::class)
 class PrisonerReceivedIntoPrisonEventServiceTest {
-  @InjectMocks
   private lateinit var eventService: PrisonerReceivedIntoPrisonEventService
 
   @Mock
@@ -85,6 +84,23 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
   private lateinit var clock: Clock
 
   private val objectMapper = ObjectMapper()
+
+  @BeforeEach
+  fun setUp() {
+    eventService = PrisonerReceivedIntoPrisonEventService(
+      inductionScheduleService = inductionScheduleService,
+      reviewScheduleService = reviewScheduleService,
+      prisonerSearchApiService = prisonerSearchApiService,
+      createInitialReviewScheduleMapper = createInitialReviewScheduleMapper,
+      inductionService = inductionService,
+      reviewService = reviewService,
+      actionPlanService = actionPlanService,
+      scheduleAdapter = scheduleAdapter,
+      educationAssessmentEventService = educationAssessmentEventService,
+      clock = clock,
+      ciagKpiProcessingRule = "PEF",
+    )
+  }
 
   @Test
   fun `should process event given reason is prisoner admission and prisoner does not already have an Induction and Induction Schedule`() {


### PR DESCRIPTION
Under the PES contract, when a prisoner with an automatically-exempt Induction Schedule (release, transfer, temporary absence, hospital, merge) is re-admitted, the Induction is re-gated on their Screening & Assessments rather than rescheduled straight to SCHEDULED: it is set back to PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS, then scheduled immediately (today + 10 days) if their S&As are already complete.

Gated on the PES contract (ciag-kpi-processing-rule), so PEF behaviour is unchanged: an automatically-exempt schedule on admission continues to be rescheduled as today. Adds InductionScheduleStatus.isAutomaticExemption to distinguish system-applied exemptions from manual ones, and integration tests for both the S&As-complete and S&As-not-complete cases.