### PR TITLE
RR-2682 - Fix SAR report test

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.se
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionSchedule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.CreateInductionScheduleDto
+import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneId
 
@@ -14,6 +15,7 @@ import java.time.ZoneId
  * The only exception to this are the abstract methods which are intended to be implemented by subclasses.
  */
 abstract class InductionScheduleDateCalculationService(
+  private val clock: Clock,
   private val scheduleDateNotBefore: LocalDate? = null,
   private val propertiesProvider: InductionSchedulePropertiesProvider,
 ) {
@@ -63,7 +65,7 @@ abstract class InductionScheduleDateCalculationService(
    * Returns the base date from which all Induction Schedule dates are calculated
    */
   protected fun baseScheduleDate(): LocalDate {
-    val today = LocalDate.now()
+    val today = LocalDate.now(clock)
     return if (scheduleDateNotBefore != null && scheduleDateNotBefore.isAfter(today)) {
       scheduleDateNotBefore
     } else {

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleDateCalculationService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleDateCalculationService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.Senten
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.SentenceType.CONVICTED_UNSENTENCED
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.SentenceType.INDETERMINATE_SENTENCE
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.SentenceType.REMAND
+import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneId
 
@@ -33,6 +34,7 @@ private val log = KotlinLogging.logger {}
  * domain.
  */
 class ReviewScheduleDateCalculationService(
+  private val clock: Clock,
   private val propertiesProvider: ReviewSchedulePropertiesProvider,
 ) {
   companion object {
@@ -133,10 +135,10 @@ class ReviewScheduleDateCalculationService(
       reviewScheduleWindow.dateTo
     } else {
       if (reviewSchedule.scheduleStatus == ReviewScheduleStatus.EXEMPT_PRISONER_TRANSFER) {
-        return LocalDate.now().plusDays(TEN_DAYS)
+        return baseScheduleDate().plusDays(TEN_DAYS)
       }
       val additionalDays = getExtensionDays(scheduleStatus)
-      val todayPlusAdditionalDays = LocalDate.now().plusDays(additionalDays)
+      val todayPlusAdditionalDays = baseScheduleDate().plusDays(additionalDays)
       maxOf(todayPlusAdditionalDays, reviewScheduleWindow.dateTo)
     }
   }
@@ -153,7 +155,7 @@ class ReviewScheduleDateCalculationService(
     val timeLeftToServe = from(baseScheduleDate()).until(releaseDate)
 
     return when {
-      releaseDate < LocalDate.now() -> RELEASE_DATE_IN_PAST
+      releaseDate < baseScheduleDate() -> RELEASE_DATE_IN_PAST
       timeLeftToServe.isNoMoreThan3Months() -> BETWEEN_RELEASE_AND_3_MONTHS_TO_SERVE
       timeLeftToServe.isBetween3MonthsAnd3Months7Days() -> BETWEEN_3_MONTHS_AND_3_MONTHS_7_DAYS_TO_SERVE
       timeLeftToServe.isBetween3Months8DaysAnd6Months() -> BETWEEN_3_MONTHS_8_DAYS_AND_6_MONTHS_TO_SERVE
@@ -169,7 +171,7 @@ class ReviewScheduleDateCalculationService(
   /**
    * Returns the base date from which all Review Schedule dates are calculated
    */
-  private fun baseScheduleDate() = LocalDate.now()
+  private fun baseScheduleDate() = LocalDate.now(clock)
 
   private fun ReviewSchedule.hadUserAppliedExemptionWhenInductionAlreadyOverdue(): Boolean = (scheduleStatus == ReviewScheduleStatus.EXEMPT_TEMP_ABSENCE || scheduleStatus.canBeSetByUserAction) &&
     reviewScheduleWindow.dateTo.isBefore(LocalDate.ofInstant(lastUpdatedAt, ZoneId.systemDefault()))

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
@@ -13,11 +13,13 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.Cr
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.CreateReviewScheduleDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.UpdateReviewScheduleStatusDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.effectiveSentenceType
+import java.time.Clock
 import java.time.LocalDate
 
 private val log = KotlinLogging.logger {}
 
 class ReviewScheduleService(
+  private val clock: Clock,
   private val reviewSchedulePersistenceAdapter: ReviewSchedulePersistenceAdapter,
   private val reviewScheduleEventService: ReviewScheduleEventService,
   private val reviewScheduleDateCalculationService: ReviewScheduleDateCalculationService,
@@ -329,7 +331,7 @@ class ReviewScheduleService(
 
       // Then update the review schedule to be SCHEDULED with an adjusted review date
       val adjustedReviewDate = reviewScheduleDateCalculationService.calculateAdjustedReviewDueDate(updatedReviewScheduleFirst)
-      val adjustedEarliestReviewDate = LocalDate.now()
+      val adjustedEarliestReviewDate = LocalDate.now(clock)
       val updatedReviewScheduleSecond = reviewSchedulePersistenceAdapter.updateReviewScheduleStatus(
         UpdateReviewScheduleStatusDto(
           reference = reference,

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
@@ -8,16 +8,19 @@ import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidInductionSchedule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.dto.CreateInductionScheduleDto
+import java.time.Clock
 import java.time.LocalDate
 
 class InductionScheduleDateCalculationServiceTest {
   companion object {
-    private val TODAY = LocalDate.now()
+    private val clock = Clock.systemDefaultZone()
+    private val TODAY = LocalDate.now(clock)
   }
 
   // New up an anonymous instance of the abstract class to test the methods implemented in the abstract class
   // The implementations of determineCreateInductionScheduleDto are tested in the concrete implementations of InductionScheduleDateCalculationService
   private val dateCalculationService = object : InductionScheduleDateCalculationService(
+    clock = clock,
     propertiesProvider = object : InductionSchedulePropertiesProvider {
       override val onlyExtendDeadlinesWhenNotOverdue = true
     },

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleDateCalculationServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleDateCalculationServiceTest.kt
@@ -13,11 +13,13 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.Review
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.SentenceType
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.aValidReviewSchedule
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
+import java.time.Clock
 import java.time.LocalDate
 import java.util.stream.Stream
 
 class ReviewScheduleDateCalculationServiceTest {
   private val dateCalculationService = ReviewScheduleDateCalculationService(
+    clock = Clock.systemDefaultZone(),
     propertiesProvider = object : ReviewSchedulePropertiesProvider {
       override val onlyExtendDeadlinesWhenNotOverdue = true
     },

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleServiceTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.Cr
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.UpdateReviewScheduleStatusDto
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.dto.aValidCreateInitialReviewScheduleDto
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit.DAYS
@@ -54,14 +55,16 @@ class ReviewScheduleServiceTest {
   private lateinit var reviewService: ReviewService
 
   companion object {
+    private val clock = Clock.systemDefaultZone()
     private val PRISON_NUMBER = randomValidPrisonNumber()
-    private val TODAY = LocalDate.now()
-    private val NOW = Instant.now()
+    private val TODAY = LocalDate.now(clock)
+    private val NOW = Instant.now(clock)
   }
 
   @BeforeEach
   fun setupService() {
     reviewScheduleService = ReviewScheduleService(
+      clock = clock,
       reviewSchedulePersistenceAdapter = reviewSchedulePersistenceAdapter,
       reviewScheduleEventService = reviewScheduleEventService,
       reviewScheduleDateCalculationService = reviewScheduleDateCalculationService,

--- a/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/TimelineEvent.kt
+++ b/domain/timeline/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/timeline/TimelineEvent.kt
@@ -51,7 +51,7 @@ data class TimelineEvent(
       contextualInfo: Map<TimelineEventContext, String> = emptyMap(),
       prisonId: String,
       actionedBy: String,
-      timestamp: Instant = Instant.now(),
+      timestamp: Instant,
       correlationId: UUID = UUID.randomUUID(),
     ) = TimelineEvent(
       reference = UUID.randomUUID(),

--- a/src/integrationTest/resources/sar/expected-report.html
+++ b/src/integrationTest/resources/sar/expected-report.html
@@ -549,7 +549,7 @@
   </tr>
   <tr>
     <td class="data-column-30">Schedule calculation rule</td>
-    <td>BETWEEN_6_AND_12_MONTHS_TO_SERVE</td>
+    <td>BETWEEN_12_AND_60_MONTHS_TO_SERVE</td>
   </tr>
   <tr>
     <td class="data-column-30">Status</td>
@@ -593,15 +593,15 @@
   </tr>
   <tr>
     <td class="data-column-30">Earliest review date</td>
-    <td>24 August 2026</td>
+    <td>21 July 2026</td>
   </tr>
   <tr>
     <td class="data-column-30">Latest review date</td>
-    <td>24 September 2026</td>
+    <td>21 September 2026</td>
   </tr>
   <tr>
     <td class="data-column-30">Schedule calculation rule</td>
-    <td>BETWEEN_6_AND_12_MONTHS_TO_SERVE</td>
+    <td>BETWEEN_12_AND_60_MONTHS_TO_SERVE</td>
   </tr>
   <tr>
     <td class="data-column-30">Status</td>
@@ -653,7 +653,7 @@
   </tr>
   <tr>
     <td class="data-column-30">Schedule calculation rule</td>
-    <td>BETWEEN_6_AND_12_MONTHS_TO_SERVE</td>
+    <td>BETWEEN_12_AND_60_MONTHS_TO_SERVE</td>
   </tr>
   <tr>
     <td class="data-column-30">Status</td>
@@ -697,15 +697,15 @@
   </tr>
   <tr>
     <td class="data-column-30">Earliest review date</td>
-    <td>24 August 2026</td>
+    <td>21 July 2026</td>
   </tr>
   <tr>
     <td class="data-column-30">Latest review date</td>
-    <td>24 September 2026</td>
+    <td>21 September 2026</td>
   </tr>
   <tr>
     <td class="data-column-30">Schedule calculation rule</td>
-    <td>BETWEEN_6_AND_12_MONTHS_TO_SERVE</td>
+    <td>BETWEEN_12_AND_60_MONTHS_TO_SERVE</td>
   </tr>
   <tr>
     <td class="data-column-30">Status</td>
@@ -757,7 +757,7 @@
   </tr>
   <tr>
     <td class="data-column-30">Schedule calculation rule</td>
-    <td>BETWEEN_6_AND_12_MONTHS_TO_SERVE</td>
+    <td>BETWEEN_12_AND_60_MONTHS_TO_SERVE</td>
   </tr>
   <tr>
     <td class="data-column-30">Status</td>
@@ -801,15 +801,15 @@
   </tr>
   <tr>
     <td class="data-column-30">Earliest review date</td>
-    <td>24 August 2026</td>
+    <td>21 July 2026</td>
   </tr>
   <tr>
     <td class="data-column-30">Latest review date</td>
-    <td>24 September 2026</td>
+    <td>21 September 2026</td>
   </tr>
   <tr>
     <td class="data-column-30">Schedule calculation rule</td>
-    <td>BETWEEN_6_AND_12_MONTHS_TO_SERVE</td>
+    <td>BETWEEN_12_AND_60_MONTHS_TO_SERVE</td>
   </tr>
   <tr>
     <td class="data-column-30">Status</td>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.domain.timeline.service.PrisonTimelineServic
 import uk.gov.justice.digital.hmpps.domain.timeline.service.TimelinePersistenceAdapter
 import uk.gov.justice.digital.hmpps.domain.timeline.service.TimelineService
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.JpaNotePersistenceAdapter
+import java.time.Clock
 
 /**
  * Configuration class responsible for providing domain bean implementations
@@ -119,17 +120,23 @@ class DomainConfiguration {
 
   @Bean
   fun reviewScheduleDomainService(
+    clock: Clock,
     reviewSchedulePersistenceAdapter: ReviewSchedulePersistenceAdapter,
     reviewScheduleEventService: ReviewScheduleEventService,
     reviewScheduleDateCalculationService: ReviewScheduleDateCalculationService,
   ): ReviewScheduleService = ReviewScheduleService(
+    clock,
     reviewSchedulePersistenceAdapter,
     reviewScheduleEventService,
     reviewScheduleDateCalculationService,
   )
 
   @Bean
-  fun reviewScheduleDateCalculationService(exemptionProperties: ExemptionProperties) = ReviewScheduleDateCalculationService(
+  fun reviewScheduleDateCalculationService(
+    clock: Clock,
+    exemptionProperties: ExemptionProperties,
+  ) = ReviewScheduleDateCalculationService(
+    clock,
     propertiesProvider = object : ReviewSchedulePropertiesProvider {
       override val onlyExtendDeadlinesWhenNotOverdue: Boolean
         get() = exemptionProperties.onlyExtendDeadlinesWhenNotOverdue

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TimelineEventFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TimelineEventFactory.kt
@@ -43,13 +43,15 @@ import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventType.INDUCTION_
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventType.STEP_COMPLETED
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventType.STEP_NOT_STARTED
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventType.STEP_STARTED
+import java.time.Clock
+import java.time.Instant
 import java.util.UUID
 
 /**
  * Responsible for identifying which [TimelineEvent]s have occurred, for example following an update to a [Goal].
  */
 @Component
-class TimelineEventFactory(private val userService: ManageUserService) {
+class TimelineEventFactory(private val clock: Clock) {
 
   fun actionPlanCreatedEvent(actionPlan: ActionPlan): List<TimelineEvent> {
     val events = mutableListOf<TimelineEvent>()
@@ -240,6 +242,7 @@ class TimelineEventFactory(private val userService: ManageUserService) {
     actionedBy = goal.lastUpdatedBy!!,
     contextualInfo = contextualInfo,
     correlationId = correlationId,
+    timestamp = Instant.now(clock),
   )
 
   private fun employabilitySkillTimelineEvent(
@@ -253,6 +256,7 @@ class TimelineEventFactory(private val userService: ManageUserService) {
     actionedBy = employabilitySkill.updatedBy,
     contextualInfo = contextualInfo,
     correlationId = correlationId,
+    timestamp = Instant.now(clock),
   )
 
   fun inductionScheduleCreatedTimelineEvent(
@@ -269,6 +273,7 @@ class TimelineEventFactory(private val userService: ManageUserService) {
         INDUCTION_SCHEDULE_DEADLINE_DATE to deadlineDate.toString(),
       ),
       correlationId = correlationId,
+      timestamp = Instant.now(clock),
     )
   }
 
@@ -340,5 +345,6 @@ class TimelineEventFactory(private val userService: ManageUserService) {
     contextualInfo = mapOf(
       TimelineEventContext.EDUCATION_ASSESSMENT_STATUS to "ALL_RELEVANT_ASSESSMENTS_COMPLETE",
     ),
+    timestamp = Instant.now(clock),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationService.kt
@@ -30,6 +30,7 @@ class PefInductionScheduleDateCalculationService(
   private val clock: Clock,
   exemptionProperties: ExemptionProperties,
 ) : InductionScheduleDateCalculationService(
+  clock = clock,
   propertiesProvider = object : InductionSchedulePropertiesProvider {
     override val onlyExtendDeadlinesWhenNotOverdue: Boolean
       get() = exemptionProperties.onlyExtendDeadlinesWhenNotOverdue

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationService.kt
@@ -22,6 +22,7 @@ import java.time.LocalDate
 @ConditionalOnProperty(name = ["ciag-kpi-processing-rule"], havingValue = "PES")
 class PesInductionScheduleDateCalculationService(exemptionProperties: ExemptionProperties, private val clock: Clock) :
   InductionScheduleDateCalculationService(
+    clock = clock,
     propertiesProvider = object : InductionSchedulePropertiesProvider {
       override val onlyExtendDeadlinesWhenNotOverdue: Boolean
         get() = exemptionProperties.onlyExtendDeadlinesWhenNotOverdue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/EducationAssessmentEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/EducationAssessmentEventServiceTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.ent
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.mapper.educationassessment.EducationAssessmentEventEntityMapper
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.EducationAssessmentEventRepository
+import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
@@ -83,6 +84,7 @@ class EducationAssessmentEventServiceTest {
       eventType = TimelineEventType.EDUCATION_ASSESSMENT_EVENT_CREATED,
       prisonId = "BXI",
       actionedBy = "system",
+      timestamp = Instant.now(),
     )
     given(timelineEventFactory.educationAssessmentEventCreatedEvent(any(), any())).willReturn(expectedTimelineEvent)
 
@@ -132,6 +134,7 @@ class EducationAssessmentEventServiceTest {
       eventType = TimelineEventType.EDUCATION_ASSESSMENT_EVENT_CREATED,
       prisonId = "N/A",
       actionedBy = "system",
+      timestamp = Instant.now(),
     )
     given(timelineEventFactory.educationAssessmentEventCreatedEvent(any(), any())).willReturn(expectedTimelineEvent)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TimelineEventFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/TimelineEventFactoryTest.kt
@@ -2,11 +2,6 @@ package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
-import org.mockito.Mock
-import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.verifyNoInteractions
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.employabilityskill.aValidEmployabilitySkill
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.GoalStatus
 import uk.gov.justice.digital.hmpps.domain.personallearningplan.StepStatus
@@ -19,20 +14,21 @@ import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEvent.Companion.newT
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventContext
 import uk.gov.justice.digital.hmpps.domain.timeline.TimelineEventType
 import uk.gov.justice.digital.hmpps.domain.timeline.assertThat
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.util.UUID
 
-@ExtendWith(MockitoExtension::class)
 class TimelineEventFactoryTest {
 
   companion object {
     val IGNORED_FIELDS = arrayOf("reference", "timestamp", "correlationId")
   }
 
-  @InjectMocks
-  private lateinit var timelineEventFactory: TimelineEventFactory
-
-  @Mock
-  private lateinit var userService: ManageUserService
+  private val clock = Clock.fixed(LocalDateTime.parse("2026-03-21T09:43:27.000").toInstant(ZoneOffset.UTC), ZoneId.of("UTC"))
+  private val timelineEventFactory = TimelineEventFactory(clock)
 
   @Test
   fun `should create action plan created event`() {
@@ -61,8 +57,6 @@ class TimelineEventFactoryTest {
       .wasActionedBy(goal.lastUpdatedBy!!)
       .hasContextualInfo(mapOf(TimelineEventContext.GOAL_TITLE to goal.title))
       .hasCorrelationId(actionPlanCreatedEvent.correlationId)
-
-    verifyNoInteractions(userService)
   }
 
   @Test
@@ -95,6 +89,7 @@ class TimelineEventFactoryTest {
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
         contextualInfo = mapOf(TimelineEventContext.GOAL_TITLE to updatedGoal.title),
+        timestamp = Instant.now(clock),
       ),
     )
 
@@ -133,6 +128,7 @@ class TimelineEventFactoryTest {
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
         contextualInfo = mapOf(TimelineEventContext.GOAL_TITLE to previousGoal.title),
+        timestamp = Instant.now(clock),
       ),
       newTimelineEvent(
         sourceReference = step1Reference.toString(),
@@ -140,6 +136,7 @@ class TimelineEventFactoryTest {
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
         contextualInfo = mapOf(TimelineEventContext.STEP_TITLE to "Book Spanish course"),
+        timestamp = Instant.now(clock),
       ),
     )
 
@@ -176,6 +173,7 @@ class TimelineEventFactoryTest {
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
         contextualInfo = mapOf(TimelineEventContext.GOAL_TITLE to previousGoal.title),
+        timestamp = Instant.now(clock),
       ),
       newTimelineEvent(
         sourceReference = step1Reference.toString(),
@@ -183,6 +181,7 @@ class TimelineEventFactoryTest {
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
         contextualInfo = mapOf(TimelineEventContext.STEP_TITLE to "Book course"),
+        timestamp = Instant.now(clock),
       ),
     )
 
@@ -235,6 +234,7 @@ class TimelineEventFactoryTest {
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
         contextualInfo = mapOf(TimelineEventContext.GOAL_TITLE to "Learn Spanish"),
+        timestamp = Instant.now(clock),
       ),
       newTimelineEvent(
         sourceReference = step1Reference.toString(),
@@ -242,6 +242,7 @@ class TimelineEventFactoryTest {
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
         contextualInfo = mapOf(TimelineEventContext.STEP_TITLE to "Book Spanish course"),
+        timestamp = Instant.now(clock),
       ),
       newTimelineEvent(
         sourceReference = step1Reference.toString(),
@@ -249,6 +250,7 @@ class TimelineEventFactoryTest {
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
         contextualInfo = mapOf(TimelineEventContext.STEP_TITLE to "Book Spanish course"),
+        timestamp = Instant.now(clock),
       ),
       newTimelineEvent(
         sourceReference = step2Reference.toString(),
@@ -256,6 +258,7 @@ class TimelineEventFactoryTest {
         prisonId = updatedGoal.lastUpdatedAtPrison,
         actionedBy = updatedGoal.lastUpdatedBy!!,
         contextualInfo = mapOf(TimelineEventContext.STEP_TITLE to "Complete course"),
+        timestamp = Instant.now(clock),
       ),
     )
 


### PR DESCRIPTION
Fix SAR report test by using the clock in the date calculation implementation classes (which I clearly forgot to do in the earlier PR that introduced the `Clock` as a spring bean)
Basically a couple of the "schedule date calculation" classes were still using `.now()` to generate the current date/time, rather than using an injected clock. 
This caused a problem in the SAR test because the Review Schedule dates were being calculated based on "today" rather than based on the `TickingClock` (which we use to generate predictable dates and times! 🤣 )

Therefore the bug fix for the SAR report test is actually in the main implementation code, specifically in the "schedule date calculation" classes, rather than SAR code itself