### PR TITLE
RR-2675 - Updated dockerfile and pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,4 +1,5 @@
 name: Pipeline [test -> build -> deploy]
+
 on:
   push:
     branches:
@@ -19,6 +20,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,70 +33,46 @@ jobs:
   helm_lint:
     strategy:
       matrix:
-        environments: [ 'dev', 'preprod', 'prod' ]
+        environments: ['dev', 'preprod', 'prod']
     name: helm lint
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
     with:
       environment: ${{ matrix.environments }}
-
-  kotlin_validate:
-    name: Validate the kotlin
+  app_version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.app_version.outputs.version }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: refresh cache
-        id: initial-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        env:
-          cache-name: kotlin-cache
-        with:
-          path: |
-            - gradle-{{ checksum "build.gradle.kts" }}
-            - gradle-
-          key: ${{ runner.os }}-gradle-${{ env.cache-name }}-${{ hashFiles('build.gradle.kts') }}
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: 'temurin'
-          java-version: '25'
-          cache: 'gradle'
-          cache-dependency-path: |
-            *.gradle*
-            **/gradle-wrapper.properties
-      - name: gradlew check
-        shell: bash
-        run: |
-          export JAVA_OPTS="-Xmx2g -XX:MaxMetaspaceSize=1g -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1"
-          ./gradlew check
-      - name: upload the artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: upload kotlin validation results
-          path: |
-            build/test-results
-            build/reports/tests
-            build/reports/jacoco
-            domain/learningandworkprogress/build/reports/tests
-            domain/learningandworkprogress/build/reports/jacoco
-            domain/personallearningplan/build/reports/tests
-            domain/personallearningplan/build/reports/jacoco
-            domain/timeline/build/reports/tests
-            domain/timeline/build/reports/jacoco
-
+      - id: app_version
+        name: Application version creators
+        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@cd5eb88ee6b73a22548a64b8c7358a3bedc9516f # v1.0.13
+  gradle_verify:
+    name: Validate the kotlin
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_verify.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+    with:
+      gradle-command: './gradlew check && BUILD_NUMBER=${{ needs.app_version.outputs.version}} ./gradlew assemble'
+      upload-build-artifacts: ${{ github.ref == 'refs/heads/main' }}
+      java-version: "25"
+    needs:
+      - app_version
   build:
     name: Build docker image from hmpps-github-actions
     if: github.ref == 'refs/heads/main'
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
     needs:
-      - kotlin_validate
+      - gradle_verify
     with:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
       additional_docker_tag: ${{ inputs.additional_docker_tag }}
-      push: ${{ inputs.push || true }}
-      docker_multiplatform: true
-
+      push: ${{ inputs.push || inputs.push == null }}
+      docker_multiplatform: false
+      download_build_artifacts: true
+      generate_sbom: true
+      attach_sbom_to_registry: true
+      sign_image: true
   deploy_dev:
     name: Deploy to the dev environment
     if: github.ref == 'refs/heads/main'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,25 @@
-FROM --platform=$BUILDPLATFORM eclipse-temurin:25.0.3_9-jdk-jammy AS builder
+ARG BASE_IMAGE=ghcr.io/ministryofjustice/hmpps-eclipse-temurin:25-jre-jammy
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS builder
 
 ARG BUILD_NUMBER
-ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
+ENV BUILD_NUMBER=${BUILD_NUMBER:-1_0_0}
 
-WORKDIR /app
-ADD . .
-RUN ./gradlew --no-daemon assemble
+WORKDIR /builder
+COPY hmpps-education-and-work-plan-api-${BUILD_NUMBER}.jar app.jar
+RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted
 
-FROM eclipse-temurin:25.0.3_9-jdk-jammy
-LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
+FROM ${BASE_IMAGE}
 
 ARG BUILD_NUMBER
-ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
-
-RUN apt-get update \
- && apt-get -y upgrade \
- && apt-get install -y --no-install-recommends \
-      wget \
- && rm -rf /var/lib/apt/lists/*
-
-ENV TZ=Europe/London
-RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
-
-RUN addgroup --gid 2000 --system appgroup && \
-    adduser --uid 2000 --system appuser --gid 2000
-
-# Install AWS RDS Root cert into Java truststore
-RUN mkdir /home/appuser/.postgresql
-ADD --chown=appuser:appgroup https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /home/appuser/.postgresql/root.crt
+ENV BUILD_NUMBER=${BUILD_NUMBER:-1_0_0}
 
 WORKDIR /app
-COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-education-and-work-plan-api*.jar /app/app.jar
-COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
-COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
-COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /app
+COPY --chown=appuser:appgroup applicationinsights.json ./
+COPY --chown=appuser:appgroup applicationinsights.dev.json ./
+COPY --chown=appuser:appgroup applicationinsights-agent*.jar ./agent.jar
+COPY --from=builder --chown=appuser:appgroup /builder/extracted/dependencies/ ./
+COPY --from=builder --chown=appuser:appgroup /builder/extracted/spring-boot-loader/ ./
+COPY --from=builder --chown=appuser:appgroup /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder --chown=appuser:appgroup /builder/extracted/application/ ./
 
-USER 2000
-
-ENTRYPOINT ["java", "-XX:+AlwaysActAsServerClassMachine", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-XX:+ExitOnOutOfMemoryError", "-XX:+AlwaysActAsServerClassMachine", "-javaagent:agent.jar", "-jar", "app.jar"]

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/health/InfoTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/health/InfoTest.kt
@@ -1,12 +1,13 @@
 package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.health
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.info.BuildProperties
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
-class InfoTest : IntegrationTestBase() {
+class InfoTest(
+  @Autowired private val buildProperties: BuildProperties,
+) : IntegrationTestBase() {
 
   @Test
   fun `Info page is accessible`() {
@@ -24,8 +25,6 @@ class InfoTest : IntegrationTestBase() {
     webTestClient.get().uri("/info")
       .exchange()
       .expectStatus().isOk
-      .expectBody().jsonPath("build.version").value<String> {
-        assertThat(it).startsWith(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-      }
+      .expectBody().jsonPath("build.version").isEqualTo(buildProperties.version)
   }
 }


### PR DESCRIPTION
PR to update the `Dockerfile` and `pipeline.yaml` to be the standard ones from the hmpps-kotlin-template repo.
It means we are now setting the base image as a JRE, not a JDK; plus we are no longer adding wget to the image

Also had to make a minor change to `InfoTest` (updated it from the current version in hmpps-kotlin-template) so that it passes on CI with the new pipeline file