### PR TITLE
RR-2682 - Fixed test

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/specialtests/resource/sar/SarReportGenerationTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/specialtests/resource/sar/SarReportGenerationTest.kt
@@ -52,27 +52,32 @@ class SarReportGenerationTest :
       createPrisonerAPIStub(prisonNumber, this)
     }
     val inductionScheduleReference = UUID.randomUUID()
+    val inductionDeadlineDate = LocalDate.parse("2026-06-20")
     createInductionSchedule(
       prisonNumber,
       reference = inductionScheduleReference,
+      deadlineDate = inductionDeadlineDate,
       status = InductionScheduleStatus.SCHEDULED,
       inductionScheduleCalculationRule = InductionScheduleCalculationRule.NEW_PRISON_ADMISSION,
     )
     createInductionScheduleHistory(
       prisonNumber,
       reference = inductionScheduleReference,
+      deadlineDate = inductionDeadlineDate,
       status = InductionScheduleStatus.SCHEDULED,
       version = 1,
     )
     createInductionScheduleHistory(
       prisonNumber,
       reference = inductionScheduleReference,
+      deadlineDate = inductionDeadlineDate,
       status = InductionScheduleStatus.EXEMPT_TEMP_ABSENCE,
       version = 2,
     )
     createInductionScheduleHistory(
       prisonNumber,
       reference = inductionScheduleReference,
+      deadlineDate = inductionDeadlineDate,
       status = InductionScheduleStatus.SCHEDULED,
       version = 3,
     )

--- a/src/integrationTest/resources/sar/expected-report.html
+++ b/src/integrationTest/resources/sar/expected-report.html
@@ -347,7 +347,7 @@
   </tr>
   <tr>
     <td class="data-column-30">Deadline date</td>
-    <td>22 July 2026</td>
+    <td>20 June 2026</td>
   </tr>
   <tr>
     <td class="data-column-30">Schedule calculation rule</td>
@@ -395,7 +395,7 @@
   </tr>
   <tr>
     <td class="data-column-30">Deadline date</td>
-    <td>22 July 2026</td>
+    <td>20 June 2026</td>
   </tr>
   <tr>
     <td class="data-column-30">Schedule calculation rule</td>
@@ -443,7 +443,7 @@
   </tr>
   <tr>
     <td class="data-column-30">Deadline date</td>
-    <td>22 July 2026</td>
+    <td>20 June 2026</td>
   </tr>
   <tr>
     <td class="data-column-30">Schedule calculation rule</td>
@@ -491,7 +491,7 @@
   </tr>
   <tr>
     <td class="data-column-30">Deadline date</td>
-    <td>22 July 2026</td>
+    <td>20 June 2026</td>
   </tr>
   <tr>
     <td class="data-column-30">Schedule calculation rule</td>


### PR DESCRIPTION
PR to fix the SAR Report test. Basically it worked yesterday, but not today.

This is because the test data setup functions `createInductionSchedule` and `createInductionScheduleHistory` both use a default value for `deadlineDate` of "today + 1 month" 
When [I updated the test yesterday to add the Induction Schedules to the report](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/pull/965), I had not specified a value for `deadlineDate`, therefore the test data was being setup with a deadline date of `2026-07-22`, hence the expected report expects the value to be `22 July 2026`. It worked fine yesterday! but fails today.

This PR fixes this by setting a fixed known date for `deadlineDate`