### PR TITLE
RR-2691: Use URI template for Prison API offender timeline endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonapi/PrisonApiClient.kt
@@ -24,7 +24,7 @@ class PrisonApiClient(
   fun getPrisonMovementEvents(prisonNumber: String): PrisonMovementEvents {
     val prisonerInPrisonSummary = prisonApiWebClient
       .get()
-      .uri("/api/offenders/$prisonNumber/prison-timeline")
+      .uri("/api/offenders/{prisonNumber}/prison-timeline", prisonNumber)
       .retrieve()
       .bodyToMono(PrisonerInPrisonSummary::class.java)
       .onErrorResume {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/client/prisonersearch/PrisonerSearchApiClient.kt
@@ -50,11 +50,11 @@ class PrisonerSearchApiClient(
   ): PagedPrisonerResponse = prisonerSearchApiWebClient
     .get()
     .uri {
-      it.path("/prisoner-search/prison/$prisonId")
+      it.path("/prisoner-search/prison/{prisonId}")
         .queryParam("page", page)
         .queryParam("size", pageSize)
         .queryParam("responseFields", RESPONSE_FIELDS)
-        .build()
+        .build(prisonId)
     }
     .headers {
       it.contentType = MediaType.APPLICATION_JSON


### PR DESCRIPTION
Refactors the `getPrisonMovementEvents` call to Prison API to leverage WebClient's URI template capabilities.