### PR TITLE
fix: make JVM heap config effective and right-size memory to mitigate search OOMs

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-api/values.yaml
@@ -23,9 +23,36 @@ generic-service:
   # Used to access resources like SQS queues and SNS topics
   serviceAccountName: hmpps-education-and-work-plan
 
+  # Container resources.
+  # Sized from the live prod JVM (jcmd on the highest pod): non-heap committed is large and steady —
+  # ~250Mi metaspace, ~150-290Mi thread stacks (~290 threads), ~240Mi reserved code cache, plus the
+  # Application Insights agent's native memory and Netty direct buffers — giving a ~700Mi non-heap
+  # baseline before any heap. With the now-effective 768m heap (see JAVA_TOOL_OPTIONS) worst-case RSS is
+  # ~768m + ~700Mi ≈ 1.45Gi, so the limit is set to 1800Mi to leave real headroom; request matches the
+  # observed ~950Mi steady-state RSS so the scheduler reserves enough and the pod isn't evicted under
+  # node memory pressure. Revisit once the proper search-endpoint fix (TODOs in PrisonerSearchService)
+  # shrinks the per-request footprint — the heap (and these numbers) can then come back down.
+  resources:
+    requests:
+      cpu: 10m
+      memory: 1024Mi
+    limits:
+      cpu: "1"
+      memory: 1800Mi
+
   # Environment variables to load into the deployment
   env:
-    JAVA_OPTS: "-Xmx512m"
+    # IMPORTANT: the Docker ENTRYPOINT is exec-form (`["java", ...]`), which does NOT expand $JAVA_OPTS,
+    # and the bare `java` binary does not read JAVA_OPTS itself. Heap settings therefore have to go via
+    # JAVA_TOOL_OPTIONS, which the JVM reads natively at startup.
+    # Previously `JAVA_OPTS: "-Xmx512m"` was silently ignored: the JVM fell back to its container default
+    # of 25% of the memory limit (~250Mi heap on a 1000Mi limit) — roughly half the intended heap, and
+    # the direct cause of how easily the prison search endpoint exhausted heap and threw OutOfMemoryError.
+    # NOTE: no -XX:+HeapDumpOnOutOfMemoryError here on purpose — main already sets -XX:+ExitOnOutOfMemoryError
+    # (RR-2675) so the container restarts immediately on OOM, which would lose a dump written to the
+    # ephemeral fs (and a ~768Mi dump risks an ephemeral-storage eviction). Capturing dumps properly needs
+    # a pod-scoped emptyDir volume mounted for -XX:HeapDumpPath — left as a follow-up.
+    JAVA_TOOL_OPTIONS: "-Xmx768m"
     SERVER_PORT: "8080"
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AbstractPrisonerSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/AbstractPrisonerSearchService.kt
@@ -7,6 +7,9 @@ abstract class AbstractPrisonerSearchService(
   protected val prisonerSearchApiService: PrisonerSearchApiService,
 ) {
 
+  // TODO (OOM mitigation follow-up): in-memory pagination — `this` is the full prison roster and all but
+  //  one page is discarded via drop()/take(). Should be replaced by pushing pagination to the data source
+  //  so the full list is never materialised. See PrisonerSearchService.searchPrisoners.
   protected fun <T> List<T>.paginate(
     page: Int,
     pageSize: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerSearchApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerSearchApiService.kt
@@ -14,6 +14,10 @@ class PrisonerSearchApiService(
   private val pageSize: Int = 9999,
 ) {
 
+  // TODO (OOM mitigation follow-up): this pulls every prisoner in the prison into memory in a single
+  //  pageSize=9999 call and accumulates full Prisoner objects. It is the main heap consumer behind the
+  //  search-endpoint OOMs. Once prisoner-search paging is trusted (see comment below) this should fetch
+  //  only the requested page rather than the whole roster. See PrisonerSearchService.searchPrisoners.
   fun getAllPrisonersInPrison(prisonId: String): List<Prisoner> {
     var page = 0
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/PrisonerSearchService.kt
@@ -15,6 +15,15 @@ class PrisonerSearchService(
   private val personSearchRepository: PersonSearchRepository,
 ) : AbstractPrisonerSearchService(prisonerSearchApiService) {
 
+  // TODO (OOM mitigation follow-up): this endpoint paginates entirely in memory. It loads the WHOLE
+  //  prison roster (see getPrisonersBySearchCriteria -> getAllPrisonersInPrison, pageSize=9999), builds
+  //  a full List<PersonResponse>, then sorts/filters/paginates in memory and discards all but one page.
+  //  Under concurrency at large prisons this is what exhausts the heap. The proper fix is to push
+  //  filtering, sorting and pagination down to the data sources so only one page (~pageSize) is ever
+  //  held in memory. This is non-trivial because the result spans two sources (prisoner-search-api for
+  //  the roster + the local DB for planStatus via PersonSearchRepository.additionalSearchData), so the
+  //  sort/filter fields straddle both. Options to explore: have prisoner-search do name/number filtering
+  //  + paging, and/or maintain the searchable fields locally so a single paged DB query can serve it.
   fun searchPrisoners(
     searchCriteria: PrisonerSearchCriteria,
   ): PersonSearchResult {


### PR DESCRIPTION
The prison search endpoint (GET /search/prisons/{prisonId}/people) was throwing java.lang.OutOfMemoryError under load. Investigation showed two compounding issues.

1. The intended `-Xmx512m` was never applied. The Docker ENTRYPOINT is exec-form, which does not expand $JAVA_OPTS, and the `java` binary does not read JAVA_OPTS. The live JVM ran with MaxHeapSize=250Mi (container default of 25% of the 1000Mi limit) — roughly half the intended heap. The pod that OOMed peaked at only ~848Mi RSS, well under the 1000Mi container limit, confirming it ran out of JVM heap rather than container memory. Moved the setting to JAVA_TOOL_OPTIONS (read natively by the JVM) at -Xmx768m.

   Right-sized the container from the live JVM: non-heap committed is a large, stable ~700Mi (metaspace ~250Mi, ~290 thread stacks, ~240Mi reserved code cache, App Insights agent native, Netty direct buffers). With a 768m heap that puts worst-case RSS at ~1.45Gi, so the limit is raised 1000Mi -> 1800Mi and the request to 1024Mi (matching observed ~950Mi steady-state RSS). No HeapDumpOnOutOfMemoryError: main already sets -XX:+ExitOnOutOfMemoryError so a dump on the ephemeral fs is lost on restart and risks an ephemeral-storage eviction — capturing dumps needs an emptyDir volume (follow-up).

2. The endpoint paginates entirely in memory — it loads the whole prison roster (pageSize=9999) and discards all but one page. This is the underlying design flaw and the real per-request heap consumer. Left TODO markers documenting the proper fix (push filtering/sorting/pagination down to prisoner-search + the DB) rather than attempting that larger, higher-risk change in this hotfix.

Mitigation only; the proper paginated-search rework is tracked by the TODOs.