### PR TITLE
RR-2682 - Updated 'Goals' section in the SAR report

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/specialtests/resource/sar/SarReportGenerationTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/specialtests/resource/sar/SarReportGenerationTest.kt
@@ -6,10 +6,13 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.prisonersearch.aValidPrisoner
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ArchiveGoalRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CompleteGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EmployabilitySkillRating
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EmployabilitySkillSessionType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EmployabilitySkillType
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.PersonalInterestType
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonToArchiveGoal
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateActionPlanRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateEmployabilitySkillRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidCreateGoalRequest
@@ -95,9 +98,38 @@ class SarReportGenerationTest :
             title = "Goal 1",
             targetCompletionDate = LocalDate.parse("2050-12-31"), // Target completion date MUST be in the future so set a very long date to prevent fragile test failure
           ),
+          aValidCreateGoalRequest(
+            title = "Goal 2",
+            targetCompletionDate = LocalDate.parse("2050-12-31"),
+          ),
+          aValidCreateGoalRequest(
+            title = "Goal 3",
+            targetCompletionDate = LocalDate.parse("2050-12-31"),
+          ),
         ),
       ),
     )
+
+    val goals = getActionPlan(prisonNumber).goals
+    completeGoal(
+      prisonNumber,
+      CompleteGoalRequest(
+        goalReference = goals.find { it.title == "Goal 2" }!!.goalReference,
+        prisonId = "MDI",
+        note = "Goal completed on time",
+      ),
+    )
+    archiveGoal(
+      prisonNumber,
+      ArchiveGoalRequest(
+        goalReference = goals.find { it.title == "Goal 3" }!!.goalReference,
+        prisonId = "MDI",
+        reason = ReasonToArchiveGoal.OTHER,
+        reasonOther = "Staff can no longer support him to achieve this goal",
+        note = "Goal archived as no longer appropriate",
+      ),
+    )
+
     // The next review date will have been calculated based on "today"; therefore it changes every day and the expected HTML output will not match
     // manually set the next (first) review date to a fixed date to prevent fragile test failure
     updateReviewScheduleReviewDates(

--- a/src/integrationTest/resources/sar/expected-report.html
+++ b/src/integrationTest/resources/sar/expected-report.html
@@ -461,29 +461,222 @@
     <td>Chris would like to improve his listening skills, not just his verbal communication</td>
   </tr>
 </table>
-
+<table class="summary-list">
+  <tr><td>Reason for archiving</td><td>No Data Held</td></tr>
+  <tr><td>Archive reason Other</td><td>No Data Held</td></tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-100">Archived goal note</td>
+  </tr>
+  <tr>
+    <td>No Data Held</td>
+  </tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-100">Goal completion note</td>
+  </tr>
+  <tr>
+    <td>No Data Held</td>
+  </tr>
+</table>
 <table class="data-table">
   <tr>
     <td class="data-column-15">Step</td>
     <td class="data-column-25">Status</td>
     <td class="data-column-60">Title</td>
   </tr>
-
   <tr>
     <td>1</td>
     <td>NOT_STARTED</td>
     <td>Book communication skills course</td>
   </tr>
-
   <tr>
     <td>2</td>
     <td>NOT_STARTED</td>
     <td>Complete communication skills course</td>
   </tr>
-
 </table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-30">Created by</td>
+    <td class="data-column-35">Created at</td>
+    <td class="data-column-30">Created at prison</td>
+  </tr>
+  <tr>
+    <td>Johnson</td>
+    <td>21 March 2026, 9:43:27 am</td>
+    <td>Moorland (HMP &amp; YOI)</td>
+  </tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-30">Updated by</td>
+    <td class="data-column-35">Updated at</td>
+    <td class="data-column-30">Updated at prison</td>
+  </tr>
+  <tr>
+    <td>Johnson</td>
+    <td>21 March 2026, 9:43:27 am</td>
+    <td>Moorland (HMP &amp; YOI)</td>
+  </tr>
+</table>
+<br>
 
+<h3>Goal</h3>
+<table class="summary-list">
+  <tr><td>Title</td><td>Goal 2</td></tr>
+  <tr><td>Target completion date</td><td>31 December 2050</td></tr>
+  <tr><td>Status</td><td>COMPLETED</td></tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-100">Notes</td>
+  </tr>
+  <tr>
+    <td>Chris would like to improve his listening skills, not just his verbal communication</td>
+  </tr>
+</table>
+<table class="summary-list">
+  <tr><td>Reason for archiving</td><td>No Data Held</td></tr>
+  <tr><td>Archive reason Other</td><td>No Data Held</td></tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-100">Archived goal note</td>
+  </tr>
+  <tr>
+    <td>No Data Held</td>
+  </tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-100">Goal completion note</td>
+  </tr>
+  <tr>
+    <td>Goal completed on time</td>
+  </tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-15">Step</td>
+    <td class="data-column-25">Status</td>
+    <td class="data-column-60">Title</td>
+  </tr>
+  <tr>
+    <td>1</td>
+    <td>COMPLETE</td>
+    <td>Book communication skills course</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>COMPLETE</td>
+    <td>Complete communication skills course</td>
+  </tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-30">Created by</td>
+    <td class="data-column-35">Created at</td>
+    <td class="data-column-30">Created at prison</td>
+  </tr>
+  <tr>
+    <td>Johnson</td>
+    <td>21 March 2026, 9:43:27 am</td>
+    <td>Moorland (HMP &amp; YOI)</td>
+  </tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-30">Updated by</td>
+    <td class="data-column-35">Updated at</td>
+    <td class="data-column-30">Updated at prison</td>
+  </tr>
+  <tr>
+    <td>Johnson</td>
+    <td>21 March 2026, 9:43:27 am</td>
+    <td>Moorland (HMP &amp; YOI)</td>
+  </tr>
+</table>
+<br>
 
+<h3>Goal</h3>
+<table class="summary-list">
+  <tr><td>Title</td><td>Goal 3</td></tr>
+  <tr><td>Target completion date</td><td>31 December 2050</td></tr>
+  <tr><td>Status</td><td>ARCHIVED</td></tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-100">Notes</td>
+  </tr>
+  <tr>
+    <td>Chris would like to improve his listening skills, not just his verbal communication</td>
+  </tr>
+</table>
+<table class="summary-list">
+  <tr><td>Reason for archiving</td><td>No Data Held</td></tr>
+  <tr><td>Archive reason Other</td><td>No Data Held</td></tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-100">Archived goal note</td>
+  </tr>
+  <tr>
+    <td>Goal archived as no longer appropriate</td>
+  </tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-100">Goal completion note</td>
+  </tr>
+  <tr>
+    <td>No Data Held</td>
+  </tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-15">Step</td>
+    <td class="data-column-25">Status</td>
+    <td class="data-column-60">Title</td>
+  </tr>
+  <tr>
+    <td>1</td>
+    <td>NOT_STARTED</td>
+    <td>Book communication skills course</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>NOT_STARTED</td>
+    <td>Complete communication skills course</td>
+  </tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-30">Created by</td>
+    <td class="data-column-35">Created at</td>
+    <td class="data-column-30">Created at prison</td>
+  </tr>
+  <tr>
+    <td>Johnson</td>
+    <td>21 March 2026, 9:43:27 am</td>
+    <td>Moorland (HMP &amp; YOI)</td>
+  </tr>
+</table>
+<table class="data-table">
+  <tr>
+    <td class="data-column-30">Updated by</td>
+    <td class="data-column-35">Updated at</td>
+    <td class="data-column-30">Updated at prison</td>
+  </tr>
+  <tr>
+    <td>Johnson</td>
+    <td>21 March 2026, 9:43:27 am</td>
+    <td>Moorland (HMP &amp; YOI)</td>
+  </tr>
+</table>
+<br>
 
 <br/>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/GoalController.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.domain.personallearningplan.Goal
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.GetGoalsDto
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.service.GoalService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.GoalResourceMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.toGoalStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.GoalReferenceMatchesReferenceInUpdateGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.validator.PRISON_NUMBER_FORMAT
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ScheduleAdapter
@@ -185,5 +186,5 @@ class GoalController(
   }
 
   // convert from the generated enum to the one we use in persistence
-  private fun convertStatuses(statuses: Set<GoalStatus>?) = statuses?.map { status -> goalResourceMapper.toGoalStatus(status) }?.toSet()
+  private fun convertStatuses(statuses: Set<GoalStatus>?) = statuses?.map { status -> toGoalStatus(status) }?.toSet()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalArchiveReasonMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalArchiveReasonMapper.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan
+
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.ReasonToArchiveGoal as ReasonToArchiveGoalDomain
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonToArchiveGoal as ReasonToArchiveGoalApi
+
+fun toReasonToArchiveGoal(reason: ReasonToArchiveGoalApi): ReasonToArchiveGoalDomain = when (reason) {
+  ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL -> ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL
+  ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG -> ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG
+  ReasonToArchiveGoalApi.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON -> ReasonToArchiveGoalDomain.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON
+  ReasonToArchiveGoalApi.OTHER -> ReasonToArchiveGoalDomain.OTHER
+}
+
+fun toReasonToArchiveGoal(reason: ReasonToArchiveGoalDomain): ReasonToArchiveGoalApi = when (reason) {
+  ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL -> ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL
+  ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG -> ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG
+  ReasonToArchiveGoalDomain.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON -> ReasonToArchiveGoalApi.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON
+  ReasonToArchiveGoalDomain.OTHER -> ReasonToArchiveGoalApi.OTHER
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalResourceMapper.kt
@@ -18,9 +18,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalR
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UnarchiveGoalRequest
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.UpdateGoalRequest
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus as GoalStatusDomain
-import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.ReasonToArchiveGoal as ReasonToArchiveGoalDomain
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus as GoalStatusApi
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonToArchiveGoal as ReasonToArchiveGoalApi
 
 @Component
 class GoalResourceMapper(
@@ -85,30 +82,4 @@ class GoalResourceMapper(
   fun fromModelToDto(unarchiveGoalRequest: UnarchiveGoalRequest): UnarchiveGoalDto = UnarchiveGoalDto(reference = unarchiveGoalRequest.goalReference, prisonId = unarchiveGoalRequest.prisonId)
 
   fun fromModelToDto(completeGoalRequest: CompleteGoalRequest): CompleteGoalDto = CompleteGoalDto(reference = completeGoalRequest.goalReference, prisonId = completeGoalRequest.prisonId)
-
-  fun toGoalStatus(status: GoalStatusApi): GoalStatusDomain = when (status) {
-    GoalStatusApi.ACTIVE -> GoalStatusDomain.ACTIVE
-    GoalStatusApi.COMPLETED -> GoalStatusDomain.COMPLETED
-    GoalStatusApi.ARCHIVED -> GoalStatusDomain.ARCHIVED
-  }
-
-  private fun toGoalStatus(status: GoalStatusDomain): GoalStatusApi = when (status) {
-    GoalStatusDomain.ACTIVE -> GoalStatusApi.ACTIVE
-    GoalStatusDomain.COMPLETED -> GoalStatusApi.COMPLETED
-    GoalStatusDomain.ARCHIVED -> GoalStatusApi.ARCHIVED
-  }
-
-  private fun toReasonToArchiveGoal(reason: ReasonToArchiveGoalApi): ReasonToArchiveGoalDomain = when (reason) {
-    ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL -> ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL
-    ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG -> ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG
-    ReasonToArchiveGoalApi.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON -> ReasonToArchiveGoalDomain.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON
-    ReasonToArchiveGoalApi.OTHER -> ReasonToArchiveGoalDomain.OTHER
-  }
-
-  private fun toReasonToArchiveGoal(reason: ReasonToArchiveGoalDomain): ReasonToArchiveGoalApi = when (reason) {
-    ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL -> ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL
-    ReasonToArchiveGoalDomain.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG -> ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG
-    ReasonToArchiveGoalDomain.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON -> ReasonToArchiveGoalApi.SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON
-    ReasonToArchiveGoalDomain.OTHER -> ReasonToArchiveGoalApi.OTHER
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalStatusMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/actionplan/GoalStatusMapper.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan
+
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus as GoalStatusDomain
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus as GoalStatusApi
+
+fun toGoalStatus(status: GoalStatusApi): GoalStatusDomain = when (status) {
+  GoalStatusApi.ACTIVE -> GoalStatusDomain.ACTIVE
+  GoalStatusApi.COMPLETED -> GoalStatusDomain.COMPLETED
+  GoalStatusApi.ARCHIVED -> GoalStatusDomain.ARCHIVED
+}
+
+fun toGoalStatus(status: GoalStatusDomain): GoalStatusApi = when (status) {
+  GoalStatusDomain.ACTIVE -> GoalStatusApi.ACTIVE
+  GoalStatusDomain.COMPLETED -> GoalStatusApi.COMPLETED
+  GoalStatusDomain.ARCHIVED -> GoalStatusApi.ARCHIVED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/sar/SarGoalResourceMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/sar/SarGoalResourceMapper.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.sar
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteDto
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteType
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.Goal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.StepResourceMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.toGoalStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.toReasonToArchiveGoal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ManageUserService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SarGoalResponse
+
+@Component
+class SarGoalResourceMapper(
+  private val stepResourceMapper: StepResourceMapper,
+  private val instantMapper: InstantMapper,
+  private val userService: ManageUserService,
+) {
+
+  fun fromDomainToModel(goalDomain: Goal, goalDomainNotes: List<NoteDto>): SarGoalResponse = with(goalDomain) {
+    SarGoalResponse(
+      title = title,
+      steps = steps.map { stepResourceMapper.fromDomainToModel(it) },
+      targetCompletionDate = targetCompletionDate,
+      status = toGoalStatus(status),
+      goalNote = goalDomainNotes
+        .sortedBy { it.createdAt }
+        .findLast { it.noteType == NoteType.GOAL }?.content,
+      goalCompletionNote = goalDomainNotes
+        .sortedBy { it.createdAt }
+        .findLast { it.noteType == NoteType.GOAL_COMPLETION }?.content,
+      goalArchiveReason = archiveReason?.let { toReasonToArchiveGoal(it) },
+      goalArchiveReasonOther = archiveReasonOther,
+      goalArchiveNote = goalDomainNotes
+        .sortedBy { it.createdAt }
+        .findLast { it.noteType == NoteType.GOAL_ARCHIVAL }?.content,
+      createdBy = createdBy!!,
+      createdByDisplayName = userService.getUserDetails(createdBy!!).name,
+      createdAt = instantMapper.toOffsetDateTime(createdAt)!!,
+      createdAtPrison = createdAtPrison,
+      updatedBy = lastUpdatedBy!!,
+      updatedByDisplayName = userService.getUserDetails(lastUpdatedBy!!).name,
+      updatedAt = instantMapper.toOffsetDateTime(lastUpdatedAt)!!,
+      updatedAtPrison = lastUpdatedAtPrison,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestService.kt
@@ -13,12 +13,12 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.servic
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewService
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.ActionPlanNotFoundException
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.service.ActionPlanService
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.GoalResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.education.EducationResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.InductionHistoryScheduleResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.InductionResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.review.CompletedActionPlanReviewResponseMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.review.ReviewScheduleHistoryResponseMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.sar.SarGoalResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SubjectAccessRequestContent
 import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonSubjectAccessRequestService
 import uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestContent
@@ -32,7 +32,7 @@ class SubjectAccessRequestService(
   private val actionPlanService: ActionPlanService,
   private val noteService: NoteService,
   private val inductionMapper: InductionResourceMapper,
-  private val goalMapper: GoalResourceMapper,
+  private val sarGoalMapper: SarGoalResourceMapper,
   private val educationService: EducationService,
   private val educationResourceMapper: EducationResourceMapper,
   private val reviewService: ReviewService,
@@ -85,8 +85,8 @@ class SubjectAccessRequestService(
         induction = induction?.let { inductionMapper.toInductionResponse(induction, employabilitySkills) },
         goals = goals.map {
           val goalNotes = noteService.getNotes(it.reference, EntityType.GOAL)
-          goalMapper.fromDomainToModel(it, goalNotes)
-        }.toSet(),
+          sarGoalMapper.fromDomainToModel(it, goalNotes)
+        },
         education = education?.let {
           educationResourceMapper.toEducationResponse(it)
         },

--- a/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
+++ b/src/main/resources/static/openapi/EducationAndWorkPlanAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Education and Work Plan API
-  version: '1.33.0'
+  version: '1.34.0'
   description: Education and Work Plan API
   contact:
     name: Learning and Work Progress team
@@ -998,7 +998,7 @@ components:
         targetCompletionDate:
           type: string
           format: date
-          description: An optional ISO-8601 date representing the target completion date of the Goal.
+          description: An ISO-8601 date representing the target completion date of the Goal.
           example: '2023-12-19'
         status:
           $ref: '#/components/schemas/GoalStatus'
@@ -2769,10 +2769,9 @@ components:
         induction:
           $ref: '#/components/schemas/InductionResponse'
         goals:
-          uniqueItems: true
           type: array
           items:
-            $ref: '#/components/schemas/GoalResponse'
+            $ref: '#/components/schemas/SarGoalResponse'
         education:
           $ref: '#/components/schemas/EducationResponse'
         completedReviews:
@@ -2790,6 +2789,61 @@ components:
           description: A List containing zero or more Review Schedule Records.
           items:
             $ref: '#/components/schemas/ScheduledActionPlanReviewResponse'
+
+    SarGoalResponse:
+      title: SarGoalResponse
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/AuditedResource'
+      description: An individual Goal that a Prisoner aims to complete as part of their Action Plan. Modelled specifically for the Subject Access Request endpoint.
+      properties:
+        title:
+          type: string
+          description: A title explaining the aim of the goal.
+          example: Improve communication skills
+        targetCompletionDate:
+          type: string
+          format: date
+          description: An ISO-8601 date representing the target completion date of the Goal.
+          example: '2023-12-19'
+        status:
+          $ref: '#/components/schemas/GoalStatus'
+        steps:
+          type: array
+          minItems: 1
+          description: A List of at least one Step.
+          items:
+            $ref: '#/components/schemas/StepResponse'
+        goalNote:
+          type: string
+          description: Some additional notes related to the Goal. This is an optional field and may not be present for all Goals.
+          example: Pay close attention to Peter's behaviour.
+        goalCompletionNote:
+          type: string
+          description: Notes entered at the time the Goal was completed. This field is only present for Goals that have been completed (see status field).
+          example: Peter has completed this goal.
+        goalArchiveReason:
+          $ref: '#/components/schemas/ReasonToArchiveGoal'
+        goalArchiveReasonOther:
+          type: string
+          description: Describes the reason for archiving if 'OTHER' is selected. This field it is only present in this scenario.
+        goalArchiveNote:
+          type: string
+          description: Notes entered at the time the Goal was archived. This field is only present for Goals that have been archived (see status field).
+          example: This goal is no longer appropriate or achievable now that Peter has been transferred.
+      required:
+        - title
+        - targetCompletionDate
+        - status
+        - steps
+        - createdBy
+        - createdByDisplayName
+        - createdAt
+        - createdAtPrison
+        - updatedBy
+        - updatedByDisplayName
+        - updatedAt
+        - updatedAtPrison
 
     SarSuccessResponse:
       properties:

--- a/src/main/resources/static/sar/template.mustache
+++ b/src/main/resources/static/sar/template.mustache
@@ -178,7 +178,27 @@
             <td class="data-column-100">Notes</td>
         </tr>
         <tr>
-            <td>{{ optionalValue notes }}</td>
+            <td>{{ optionalValue goalNote }}</td>
+        </tr>
+    </table>
+    <table class="summary-list">
+        <tr><td>Reason for archiving</td><td>{{ optionalValue archiveReason }}</td></tr>
+        <tr><td>Archive reason Other</td><td>{{ optionalValue archiveReasonOther }}</td></tr>
+    </table>
+    <table class="data-table">
+        <tr>
+            <td class="data-column-100">Archived goal note</td>
+        </tr>
+        <tr>
+            <td>{{ optionalValue goalArchiveNote }}</td>
+        </tr>
+    </table>
+    <table class="data-table">
+        <tr>
+            <td class="data-column-100">Goal completion note</td>
+        </tr>
+        <tr>
+            <td>{{ optionalValue goalCompletionNote }}</td>
         </tr>
     </table>
 
@@ -197,6 +217,31 @@
         {{/steps}}
     </table>
 
+    <table class="data-table">
+        <tr>
+            <td class="data-column-30">Created by</td>
+            <td class="data-column-35">Created at</td>
+            <td class="data-column-30">Created at prison</td>
+        </tr>
+        <tr>
+            <td>{{ getUserLastName createdBy }}</td>
+            <td>{{ optionalValue (formatDate createdAt) }}</td>
+            <td>{{ getPrisonName createdAtPrison }}</td>
+        </tr>
+    </table>
+    <table class="data-table">
+        <tr>
+            <td class="data-column-30">Updated by</td>
+            <td class="data-column-35">Updated at</td>
+            <td class="data-column-30">Updated at prison</td>
+        </tr>
+        <tr>
+            <td>{{ getUserLastName updatedBy }}</td>
+            <td>{{ optionalValue (formatDate updatedAt) }}</td>
+            <td>{{ getPrisonName updatedAtPrison }}</td>
+        </tr>
+    </table>
+    <br>
 {{/goals}}
 {{^goals}}
     <p>No Data Held</p>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/sar/SarGoalResourceMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/mapper/sar/SarGoalResourceMapperTest.kt
@@ -1,0 +1,274 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.sar
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.EntityType
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.NoteType
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.dto.aValidNoteDto
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidGoal
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidStep
+import uk.gov.justice.digital.hmpps.domain.personallearningplan.dto.ReasonToArchiveGoal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.client.manageusers.UserDetailsDto
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.InstantMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.StepResourceMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.ManageUserService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidStepResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.sar.aValidSarGoalResponse
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus as GoalStatusApi
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonToArchiveGoal as ReasonToArchiveGoalApi
+
+@ExtendWith(MockitoExtension::class)
+internal class SarGoalResourceMapperTest {
+
+  @InjectMocks
+  private lateinit var mapper: SarGoalResourceMapper
+
+  @Mock
+  private lateinit var stepMapper: StepResourceMapper
+
+  @Mock
+  private lateinit var instantMapper: InstantMapper
+
+  @Mock
+  private lateinit var userService: ManageUserService
+
+  @Test
+  fun `should map from domain to model given an active goal`() {
+    // Given
+    val step = aValidStep()
+    val goal = aValidGoal(
+      status = GoalStatus.ACTIVE,
+      targetCompletionDate = LocalDate.now().plusMonths(6),
+      steps = mutableListOf(step),
+      createdBy = "asmith_gen",
+      createdAtPrison = "BXI",
+      lastUpdatedBy = "bjones_gen",
+      lastUpdatedAtPrison = "MDI",
+    )
+
+    val goalNote1 = aValidNoteDto(
+      content = "Note 1",
+      entityReference = goal.reference,
+      entityType = EntityType.GOAL,
+      createdAt = Instant.now().minusSeconds(60),
+    )
+    val goalNote2 = aValidNoteDto(
+      content = "Note 2",
+      entityReference = goal.reference,
+      entityType = EntityType.GOAL,
+      createdAt = Instant.now(),
+    )
+    val goalNotes = listOf(goalNote1, goalNote2)
+
+    val expectedStepResponse = aValidStepResponse()
+    val expectedDateTime = OffsetDateTime.now()
+    given(stepMapper.fromDomainToModel(any())).willReturn(expectedStepResponse)
+    given(instantMapper.toOffsetDateTime(any())).willReturn(expectedDateTime)
+
+    given(userService.getUserDetails(any())).willReturn(
+      UserDetailsDto("asmith_gen", true, "Alex Smith"),
+      UserDetailsDto("bjones_gen", true, "Barry Jones"),
+    )
+
+    val expected = aValidSarGoalResponse(
+      title = goal.title,
+      targetCompletionDate = goal.targetCompletionDate,
+      status = GoalStatusApi.ACTIVE,
+      goalNote = "Note 2",
+      completionNote = null,
+      archiveReason = null,
+      archiveReasonOther = null,
+      archiveNote = null,
+      steps = listOf(expectedStepResponse),
+      createdAt = expectedDateTime,
+      createdAtPrison = "BXI",
+      createdBy = "asmith_gen",
+      createdByDisplayName = "Alex Smith",
+      updatedAt = expectedDateTime,
+      updatedAtPrison = "MDI",
+      updatedBy = "bjones_gen",
+      updatedByDisplayName = "Barry Jones",
+    )
+
+    // When
+    val actual = mapper.fromDomainToModel(goal, goalNotes)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+    verify(stepMapper).fromDomainToModel(step)
+    verify(userService).getUserDetails("asmith_gen")
+    verify(userService).getUserDetails("bjones_gen")
+  }
+
+  @Test
+  fun `should map from domain to model given an archived goal`() {
+    // Given
+    val step = aValidStep()
+    val goal = aValidGoal(
+      status = GoalStatus.ARCHIVED,
+      targetCompletionDate = LocalDate.now().plusMonths(6),
+      steps = mutableListOf(step),
+      archiveReason = ReasonToArchiveGoal.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL,
+      createdBy = "asmith_gen",
+      createdAtPrison = "BXI",
+      lastUpdatedBy = "bjones_gen",
+      lastUpdatedAtPrison = "MDI",
+    )
+
+    val goalNote1 = aValidNoteDto(
+      content = "Note 1",
+      entityReference = goal.reference,
+      entityType = EntityType.GOAL,
+      noteType = NoteType.GOAL,
+      createdAt = Instant.now().minusSeconds(60),
+    )
+    val goalNote2 = aValidNoteDto(
+      content = "Note 2",
+      entityReference = goal.reference,
+      entityType = EntityType.GOAL,
+      noteType = NoteType.GOAL,
+      createdAt = Instant.now(),
+    )
+    val archivedNote1 = aValidNoteDto(
+      content = "Archive Note 1",
+      entityReference = goal.reference,
+      entityType = EntityType.GOAL,
+      noteType = NoteType.GOAL_ARCHIVAL,
+      createdAt = Instant.now().minusSeconds(30),
+    )
+    val archivedNote2 = aValidNoteDto(
+      content = "Archive Note 2",
+      entityReference = goal.reference,
+      entityType = EntityType.GOAL,
+      noteType = NoteType.GOAL_ARCHIVAL,
+      createdAt = Instant.now(),
+    )
+    val goalNotes = listOf(goalNote1, goalNote2, archivedNote1, archivedNote2)
+
+    val expectedStepResponse = aValidStepResponse()
+    val expectedDateTime = OffsetDateTime.now()
+    given(stepMapper.fromDomainToModel(any())).willReturn(expectedStepResponse)
+    given(instantMapper.toOffsetDateTime(any())).willReturn(expectedDateTime)
+
+    given(userService.getUserDetails(any())).willReturn(
+      UserDetailsDto("asmith_gen", true, "Alex Smith"),
+      UserDetailsDto("bjones_gen", true, "Barry Jones"),
+    )
+
+    val expected = aValidSarGoalResponse(
+      title = goal.title,
+      targetCompletionDate = goal.targetCompletionDate,
+      status = GoalStatusApi.ARCHIVED,
+      goalNote = "Note 2",
+      completionNote = null,
+      archiveReason = ReasonToArchiveGoalApi.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL,
+      archiveReasonOther = null,
+      archiveNote = "Archive Note 2",
+      steps = listOf(expectedStepResponse),
+      createdAt = expectedDateTime,
+      createdAtPrison = "BXI",
+      createdBy = "asmith_gen",
+      createdByDisplayName = "Alex Smith",
+      updatedAt = expectedDateTime,
+      updatedAtPrison = "MDI",
+      updatedBy = "bjones_gen",
+      updatedByDisplayName = "Barry Jones",
+    )
+
+    // When
+    val actual = mapper.fromDomainToModel(goal, goalNotes)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+    verify(stepMapper).fromDomainToModel(step)
+    verify(userService).getUserDetails("asmith_gen")
+    verify(userService).getUserDetails("bjones_gen")
+  }
+
+  @Test
+  fun `should map from domain to model given a completed goal`() {
+    // Given
+    val step = aValidStep()
+    val goal = aValidGoal(
+      status = GoalStatus.COMPLETED,
+      targetCompletionDate = LocalDate.now().plusMonths(6),
+      steps = mutableListOf(step),
+      createdBy = "asmith_gen",
+      createdAtPrison = "BXI",
+      lastUpdatedBy = "bjones_gen",
+      lastUpdatedAtPrison = "MDI",
+    )
+
+    val goalNote1 = aValidNoteDto(
+      content = "Note 1",
+      entityReference = goal.reference,
+      entityType = EntityType.GOAL,
+      noteType = NoteType.GOAL,
+      createdAt = Instant.now().minusSeconds(60),
+    )
+    val goalNote2 = aValidNoteDto(
+      content = "Note 2",
+      entityReference = goal.reference,
+      entityType = EntityType.GOAL,
+      noteType = NoteType.GOAL,
+      createdAt = Instant.now(),
+    )
+    val completionNote = aValidNoteDto(
+      content = "Completion Note 1",
+      entityReference = goal.reference,
+      entityType = EntityType.GOAL,
+      noteType = NoteType.GOAL_COMPLETION,
+    )
+    val goalNotes = listOf(goalNote1, goalNote2, completionNote)
+
+    val expectedStepResponse = aValidStepResponse()
+    val expectedDateTime = OffsetDateTime.now()
+    given(stepMapper.fromDomainToModel(any())).willReturn(expectedStepResponse)
+    given(instantMapper.toOffsetDateTime(any())).willReturn(expectedDateTime)
+
+    given(userService.getUserDetails(any())).willReturn(
+      UserDetailsDto("asmith_gen", true, "Alex Smith"),
+      UserDetailsDto("bjones_gen", true, "Barry Jones"),
+    )
+
+    val expected = aValidSarGoalResponse(
+      title = goal.title,
+      targetCompletionDate = goal.targetCompletionDate,
+      status = GoalStatusApi.COMPLETED,
+      goalNote = "Note 2",
+      completionNote = "Completion Note 1",
+      archiveReason = null,
+      archiveReasonOther = null,
+      archiveNote = null,
+      steps = listOf(expectedStepResponse),
+      createdAt = expectedDateTime,
+      createdAtPrison = "BXI",
+      createdBy = "asmith_gen",
+      createdByDisplayName = "Alex Smith",
+      updatedAt = expectedDateTime,
+      updatedAtPrison = "MDI",
+      updatedBy = "bjones_gen",
+      updatedByDisplayName = "Barry Jones",
+    )
+
+    // When
+    val actual = mapper.fromDomainToModel(goal, goalNotes)
+
+    // Then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+    verify(stepMapper).fromDomainToModel(step)
+    verify(userService).getUserDetails("asmith_gen")
+    verify(userService).getUserDetails("bjones_gen")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestServiceTest.kt
@@ -29,23 +29,22 @@ import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidActionPlan
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.aValidGoal
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.service.ActionPlanService
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.actionplan.GoalResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.education.EducationResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.InductionHistoryScheduleResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.induction.InductionResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.review.CompletedActionPlanReviewResponseMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.review.ReviewScheduleHistoryResponseMapper
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.mapper.sar.SarGoalResourceMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationLevel
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SubjectAccessRequestContent
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidGoalResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.aValidEducationResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidEmployabilitySkillResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidInductionResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidInductionResponseForPrisonerNotLookingToWork
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidInductionScheduleResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidReviewScheduleResponse
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.note.aValidNoteResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.aValidCompletedActionPlanReviewResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.sar.aValidSarGoalResponse
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -73,7 +72,7 @@ class SubjectAccessRequestServiceTest {
   private lateinit var inductionMapper: InductionResourceMapper
 
   @Mock
-  private lateinit var goalMapper: GoalResourceMapper
+  private lateinit var sarGoalMapper: SarGoalResourceMapper
 
   @Mock
   private lateinit var educationService: EducationService
@@ -130,15 +129,15 @@ class SubjectAccessRequestServiceTest {
     given(noteService.getNotes(goal1.reference, EntityType.GOAL)).willReturn(listOf(note1ForGoal1))
     given(noteService.getNotes(goal2.reference, EntityType.GOAL)).willReturn(listOf(note1ForGoal2, note2ForGoal2))
 
-    val expectedGoalResponse1 = aValidGoalResponse(
+    val expectedGoalResponse1 = aValidSarGoalResponse(
       title = "Goal 1",
-      goalNotes = listOf(aValidNoteResponse(content = "Note 1 for Goal 1")),
+      goalNote = "Note 1 for Goal 1",
     )
-    val expectedGoalResponse2 = aValidGoalResponse(
+    val expectedGoalResponse2 = aValidSarGoalResponse(
       title = "Goal 2",
-      goalNotes = listOf(aValidNoteResponse(content = "Note 1 for Goal 2"), aValidNoteResponse(content = "Note 2 for Goal 2")),
+      goalNote = "Note 2 for Goal 2",
     )
-    given(goalMapper.fromDomainToModel(any(), any())).willReturn(expectedGoalResponse1, expectedGoalResponse2)
+    given(sarGoalMapper.fromDomainToModel(any(), any())).willReturn(expectedGoalResponse1, expectedGoalResponse2)
 
     // When
     val sarResponse = subjectAccessRequestService.getPrisonContentFor(prisonNumber, null, null)
@@ -150,15 +149,15 @@ class SubjectAccessRequestServiceTest {
     verify(inductionMapper).toInductionResponse(induction, employabilitySkills)
 
     verify(actionPlanService).getActionPlan(prisonNumber)
-    verify(goalMapper).fromDomainToModel(goal1, listOf(note1ForGoal1))
-    verify(goalMapper).fromDomainToModel(goal2, listOf(note1ForGoal2, note2ForGoal2))
+    verify(sarGoalMapper).fromDomainToModel(goal1, listOf(note1ForGoal1))
+    verify(sarGoalMapper).fromDomainToModel(goal2, listOf(note1ForGoal2, note2ForGoal2))
 
     verify(noteService).getNotes(goal1.reference, EntityType.GOAL)
     verify(noteService).getNotes(goal2.reference, EntityType.GOAL)
 
     with(sarContent) {
       assertThat(this.induction).isEqualTo(expectedInductionResponse)
-      assertThat(goals).isEqualTo(setOf(expectedGoalResponse1, expectedGoalResponse2))
+      assertThat(goals).isEqualTo(listOf(expectedGoalResponse1, expectedGoalResponse2))
     }
   }
 
@@ -181,11 +180,11 @@ class SubjectAccessRequestServiceTest {
     val note1ForGoal2 = aValidNoteDto(content = "Note 1 for Goal 2", entityReference = goal2.reference, entityType = EntityType.GOAL)
     given(noteService.getNotes(goal2.reference, EntityType.GOAL)).willReturn(listOf(note1ForGoal2))
 
-    val expectedGoalResponse2 = aValidGoalResponse(
+    val expectedGoalResponse2 = aValidSarGoalResponse(
       title = "Goal 2",
-      goalNotes = listOf(aValidNoteResponse(content = "Note 1 for Goal 2")),
+      goalNote = "Note 1 for Goal 2",
     )
-    given(goalMapper.fromDomainToModel(any(), any())).willReturn(expectedGoalResponse2)
+    given(sarGoalMapper.fromDomainToModel(any(), any())).willReturn(expectedGoalResponse2)
 
     // When
     val fromDate = LocalDate.parse("2024-01-15")
@@ -197,7 +196,7 @@ class SubjectAccessRequestServiceTest {
     verify(inductionMapper, never()).toInductionResponse(any(), any())
 
     verify(actionPlanService).getActionPlan(prisonNumber)
-    verify(goalMapper).fromDomainToModel(goal2, listOf(note1ForGoal2))
+    verify(sarGoalMapper).fromDomainToModel(goal2, listOf(note1ForGoal2))
 
     verify(noteService).getNotes(goal2.reference, EntityType.GOAL)
 
@@ -205,7 +204,7 @@ class SubjectAccessRequestServiceTest {
 
     with(sarContent) {
       assertThat(this.induction).isNull()
-      assertThat(goals).isEqualTo(setOf(expectedGoalResponse2))
+      assertThat(goals).isEqualTo(listOf(expectedGoalResponse2))
     }
   }
 
@@ -246,8 +245,8 @@ class SubjectAccessRequestServiceTest {
 
     given(noteService.getNotes(any(), any())).willReturn(emptyList())
 
-    val expectedGoalResponse1 = aValidGoalResponse(goalNotes = emptyList())
-    given(goalMapper.fromDomainToModel(any(), any())).willReturn(expectedGoalResponse1)
+    val expectedGoalResponse1 = aValidSarGoalResponse(goalNote = null)
+    given(sarGoalMapper.fromDomainToModel(any(), any())).willReturn(expectedGoalResponse1)
 
     val inductionScheduleHistory = aValidInductionScheduleHistory()
     given(inductionScheduleService.getInductionScheduleHistoryForPrisoner(prisonNumber)).willReturn(
@@ -275,13 +274,13 @@ class SubjectAccessRequestServiceTest {
     verify(inductionMapper).toInductionResponse(induction, employabilitySkills)
 
     verify(actionPlanService).getActionPlan(prisonNumber)
-    verify(goalMapper).fromDomainToModel(goal1, emptyList())
+    verify(sarGoalMapper).fromDomainToModel(goal1, emptyList())
 
     verify(noteService).getNotes(goal1.reference, EntityType.GOAL)
 
     with(sarContent) {
       assertThat(this.induction).isEqualTo(expectedInductionResponse)
-      assertThat(goals).isEqualTo(setOf(expectedGoalResponse1))
+      assertThat(goals).isEqualTo(listOf(expectedGoalResponse1))
       assertThat(education).isEqualTo(expectedEducationResponse)
       assertThat(this.inductionScheduleHistory?.size).isEqualTo(1)
       assertThat(this.reviewScheduleHistory?.size).isEqualTo(1)
@@ -308,8 +307,8 @@ class SubjectAccessRequestServiceTest {
 
     given(noteService.getNotes(any(), any())).willReturn(emptyList())
 
-    val expectedGoalResponse2 = aValidGoalResponse(title = "Goal 2", goalNotes = emptyList())
-    given(goalMapper.fromDomainToModel(any(), any())).willReturn(expectedGoalResponse2)
+    val expectedGoalResponse2 = aValidSarGoalResponse(title = "Goal 2", goalNote = null)
+    given(sarGoalMapper.fromDomainToModel(any(), any())).willReturn(expectedGoalResponse2)
 
     // When
     val fromDate = LocalDate.parse("2024-02-01")
@@ -324,13 +323,13 @@ class SubjectAccessRequestServiceTest {
     verify(inductionMapper, never()).toInductionResponse(any(), any())
 
     verify(actionPlanService).getActionPlan(prisonNumber)
-    verify(goalMapper).fromDomainToModel(goal2, emptyList())
+    verify(sarGoalMapper).fromDomainToModel(goal2, emptyList())
 
     verify(noteService).getNotes(goal2.reference, EntityType.GOAL)
 
     with(sarContent) {
       assertThat(this.induction).isNull()
-      assertThat(goals).isEqualTo(setOf(expectedGoalResponse2))
+      assertThat(goals).isEqualTo(listOf(expectedGoalResponse2))
     }
   }
 
@@ -353,7 +352,7 @@ class SubjectAccessRequestServiceTest {
     verify(employabilitySkillsService).getEmployabilitySkills(prisonNumber)
 
     verify(actionPlanService).getActionPlan(prisonNumber)
-    verify(goalMapper, never()).fromDomainToModel(any(), any())
+    verify(sarGoalMapper, never()).fromDomainToModel(any(), any())
 
     verify(noteService, never()).getNotes(any(), any())
 

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/sar/SarGoalResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/sar/SarGoalResponseAssert.kt
@@ -1,0 +1,264 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.sar
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonToArchiveGoal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SarGoalResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.StepStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.StepResponseAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.assertThat
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.function.Consumer
+
+fun assertThat(actual: SarGoalResponse?) = SarGoalResponseAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [SarGoalResponse]
+ */
+class SarGoalResponseAssert(actual: SarGoalResponse?) : AbstractObjectAssert<SarGoalResponseAssert, SarGoalResponse?>(actual, SarGoalResponseAssert::class.java) {
+
+  fun wasCreatedBy(expected: String): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdBy != expected) {
+        failWithMessage("Expected createdBy to be $expected, but was $createdBy")
+      }
+    }
+    return this
+  }
+
+  fun hasCreatedByDisplayName(expected: String): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdByDisplayName != expected) {
+        failWithMessage("Expected createdByDisplayName to be $expected, but was $createdByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAt(expected: OffsetDateTime): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAt != expected) {
+        failWithMessage("Expected createdAt to be $expected, but was $createdAt")
+      }
+    }
+    return this
+  }
+
+  fun wasCreatedAtPrison(expected: String): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (createdAtPrison != expected) {
+        failWithMessage("Expected createdAtPrison to be $expected, but was $createdAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedBy(expected: String): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedBy != expected) {
+        failWithMessage("Expected updatedBy to be $expected, but was $updatedBy")
+      }
+    }
+    return this
+  }
+
+  fun hasUpdatedByDisplayName(expected: String): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedByDisplayName != expected) {
+        failWithMessage("Expected updatedByDisplayName to be $expected, but was $updatedByDisplayName")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAt(expected: OffsetDateTime): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAt != expected) {
+        failWithMessage("Expected updatedAt to be $expected, but was $updatedAt")
+      }
+    }
+    return this
+  }
+
+  fun wasUpdatedAtPrison(expected: String): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (updatedAtPrison != expected) {
+        failWithMessage("Expected updatedAtPrison to be $expected, but was $updatedAtPrison")
+      }
+    }
+    return this
+  }
+
+  fun hasTitle(expected: String): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (title != expected) {
+        failWithMessage("Expected title to be $expected, but was $title")
+      }
+    }
+    return this
+  }
+
+  fun hasTargetCompletionDate(expected: LocalDate): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (targetCompletionDate != expected) {
+        failWithMessage("Expected targetCompletionDate to be $expected, but was $targetCompletionDate")
+      }
+    }
+    return this
+  }
+
+  fun hasNumberOfSteps(expected: Int): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (steps.size != expected) {
+        failWithMessage("Expected goal to have $expected Steps, but was ${steps.size}")
+      }
+    }
+    return this
+  }
+
+  fun hasNoGoalNote(): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!goalNote.isNullOrBlank()) {
+        failWithMessage("Expected goal to have no goal notes, but had note $goalNote")
+      }
+    }
+    return this
+  }
+
+  fun hasNoArchiveNote(): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!goalArchiveNote.isNullOrBlank()) {
+        failWithMessage("Expected goal to have no archive notes, but had note $goalArchiveNote")
+      }
+    }
+    return this
+  }
+
+  fun hasNoCompletedNote(): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (!goalCompletionNote.isNullOrBlank()) {
+        failWithMessage("Expected goal to have no completion notes, but had note $goalCompletionNote")
+      }
+    }
+    return this
+  }
+
+  fun hasCompletedSteps(): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val incompleteStepsCount = steps.count { it.status != StepStatus.COMPLETE }
+      if (incompleteStepsCount > 0) {
+        failWithMessage("Expected goal to have no incomplete steps, but there were $incompleteStepsCount")
+      }
+    }
+    return this
+  }
+
+  fun hasGoalNote(expected: String): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (goalNote != expected) {
+        failWithMessage("Expected goal to have goal note $expected, but was $goalNote")
+      }
+    }
+    return this
+  }
+
+  fun hasArchiveNote(expected: String): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (goalArchiveNote != expected) {
+        failWithMessage("Expected goal to have archive note $expected, but was $goalArchiveNote")
+      }
+    }
+    return this
+  }
+
+  fun hasCompletedNote(expected: String): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (goalCompletionNote != expected) {
+        failWithMessage("Expected goal to have completion note $expected, but was $goalCompletionNote")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [StepResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [StepResponseAssert].
+   * Returns this [SarGoalResponseAssert] to allow further chained assertions on the parent [SarGoalResponse]
+   *
+   * The `stepNumber` parameter is not zero indexed to make for better readability in tests. IE. the first step
+   * should be referenced as `.step(1) { .... }`
+   */
+  fun step(stepNumber: Int, consumer: Consumer<StepResponseAssert>): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val step = steps[stepNumber - 1]
+      consumer.accept(assertThat(step))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into all child [StepResponse]s. Takes a lambda as the method argument
+   * to call assertion methods provided by [SteoResponseAssert].
+   * Returns this [SarGoalResponseAssert] to allow further chained assertions on the parent [SarGoalResponse]
+   * The assertions on all [StepResponse]s must pass as true.
+   */
+  fun allSteps(consumer: Consumer<StepResponseAssert>): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      steps.onEach {
+        consumer.accept(assertThat(it))
+      }
+    }
+    return this
+  }
+
+  fun hasStatus(expected: GoalStatus): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (status != expected) {
+        failWithMessage("Expected goal to have status '$expected', but was $status")
+      }
+    }
+    return this
+  }
+
+  fun hasArchiveReason(expected: ReasonToArchiveGoal?): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (goalArchiveReason != expected) {
+        failWithMessage("Expected goal to have archive reason '$expected', but was $goalArchiveReason")
+      }
+    }
+    return this
+  }
+
+  fun hasArchiveReasonOther(expected: String?): SarGoalResponseAssert {
+    isNotNull
+    with(actual!!) {
+      if (goalArchiveReasonOther != expected) {
+        failWithMessage("Expected goal to have archive reason other '$expected', but was $goalArchiveReasonOther")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/sar/SarGoalResponseBuilder.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/sar/SarGoalResponseBuilder.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.sar
+
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.GoalStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.ReasonToArchiveGoal
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SarGoalResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.StepResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.aValidStepResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.actionplan.anotherValidStepResponse
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+fun aValidSarGoalResponse(
+  title: String = "Improve communication skills",
+  targetCompletionDate: LocalDate = LocalDate.now().plusMonths(6),
+  steps: List<StepResponse> = listOf(aValidStepResponse(), anotherValidStepResponse()),
+  status: GoalStatus = GoalStatus.ACTIVE,
+  goalNote: String? = "Chris would like to improve his listening skills, not just his verbal communication",
+  completionNote: String? = null,
+  archiveReason: ReasonToArchiveGoal? = null,
+  archiveReasonOther: String? = null,
+  archiveNote: String? = null,
+  createdBy: String = "asmith_gen",
+  createdByDisplayName: String = "Alex Smith",
+  createdAt: OffsetDateTime = OffsetDateTime.now(),
+  createdAtPrison: String = "BXI",
+  updatedBy: String = "asmith_gen",
+  updatedByDisplayName: String = "Alex Smith",
+  updatedAt: OffsetDateTime = OffsetDateTime.now(),
+  updatedAtPrison: String = "BXI",
+): SarGoalResponse = SarGoalResponse(
+  title = title,
+  targetCompletionDate = targetCompletionDate,
+  steps = steps,
+  status = status,
+  goalNote = goalNote,
+  goalCompletionNote = completionNote,
+  goalArchiveReason = archiveReason,
+  goalArchiveReasonOther = archiveReasonOther,
+  goalArchiveNote = archiveNote,
+  createdBy = createdBy,
+  createdByDisplayName = createdByDisplayName,
+  createdAt = createdAt,
+  createdAtPrison = createdAtPrison,
+  updatedBy = updatedBy,
+  updatedByDisplayName = updatedByDisplayName,
+  updatedAt = updatedAt,
+  updatedAtPrison = updatedAtPrison,
+)


### PR DESCRIPTION
PR to update the Goals section of the SAR report
See attached PDF for example report
[sar-generated-report.pdf](https://github.com/user-attachments/files/29057302/sar-generated-report.pdf)

This PR updates the Goals section in the SAR report. In order to do this I've had to add a new response type for Goals specifically for SAR, hence the change to the swagger spec. The new response type has the notes mapped in as 3 separate fields (goalNote, goalArchiveNote, and goalCompletionNote). I've had to do this because mustache is "logic-less" templating so cannot iterate and filter collections etc. I've had to do all of that in the service layer and mapper.
