### PR TITLE
RR-2692: Add guard tests for prisoner-search roster projection trim

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetSessionSummaryTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GetSessionSummaryTest.kt
@@ -105,6 +105,32 @@ class GetSessionSummaryTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should still calculate counts when prisoner-search returns only the roster fields`() {
+    // RR-2692 guard: the summary only needs prisonNumber. Simulate prisoner-search returning ONLY the
+    // roster fields (the 5 fields proposed for dropping are absent) and assert the counts are unchanged.
+    // Expected green BEFORE the RESPONSE_FIELDS trim.
+    // Given
+    setUpData()
+    wiremockService.stubPrisonersInAPrisonSearchApiReturningOnlyRosterFields(
+      PRISON_ID,
+      listOf(prisoner1, prisoner2, prisoner3, prisoner4, prisoner5, prisoner6),
+    )
+
+    // When
+    val response = getSessionSummary()
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual).isNotNull
+    assertThat(actual!!.dueReviews).isEqualTo(1)
+    assertThat(actual.dueInductions).isEqualTo(1)
+    assertThat(actual.overdueReviews).isEqualTo(1)
+    assertThat(actual.overdueInductions).isEqualTo(1)
+    assertThat(actual.exemptReviews).isEqualTo(1)
+    assertThat(actual.exemptInductions).isEqualTo(1)
+  }
+
+  @Test
   fun `should return 1 count in due induction section`() {
     // Given
     setUpData()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/PrisonerSearchTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/PrisonerSearchTest.kt
@@ -127,6 +127,59 @@ class PrisonerSearchTest : IntegrationTestBase() {
       }
   }
 
+  @Test
+  fun `should map all display fields when prisoner-search returns only the roster fields`() {
+    // RR-2692 guard: simulate prisoner-search returning ONLY the fields the roster path uses (the 5
+    // fields proposed for dropping are absent). Proves the endpoint still maps correctly, so trimming
+    // PrisonerSearchApiClient.RESPONSE_FIELDS is safe. Expected green BEFORE the trim.
+    // Given
+    val prisoner = aValidPrisoner(
+      prisonerNumber = "A1234BC",
+      firstName = "Alice",
+      lastName = "Anderson",
+      cellLocation = "A-1-001",
+      dateOfBirth = LocalDate.parse("1990-01-15"),
+      releaseDate = LocalDate.parse("2030-06-01"),
+      receptionDate = LocalDate.parse("2020-02-02"),
+    )
+    wiremockService.stubPrisonersInAPrisonSearchApiReturningOnlyRosterFields(PRISON_ID, listOf(prisoner))
+
+    // When
+    val response = searchPeople()
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasNumberOfPersonResponses(1)
+      .personResponse(
+        1,
+        {
+          it
+            .hasPrisonNumber("A1234BC")
+            .hasForename("Alice")
+            .hasSurname("Anderson")
+            .hasCellLocation("A-1-001")
+            .hasDateOfBirth(LocalDate.parse("1990-01-15"))
+            .hasReleaseDate(LocalDate.parse("2030-06-01"))
+            .enteredPrisonOn(LocalDate.parse("2020-02-02"))
+        },
+      )
+  }
+
+  @Test
+  fun `should request the expected responseFields from prisoner-search`() {
+    // RR-2692 guard: pin the exact responseFields requested from prisoner-search. If RESPONSE_FIELDS
+    // changes (e.g. the trim), this fails and forces a conscious update of the expected list below.
+    // When
+    searchPeople()
+
+    // Then
+    wiremockService.verifyPrisonersInAPrisonSearchApiCalledWithResponseFields(
+      PRISON_ID,
+      "prisonerNumber,legalStatus,releaseDate,receptionDate,prisonId,indeterminateSentence,recall,lastName,firstName,dateOfBirth,cellLocation,nonDtoReleaseDateType",
+    )
+  }
+
   @Nested
   inner class Sorting {
     @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/PrisonerSessionSearchTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/PrisonerSessionSearchTest.kt
@@ -110,6 +110,33 @@ class PrisonerSessionSearchTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should map prisoner fields when prisoner-search returns only the roster fields`() {
+    // RR-2692 guard: simulate prisoner-search returning ONLY the roster fields (the 5 fields proposed
+    // for dropping are absent) and assert the sessions still resolve with correct prisoner detail.
+    // Expected green BEFORE the RESPONSE_FIELDS trim.
+    // Given
+    setUpData()
+    wiremockService.stubPrisonersInAPrisonSearchApiReturningOnlyRosterFields(
+      PRISON_ID,
+      listOf(prisoner1, prisoner2, prisoner3, prisoner4, prisoner5, prisoner6),
+    )
+
+    // When
+    val response = searchPeople()
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual).isNotNull
+    assertThat(actual!!.sessions.size).isEqualTo(2)
+    assertThat(actual.sessions[0].sessionType).isEqualTo(SessionType.INDUCTION)
+    assertThat(actual.sessions[0].prisonNumber).isEqualTo(prisoner1.prisonerNumber)
+    assertThat(actual.sessions[0].forename).isEqualTo("John")
+    assertThat(actual.sessions[0].surname).isEqualTo("Rambo")
+    assertThat(actual.sessions[1].sessionType).isEqualTo(SessionType.REVIEW)
+    assertThat(actual.sessions[1].prisonNumber).isEqualTo(prisoner4.prisonerNumber)
+  }
+
+  @Test
   fun `sort by release date ascending`() {
     // Given
     setUpData()

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/WiremockService.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/WiremockService.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.exactly
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
@@ -95,6 +96,57 @@ class WiremockService(private val wireMockServer: WireMockServer) {
         ),
     )
   }
+
+  fun stubPrisonersInAPrisonSearchApiWithRawJsonBody(prisonId: String, jsonBody: String) {
+    wireMockServer.stubFor(
+      get(urlPathMatching("/prisoner-search/prison/$prisonId"))
+        .willReturn(
+          responseDefinition()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(jsonBody),
+        ),
+    )
+  }
+
+  /**
+   * Stubs the "prisoners in a prison" search returning ONLY the fields the roster path actually consumes
+   * (prisonerNumber, firstName, lastName, dateOfBirth, cellLocation, releaseDate, receptionDate) — i.e.
+   * simulating a trimmed `responseFields` request. The 5 fields that RR-2692 proposes to drop
+   * (legalStatus, prisonId, indeterminateSentence, recall, nonDtoReleaseDateType) are deliberately ABSENT
+   * from the JSON. This is a guard: the roster endpoints can be proven to behave correctly without those
+   * fields BEFORE `PrisonerSearchApiClient.RESPONSE_FIELDS` is trimmed.
+   */
+  fun stubPrisonersInAPrisonSearchApiReturningOnlyRosterFields(prisonId: String, prisoners: List<Prisoner>) {
+    val content = prisoners.map { prisoner ->
+      buildMap<String, Any?> {
+        put("prisonerNumber", prisoner.prisonerNumber)
+        put("firstName", prisoner.firstName)
+        put("lastName", prisoner.lastName)
+        put("dateOfBirth", prisoner.dateOfBirth.toString())
+        put("cellLocation", prisoner.cellLocation)
+        put("releaseDate", prisoner.releaseDate?.toString())
+        put("receptionDate", prisoner.receptionDate?.toString())
+      }
+    }
+    val jsonBody = objectMapper.writeValueAsString(mapOf("last" to true, "content" to content))
+    stubPrisonersInAPrisonSearchApiWithRawJsonBody(prisonId, jsonBody)
+  }
+
+  /**
+   * Verifies the outbound "prisoners in a prison" call requested exactly [expectedResponseFields] (the
+   * comma-joined `responseFields` query param). Pin this to the literal field list so any change to
+   * `PrisonerSearchApiClient.RESPONSE_FIELDS` fails the test and forces a conscious update (RR-2692).
+   */
+  fun verifyPrisonersInAPrisonSearchApiCalledWithResponseFields(
+    prisonId: String,
+    expectedResponseFields: String,
+    expectedCount: Int = 1,
+  ) = wireMockServer.verify(
+    exactly(expectedCount),
+    getRequestedFor(urlPathMatching("/prisoner-search/prison/$prisonId"))
+      .withQueryParam("responseFields", equalTo(expectedResponseFields)),
+  )
 
   fun stubGetPrisonerNotFound(prisonNumber: String) {
     wireMockServer.stubFor(


### PR DESCRIPTION
These tests act as a guard for the planned trimming of `PrisonerSearchApiClient.RESPONSE_FIELDS`. They verify that endpoints consuming `prisoner-search` data (session summary, prisoner search, prisoner session search) continue to function correctly when the upstream API returns only the fields essential for the roster projection. A dedicated test also pins the exact `responseFields` requested, forcing a conscious update if the list changes.

The planned trim will only be a modest footprint reduction, the root cause of the original OOM error from RR-2691 is yet to be confirmed 