### PR TITLE
RR-2682 - Fix "toDate" filtering

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/sar/SarApiTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/sar/SarApiTest.kt
@@ -25,6 +25,7 @@ import java.time.LocalDate
 class SarApiTest : IntegrationTestBase() {
   companion object {
     private const val URI_TEMPLATE = "/subject-access-request"
+    private val today = LocalDate.now()
   }
 
   @Test
@@ -175,8 +176,8 @@ class SarApiTest : IntegrationTestBase() {
     }
 
     // When
-    val responseFromLastWeek = webTestClient.sarRequest(prisoner1, LocalDate.now().minusWeeks(1), null)
-    val responseFromTomorrow = webTestClient.sarRequest(prisoner2, LocalDate.now().plusDays(1), null)
+    val responseFromLastWeek = webTestClient.sarRequest(prisoner1, today.minusWeeks(1), null)
+    val responseFromTomorrow = webTestClient.sarRequest(prisoner2, today.plusDays(1), null)
 
     // Then
     val responseBody = responseFromLastWeek
@@ -215,8 +216,8 @@ class SarApiTest : IntegrationTestBase() {
     }
 
     // When
-    val responseToLastWeek = webTestClient.sarRequest(prisoner1, null, LocalDate.now().minusWeeks(1))
-    val responseToTomorrow = webTestClient.sarRequest(prisoner2, null, LocalDate.now().plusDays(1))
+    val responseToLastWeek = webTestClient.sarRequest(prisoner1, null, today.minusWeeks(1))
+    val responseToTomorrow = webTestClient.sarRequest(prisoner2, null, today.plusDays(1))
 
     // Then
     responseToLastWeek.expectStatus().isNoContent
@@ -259,8 +260,8 @@ class SarApiTest : IntegrationTestBase() {
     }
 
     // When
-    val responseThisWeek = webTestClient.sarRequest(prisoner1, LocalDate.now(), LocalDate.now().plusWeeks(1))
-    val responseLastWeek = webTestClient.sarRequest(prisoner2, LocalDate.now().minusWeeks(1), LocalDate.now())
+    val responseThisWeek = webTestClient.sarRequest(prisoner1, today, today.plusWeeks(1))
+    val responseLastWeek = webTestClient.sarRequest(prisoner2, today.minusWeeks(1), today.minusDays(1))
 
     // Then
     val responseBody = responseThisWeek

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestService.kt
@@ -24,6 +24,8 @@ import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonSubjectAccessRequestService
 import uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestContent
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.ZoneOffset
 
 @Service
@@ -49,7 +51,7 @@ class SubjectAccessRequestService(
     toDate: LocalDate?,
   ): HmppsSubjectAccessRequestContent? {
     val fromDateInstance = fromDate?.atStartOfDay()?.toInstant(ZoneOffset.UTC)
-    val toDateInstance = toDate?.atStartOfDay()?.toInstant(ZoneOffset.UTC)
+    val toDateInstance = toDate?.atEndOfDay()?.toInstant(ZoneOffset.UTC)
 
     val goals = try {
       actionPlanService.getActionPlan(prn).goals
@@ -92,26 +94,42 @@ class SubjectAccessRequestService(
     val employabilitySkills = employabilitySkillsService.getEmployabilitySkills(prn)
       .filter { it.createdAt.inRange(fromDateInstance, toDateInstance) }
 
-    if (goals.isEmpty() && induction == null) return null
-    return HmppsSubjectAccessRequestContent(
-      content = SubjectAccessRequestContent(
-        induction = induction?.let { inductionMapper.toInductionResponse(induction, employabilitySkills) },
-        goals = goals.map {
-          val goalNotes = noteService.getNotes(it.reference, EntityType.GOAL)
-          sarGoalMapper.fromDomainToModel(it, goalNotes)
-        },
-        education = education?.let {
-          educationResourceMapper.toEducationResponse(it)
-        },
-        completedReviews = completedReviews.map { completedActionPlanReviewResponseMapper.fromDomainToModel(it) },
-        inductionScheduleHistory = inductionScheduleHistory
-          .map { inductionScheduleMapper.toInductionResponse(it, induction) }
-          .sortedBy { it.version },
-        reviewScheduleHistory = reviewScheduleHistory.map { reviewScheduleMapper.fromDomainToModel(it) },
-      ),
-    )
+    return if (goals.isEmpty() &&
+      induction == null &&
+      education == null &&
+      inductionScheduleHistory.isEmpty() &&
+      reviewScheduleHistory.isEmpty() &&
+      completedReviews.isEmpty() &&
+      employabilitySkills.isEmpty()
+    ) {
+      null
+    } else {
+      HmppsSubjectAccessRequestContent(
+        content = SubjectAccessRequestContent(
+          induction = induction?.let { inductionMapper.toInductionResponse(induction, employabilitySkills) },
+          goals = goals.map {
+            val goalNotes = noteService.getNotes(it.reference, EntityType.GOAL)
+            sarGoalMapper.fromDomainToModel(it, goalNotes)
+          },
+          education = education?.let {
+            educationResourceMapper.toEducationResponse(it)
+          },
+          completedReviews = completedReviews.map { completedActionPlanReviewResponseMapper.fromDomainToModel(it) },
+          inductionScheduleHistory = inductionScheduleHistory
+            .map { inductionScheduleMapper.toInductionResponse(it, induction) }
+            .sortedBy { it.version },
+          reviewScheduleHistory = reviewScheduleHistory.map { reviewScheduleMapper.fromDomainToModel(it) },
+        ),
+      )
+    }
   }
 }
 
-private fun Instant.inRange(from: Instant?, to: Instant?): Boolean = (from == null || !this.isBefore(from)) &&
-  (to == null || this.isBefore(to))
+private fun Instant.inRange(from: Instant?, to: Instant?): Boolean = (from == null || this.isEqualOrAfter(from)) &&
+  (to == null || this.isEqualOrBefore(to))
+
+private fun Instant.isEqualOrAfter(other: Instant): Boolean = (this == other || isAfter(other))
+
+private fun Instant.isEqualOrBefore(other: Instant): Boolean = (this == other || this.isBefore(other))
+
+private fun LocalDate.atEndOfDay(): LocalDateTime = LocalDateTime.of(this, LocalTime.parse("23:59:59.999"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/SubjectAccessRequestServiceTest.kt
@@ -48,6 +48,7 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induc
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.aValidReviewScheduleResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.aValidCompletedActionPlanReviewResponse
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.sar.aValidSarGoalResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.sar.assertThat
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -148,6 +149,12 @@ class SubjectAccessRequestServiceTest {
     val sarContent = sarResponse!!.content as SubjectAccessRequestContent
 
     // Then
+    assertThat(sarContent)
+      .induction { it.isEqualTo(expectedInductionResponse) }
+      .hasNumberOfGoals(2)
+      .goal(1) { it.isEqualTo(expectedGoalResponse1) }
+      .goal(2) { it.isEqualTo(expectedGoalResponse2) }
+
     verify(inductionService).getInductionForPrisoner(prisonNumber)
     verify(employabilitySkillsService).getEmployabilitySkills(prisonNumber)
     verify(inductionMapper).toInductionResponse(induction, employabilitySkills)
@@ -158,16 +165,13 @@ class SubjectAccessRequestServiceTest {
 
     verify(noteService).getNotes(goal1.reference, EntityType.GOAL)
     verify(noteService).getNotes(goal2.reference, EntityType.GOAL)
-
-    with(sarContent) {
-      assertThat(this.induction).isEqualTo(expectedInductionResponse)
-      assertThat(goals).isEqualTo(listOf(expectedGoalResponse1, expectedGoalResponse2))
-    }
   }
 
   @Test
   fun `should return SAR content for a prisoner filtered by from date`() {
     // Given
+    val fromDate = LocalDate.parse("2024-01-15")
+
     val prisonNumber = randomValidPrisonNumber()
 
     val induction = aFullyPopulatedInduction(
@@ -207,11 +211,15 @@ class SubjectAccessRequestServiceTest {
     given(sarGoalMapper.fromDomainToModel(any(), any())).willReturn(expectedGoalResponse2)
 
     // When
-    val fromDate = LocalDate.parse("2024-01-15")
     val sarResponse = subjectAccessRequestService.getPrisonContentFor(prisonNumber, fromDate, null)
     val sarContent = sarResponse!!.content as SubjectAccessRequestContent
 
     // Then
+    assertThat(sarContent)
+      .hasNoInduction() // Expect the Induction to be null because it was created before the "fromDate"
+      .hasNumberOfGoals(1)
+      .goal(1) { it.isEqualTo(expectedGoalResponse2) }
+
     verify(inductionService).getInductionForPrisoner(prisonNumber)
     verify(inductionMapper, never()).toInductionResponse(any(), any())
 
@@ -221,16 +229,13 @@ class SubjectAccessRequestServiceTest {
     verify(noteService).getNotes(goal2.reference, EntityType.GOAL)
 
     verify(inductionScheduleService).getInductionScheduleHistoryForPrisoner(prisonNumber)
-
-    with(sarContent) {
-      assertThat(this.induction).isNull()
-      assertThat(goals).isEqualTo(listOf(expectedGoalResponse2))
-    }
   }
 
   @Test
   fun `should return SAR content for a prisoner filtered by to date`() {
     // Given
+    val toDate = LocalDate.parse("2024-01-10")
+
     val prisonNumber = randomValidPrisonNumber()
 
     val induction = aFullyPopulatedInduction(
@@ -298,11 +303,19 @@ class SubjectAccessRequestServiceTest {
     )
 
     // When
-    val toDate = LocalDate.parse("2024-01-10")
     val sarResponse = subjectAccessRequestService.getPrisonContentFor(prisonNumber, null, toDate)
     val sarContent = sarResponse!!.content as SubjectAccessRequestContent
 
     // Then
+    assertThat(sarContent)
+      .induction { it.isEqualTo(expectedInductionResponse) }
+      .hasNumberOfGoals(1)
+      .goal(1) { it.isEqualTo(expectedGoalResponse1) }
+      .education { it.isEqualTo(expectedEducationResponse) }
+      .hasNumberOfInductionScheduleRecords(1)
+      .hasNumberOfReviewScheduleRecords(1)
+      .hasNumberOfCompletedReviews(1)
+
     verify(inductionService).getInductionForPrisoner(prisonNumber)
     verify(employabilitySkillsService).getEmployabilitySkills(prisonNumber)
 
@@ -312,19 +325,14 @@ class SubjectAccessRequestServiceTest {
     verify(sarGoalMapper).fromDomainToModel(goal1, emptyList())
 
     verify(noteService).getNotes(goal1.reference, EntityType.GOAL)
-
-    with(sarContent) {
-      assertThat(this.induction).isEqualTo(expectedInductionResponse)
-      assertThat(goals).isEqualTo(listOf(expectedGoalResponse1))
-      assertThat(education).isEqualTo(expectedEducationResponse)
-      assertThat(this.inductionScheduleHistory?.size).isEqualTo(1)
-      assertThat(this.reviewScheduleHistory?.size).isEqualTo(1)
-    }
   }
 
   @Test
   fun `should return induction and action plan data for a prisoner filtered by from date and to date`() {
     // Given
+    val fromDate = LocalDate.parse("2024-02-01")
+    val toDate = LocalDate.parse("2024-03-01")
+
     val prisonNumber = randomValidPrisonNumber()
 
     val induction = aFullyPopulatedInduction(
@@ -346,12 +354,15 @@ class SubjectAccessRequestServiceTest {
     given(sarGoalMapper.fromDomainToModel(any(), any())).willReturn(expectedGoalResponse2)
 
     // When
-    val fromDate = LocalDate.parse("2024-02-01")
-    val toDate = LocalDate.parse("2024-03-01")
     val sarResponse = subjectAccessRequestService.getPrisonContentFor(prisonNumber, fromDate, toDate)
     val sarContent = sarResponse!!.content as SubjectAccessRequestContent
 
     // Then
+    assertThat(sarContent)
+      .hasNoInduction()
+      .hasNumberOfGoals(1)
+      .goal(1) { it.isEqualTo(expectedGoalResponse2) }
+
     verify(inductionService).getInductionForPrisoner(prisonNumber)
     verify(educationService).getPreviousQualificationsForPrisoner(prisonNumber)
     verify(employabilitySkillsService).getEmployabilitySkills(prisonNumber)
@@ -361,11 +372,6 @@ class SubjectAccessRequestServiceTest {
     verify(sarGoalMapper).fromDomainToModel(goal2, emptyList())
 
     verify(noteService).getNotes(goal2.reference, EntityType.GOAL)
-
-    with(sarContent) {
-      assertThat(this.induction).isNull()
-      assertThat(goals).isEqualTo(listOf(expectedGoalResponse2))
-    }
   }
 
   @Test
@@ -385,6 +391,8 @@ class SubjectAccessRequestServiceTest {
     val sarResponse = subjectAccessRequestService.getPrisonContentFor(prisonNumber, null, null)
 
     // Then
+    assertThat(sarResponse).isNull()
+
     verify(inductionService).getInductionForPrisoner(prisonNumber)
     verify(inductionMapper, never()).toInductionResponse(any(), any())
     verify(actionPlanService).getActionPlan(prisonNumber)
@@ -399,7 +407,5 @@ class SubjectAccessRequestServiceTest {
     verify(completedActionPlanReviewResponseMapper, never()).fromDomainToModel(any())
     verify(employabilitySkillsService).getEmployabilitySkills(prisonNumber)
     verify(noteService, never()).getNotes(any(), any())
-
-    assertThat(sarResponse).isNull()
   }
 }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/sar/SubjectAccessRequestContentAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/resource/model/sar/SubjectAccessRequestContentAssert.kt
@@ -1,0 +1,250 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.sar
+
+import org.assertj.core.api.AbstractObjectAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.CompletedActionPlanReviewResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.EducationResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SarGoalResponse
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.SubjectAccessRequestContent
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.EducationResponseAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.education.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.InductionResponseAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.InductionScheduleResponseAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.CompletedActionPlanReviewResponseAssert
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.review.assertThat
+import java.util.function.Consumer
+
+fun assertThat(actual: SubjectAccessRequestContent?) = SubjectAccessRequestContentAssert(actual)
+
+/**
+ * AssertJ custom assertion for a single [SubjectAccessRequestContent]
+ */
+class SubjectAccessRequestContentAssert(actual: SubjectAccessRequestContent?) : AbstractObjectAssert<SubjectAccessRequestContentAssert, SubjectAccessRequestContent?>(actual, SubjectAccessRequestContentAssert::class.java) {
+
+  fun hasNoInduction(): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      if (induction != null) {
+        failWithMessage("Expected induction to be null but was: $induction")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the child [InductionResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [InductionResponseAssert].
+   * Returns this [SubjectAccessRequestContentAssert] to allow further chained assertions on the parent [SubjectAccessRequestContent]
+   */
+  fun induction(consumer: Consumer<InductionResponseAssert>): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      consumer.accept(assertThat(induction))
+    }
+    return this
+  }
+
+  fun hasNoGoals(): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      if (!goals.isNullOrEmpty()) {
+        failWithMessage("Expected no goals but has ${goals.size} goals")
+      }
+    }
+    return this
+  }
+
+  fun hasNumberOfGoals(expected: Int): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      if (goals?.size != expected) {
+        failWithMessage("Expected SubjectAccessRequestContent to be have $expected goals set, but has ${goals?.size}")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [SarGoalResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [SarGoalResponseAssert].
+   * Returns this [SubjectAccessRequestContentAssert] to allow further chained assertions on the parent [SubjectAccessRequestContent]
+   *
+   * The `goalNumber` parameter is not zero indexed to make for better readability in tests. IE. the first goal
+   * should be referenced as `.goal(1) { .... }`
+   */
+  fun goal(goalNumber: Int, consumer: Consumer<SarGoalResponseAssert>): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      val goal = goals?.get(goalNumber - 1)
+      consumer.accept(assertThat(goal))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into all child [SarGoalResponse]s. Takes a lambda as the method argument
+   * to call assertion methods provided by [SarGoalResponseAssert].
+   * Returns this [SubjectAccessRequestContentAssert] to allow further chained assertions on the parent [SubjectAccessRequestContent]
+   * The assertions on all [SarGoalResponse]s must pass as true.
+   */
+  fun allGoals(consumer: Consumer<SarGoalResponseAssert>): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      goals?.onEach {
+        consumer.accept(assertThat(it))
+      }
+    }
+    return this
+  }
+
+  fun hasNoEducation(): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      if (education != null) {
+        failWithMessage("Expected education to be null but was: $education")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the child [EducationResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [EducationResponseAssert].
+   * Returns this [SubjectAccessRequestContentAssert] to allow further chained assertions on the parent [SubjectAccessRequestContent]
+   */
+  fun education(consumer: Consumer<EducationResponseAssert>): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      consumer.accept(assertThat(education))
+    }
+    return this
+  }
+
+  fun hasNoCompletedReviews(): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      if (!completedReviews.isNullOrEmpty()) {
+        failWithMessage("Expected no completed reviews but has ${completedReviews.size} completed reviews")
+      }
+    }
+    return this
+  }
+
+  fun hasNumberOfCompletedReviews(expected: Int): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      if (completedReviews?.size != expected) {
+        failWithMessage("Expected SubjectAccessRequestContent to be have $expected completed reviews set, but has ${completedReviews?.size}")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [CompletedActionPlanReviewResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [CompletedActionPlanReviewResponseAssert].
+   * Returns this [SubjectAccessRequestContentAssert] to allow further chained assertions on the parent [SubjectAccessRequestContent]
+   *
+   * The `completedReviewNumber` parameter is not zero indexed to make for better readability in tests. IE. the first completed review
+   * should be referenced as `.completedReview(1) { .... }`
+   */
+  fun completedReview(completedReviewNumber: Int, consumer: Consumer<CompletedActionPlanReviewResponseAssert>): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      val goal = completedReviews?.get(completedReviewNumber - 1)
+      consumer.accept(assertThat(goal))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into all child [CompletedActionPlanReviewResponse]s. Takes a lambda as the method argument
+   * to call assertion methods provided by [CompletedActionPlanReviewResponseAssert].
+   * Returns this [SubjectAccessRequestContentAssert] to allow further chained assertions on the parent [SubjectAccessRequestContent]
+   * The assertions on all [CompletedActionPlanReviewResponse]s must pass as true.
+   */
+  fun allCompletedReviews(consumer: Consumer<CompletedActionPlanReviewResponseAssert>): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      completedReviews?.onEach {
+        consumer.accept(assertThat(it))
+      }
+    }
+    return this
+  }
+
+  fun hasNoInductionScheduleRecords(): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      if (!inductionScheduleHistory.isNullOrEmpty()) {
+        failWithMessage("Expected no induction schedule records but has ${inductionScheduleHistory.size} goals")
+      }
+    }
+    return this
+  }
+
+  fun hasNumberOfInductionScheduleRecords(expected: Int): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      if (inductionScheduleHistory?.size != expected) {
+        failWithMessage("Expected SubjectAccessRequestContent to be have $expected induction schedule records, but has ${inductionScheduleHistory?.size}")
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [InductionScheduleResponse]. Takes a lambda as the method argument
+   * to call assertion methods provided by [InductionScheduleResponseAssert].
+   * Returns this [SubjectAccessRequestContentAssert] to allow further chained assertions on the parent [SubjectAccessRequestContent]
+   *
+   * The `inductionScheduleNumber` parameter is not zero indexed to make for better readability in tests. IE. the first induction schedule
+   * should be referenced as `.inductionSchedule(1) { .... }`
+   */
+  fun inductionScheduleRecord(inductionScheduleNumber: Int, consumer: Consumer<InductionScheduleResponseAssert>): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      val goal = inductionScheduleHistory?.get(inductionScheduleNumber - 1)
+      consumer.accept(assertThat(goal))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into all child [InductionScheduleResponse]s. Takes a lambda as the method argument
+   * to call assertion methods provided by [InductionScheduleResponseAssert].
+   * Returns this [SubjectAccessRequestContentAssert] to allow further chained assertions on the parent [SubjectAccessRequestContent]
+   * The assertions on all [InductionScheduleResponseAssert]s must pass as true.
+   */
+  fun allInductionScheduleRecords(consumer: Consumer<InductionScheduleResponseAssert>): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      inductionScheduleHistory?.onEach {
+        consumer.accept(assertThat(it))
+      }
+    }
+    return this
+  }
+
+  fun hasNoReviewScheduleRecords(): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      if (!reviewScheduleHistory.isNullOrEmpty()) {
+        failWithMessage("Expected no review schedule records but has ${reviewScheduleHistory.size} goals")
+      }
+    }
+    return this
+  }
+
+  fun hasNumberOfReviewScheduleRecords(expected: Int): SubjectAccessRequestContentAssert {
+    isNotNull
+    with(actual!!) {
+      if (reviewScheduleHistory?.size != expected) {
+        failWithMessage("Expected SubjectAccessRequestContent to be have $expected review schedule records, but has ${reviewScheduleHistory?.size}")
+      }
+    }
+    return this
+  }
+}


### PR DESCRIPTION
PR to fix a problem in the LWP SAR report with the "toDate"

The "toDate" is passed into the service as a `LocalDate` (ie. no time), and is converted to an `Instant`. In order to convert to an `Instant` it needs a time component, and this was incorrectly being set as `atStartOfDay`

This meant that prisoner data that was created on the same day as the "toDate" would not appear in the report, because they were created after the "toDate" (once the `atStartOfDay` time had been set)

This has been corrected by creating and using an `atEndOfDay` method.

I've also taken the opportunity to improve a couple of tests, including adding a new custom assertJ assertion class