### PR TITLE
RR-2785 - Fixed implementation for transfers under PES. Integration tests now pass

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationService.kt
@@ -42,12 +42,17 @@ abstract class InductionScheduleDateCalculationService(
    */
   abstract fun determineDeadlineDateForCompletedAssessments(calculationRule: InductionScheduleCalculationRule): LocalDate
 
+  /**
+   * Returns the number of days that are added to the Induction deadline date when processing a transfer
+   */
+  abstract fun extensionDaysForTransfer(): Long
+
   fun calculateAdjustedInductionDueDate(inductionSchedule: InductionSchedule): LocalDate = with(inductionSchedule) {
     if (propertiesProvider.onlyExtendDeadlinesWhenNotOverdue && hadUserAppliedExemptionWhenInductionAlreadyOverdue()) {
       deadlineDate
     } else {
       if (scheduleStatus == InductionScheduleStatus.EXEMPT_PRISONER_TRANSFER) {
-        return baseScheduleDate().plusDays(TWENTY_DAYS)
+        return baseScheduleDate().plusDays(extensionDaysForTransfer())
       }
       val additionalDays = getExtensionDays(scheduleStatus)
       val baseDatePlusAdditionalDays = baseScheduleDate().plusDays(additionalDays)

--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleService.kt
@@ -16,13 +16,30 @@ import java.time.LocalDate
 
 private val log = KotlinLogging.logger {}
 
-class InductionScheduleService(
+/**
+ * Abstract service class exposing methods that implement the business rules for updating a prisoner's [InductionSchedule]
+ *
+ * This implemented methods are deliberately final so that they cannot be subclassed, ensuring that the business rules stay within the
+ * domain.
+ * The only exception to this are the abstract methods which are intended to be implemented by subclasses.
+ */
+abstract class InductionScheduleService(
   private val inductionSchedulePersistenceAdapter: InductionSchedulePersistenceAdapter,
   private val inductionScheduleEventService: InductionScheduleEventService,
   private val inductionScheduleDateCalculationService: InductionScheduleDateCalculationService,
 ) {
 
   private val inductionScheduleStatusTransitionValidator = InductionScheduleStatusTransitionValidator()
+
+  /**
+   * Returns the new deadline date for the [InductionSchedule] when it is being updated as part of a transfer
+   */
+  abstract fun updatedInductionDeadlineForProcessingTransfer(inductionSchedule: InductionSchedule): LocalDate
+
+  /**
+   * Returns the new status  for the [InductionSchedule] when it is being updated as part of a transfer
+   */
+  abstract fun updatedStatusForProcessingTransfer(inductionSchedule: InductionSchedule): InductionScheduleStatus
 
   /**
    * Creates the prisoner's [InductionSchedule].
@@ -204,11 +221,11 @@ class InductionScheduleService(
     )
 
     // Step 2: Adjust induction date and reschedule
-    val adjustedInductionDate = inductionScheduleDateCalculationService
-      .calculateAdjustedInductionDueDate(updatedSchedule)
+    val adjustedInductionDate = updatedInductionDeadlineForProcessingTransfer(updatedSchedule)
+    val newStatus = updatedStatusForProcessingTransfer(updatedSchedule)
     return updateInductionSchedule(
       inductionSchedule = updatedSchedule,
-      newStatus = SCHEDULED,
+      newStatus = newStatus,
       adjustedInductionDate = adjustedInductionDate,
       prisonId = prisonTransferredTo,
     )

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleDateCalculationServiceTest.kt
@@ -19,7 +19,7 @@ class InductionScheduleDateCalculationServiceTest {
   }
 
   // New up an anonymous instance of the abstract class to test the methods implemented in the abstract class
-  // The implementations of determineCreateInductionScheduleDto are tested in the concrete implementations of InductionScheduleDateCalculationService
+  // The implementations of the abstract methods are tested in the concrete implementations of InductionScheduleDateCalculationService
   private val dateCalculationService = object : InductionScheduleDateCalculationService(
     clock = clock,
     propertiesProvider = object : InductionSchedulePropertiesProvider {
@@ -41,6 +41,8 @@ class InductionScheduleDateCalculationServiceTest {
     override fun getNewAdmissionAdditionalDays(calculationRule: InductionScheduleCalculationRule): Long {
       TODO("Not implemented here")
     }
+
+    override fun extensionDaysForTransfer(): Long = TWENTY_DAYS
   }
 
   @Nested

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/induction/service/InductionScheduleServiceTest.kt
@@ -4,18 +4,17 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowableOfType
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
-import org.mockito.Mock
-import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionSchedule
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleAlreadyExistsException
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleCalculationRule.NEW_PRISON_ADMISSION
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleNotFoundException
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.COMPLETED
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.EXEMPT_PRISONER_FAILED_TO_ENGAGE
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS
@@ -33,20 +32,24 @@ import java.time.temporal.ChronoUnit.MINUTES
 import java.time.temporal.ChronoUnit.SECONDS
 import java.util.UUID
 
-@ExtendWith(MockitoExtension::class)
 class InductionScheduleServiceTest {
 
-  @InjectMocks
-  private lateinit var service: InductionScheduleService
+  private val inductionSchedulePersistenceAdapter = mock<InductionSchedulePersistenceAdapter>()
 
-  @Mock
-  private lateinit var inductionSchedulePersistenceAdapter: InductionSchedulePersistenceAdapter
+  private val inductionScheduleEventService = mock<InductionScheduleEventService>()
 
-  @Mock
-  private lateinit var inductionScheduleEventService: InductionScheduleEventService
+  private val inductionScheduleDateCalculationService = mock<InductionScheduleDateCalculationService>()
 
-  @Mock
-  private lateinit var inductionScheduleDateCalculationService: InductionScheduleDateCalculationService
+  // New up an anonymous instance of the abstract class to test the methods implemented in the abstract class
+  private val service = object : InductionScheduleService(
+    inductionSchedulePersistenceAdapter,
+    inductionScheduleEventService,
+    inductionScheduleDateCalculationService,
+  ) {
+    override fun updatedInductionDeadlineForProcessingTransfer(inductionSchedule: InductionSchedule): LocalDate = LocalDate.now()
+
+    override fun updatedStatusForProcessingTransfer(inductionSchedule: InductionSchedule): InductionScheduleStatus = InductionScheduleStatus.SCHEDULED
+  }
 
   companion object {
     private val PRISON_NUMBER = randomValidPrisonNumber()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventDueToTransferInductionScheduleTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventDueToTransferInductionScheduleTest.kt
@@ -13,8 +13,6 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.Additi
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.messaging.EventType.PRISONER_RECEIVED_INTO_PRISON
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleCalculationRule
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus.COMPLETED
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus.EXEMPT_PRISONER_TRANSFER
-import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus.SCHEDULED
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import java.time.OffsetDateTime
@@ -25,62 +23,6 @@ class PrisonerReceivedEventDueToTransferInductionScheduleTest : IntegrationTestB
   companion object {
     private const val ORIGINAL_PRISON = "BXI"
     private const val PRISON_TRANSFERRING_TO = "MDI"
-  }
-
-  @Test
-  fun `should update Induction Schedule and send outbound message given 'prisoner received' (transfer) event for prisoner that has an active Induction Schedule`() {
-    // Given
-    // an induction Schedule exists
-    val prisonNumber = randomValidPrisonNumber()
-    val earliestDateTime = OffsetDateTime.now()
-
-    createInductionSchedule(prisonNumber, status = InductionScheduleStatus.SCHEDULED)
-
-    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
-      prisonNumber = prisonNumber,
-      eventType = PRISONER_RECEIVED_INTO_PRISON,
-      additionalInformation = aValidPrisonerReceivedAdditionalInformation(
-        prisonNumber = prisonNumber,
-        prisonId = PRISON_TRANSFERRING_TO,
-        reason = TRANSFERRED,
-      ),
-    )
-    // When
-    sendDomainEvent(sqsMessage)
-
-    // Then
-    // wait until the queue is drained / message is processed
-    await untilCallTo {
-      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
-    } matches { it == 0 }
-
-    val inductionSchedule = getInductionSchedule(prisonNumber)
-    assertThat(inductionSchedule)
-      .wasCreatedAtOrAfter(earliestDateTime)
-      .wasUpdatedAtOrAfter(earliestDateTime)
-      .wasCreatedBy("system")
-      .wasCreatedByDisplayName("system")
-      .wasCreatedAtPrison(ORIGINAL_PRISON)
-      .wasUpdatedBy("system")
-      .wasUpdatedByDisplayName("system")
-      .wasUpdatedAtPrison(PRISON_TRANSFERRING_TO)
-      .wasScheduleCalculationRule(InductionScheduleCalculationRule.NEW_PRISON_ADMISSION)
-      .wasStatus(SCHEDULED)
-
-    val inductionScheduleHistories = getInductionScheduleHistory(prisonNumber)
-    assertThat(inductionScheduleHistories.inductionSchedules.size).isEqualTo(2)
-    assertThat(inductionScheduleHistories.inductionSchedules[1].scheduleStatus).isEqualTo(EXEMPT_PRISONER_TRANSFER)
-    assertThat(inductionScheduleHistories.inductionSchedules[0].scheduleStatus).isEqualTo(SCHEDULED)
-
-    val inductionScheduleEvents = inductionScheduleEventQueue.receiveEventsOnQueue(QueueType.INDUCTION)
-
-    await.untilAsserted {
-      assertThat(inductionScheduleEvents).hasSize(2)
-      assertThat(inductionScheduleEvents).allSatisfy {
-        assertThat(it.personReference.identifiers[0].value).isEqualTo(prisonNumber)
-        assertThat(it.detailUrl).isEqualTo("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
-      }
-    }
   }
 
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventDueToTransferTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventDueToTransferTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Isolated
 import org.springframework.http.MediaType.APPLICATION_JSON
@@ -194,7 +193,6 @@ class PrisonerReceivedEventDueToTransferTest : IntegrationTestBase() {
     }
   }
 
-  @Disabled("Disabled until PES implementation is written which will allow this test to to pass")
   @Test
   fun `should update Induction Schedule and send outbound message given 'prisoner received' (transfer) event for prisoner that has a SCHEDULED induction and does not have completed Screenings and Assessments`() {
     // Given
@@ -263,7 +261,6 @@ class PrisonerReceivedEventDueToTransferTest : IntegrationTestBase() {
     }
   }
 
-  @Disabled("Disabled until PES implementation is written which will allow this test to to pass")
   @Test
   fun `should update Induction Schedule and send outbound message given 'prisoner received' (transfer) event for prisoner that has a SCHEDULED induction and already has completed Screenings and Assessments`() {
     // Given
@@ -347,7 +344,6 @@ class PrisonerReceivedEventDueToTransferTest : IntegrationTestBase() {
     }
   }
 
-  @Disabled("Disabled until PES implementation is written which will allow this test to to pass")
   @Test
   fun `should update Induction Schedule and send outbound message given 'prisoner received' (transfer) event for prisoner that has an EXEMPT induction and does not have completed Screenings and Assessments`() {
     // Given
@@ -396,7 +392,7 @@ class PrisonerReceivedEventDueToTransferTest : IntegrationTestBase() {
 
     val inductionSchedules = getInductionScheduleHistory(prisonNumber)
     assertThat(inductionSchedules)
-      // Expect 4 schedules - 1 is the initial scheduled, 2 is exemption, 4 is exemption due to transfer, 4 is the pending S&A
+      // Expect 4 schedules - 1 is the initial scheduled, 2 is exemption, 3 is exemption due to transfer, 4 is the pending S&A
       .hasNumberOfInductionScheduleVersions(4)
       .inductionScheduleVersion(1) {
         // Induction Schedule version 1 is the original schedule
@@ -429,7 +425,6 @@ class PrisonerReceivedEventDueToTransferTest : IntegrationTestBase() {
     }
   }
 
-  @Disabled("Disabled until PES implementation is written which will allow this test to to pass")
   @Test
   fun `should update Induction Schedule and send outbound message given 'prisoner received' (transfer) event for prisoner that has an EXEMPT induction and already has completed Screenings and Assessments`() {
     // Given
@@ -493,7 +488,7 @@ class PrisonerReceivedEventDueToTransferTest : IntegrationTestBase() {
 
     val inductionSchedules = getInductionScheduleHistory(prisonNumber)
     assertThat(inductionSchedules)
-      // Expect 4 schedules - 1 is the initial scheduled, 2 is exemption, 4 is exemption due to transfer, 4 is the rescheduled
+      // Expect 4 schedules - 1 is the initial scheduled, 2 is exemption, 3 is exemption due to transfer, 4 is the rescheduled
       .hasNumberOfInductionScheduleVersions(4)
       .inductionScheduleVersion(1) {
         // Induction Schedule version 1 is the original schedule

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ScheduleEtlTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/resource/ScheduleEtlTest.kt
@@ -13,6 +13,8 @@ import org.mockito.kotlin.verify
 import org.springframework.http.MediaType.APPLICATION_JSON
 import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventEntity
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionScheduleStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.review.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
@@ -27,6 +29,8 @@ import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.Revie
 @Isolated
 class ScheduleEtlTest : IntegrationTestBase() {
 
+  private val today = LocalDate.now()
+
   @BeforeEach
   fun setup() {
     clearDatabase()
@@ -37,7 +41,7 @@ class ScheduleEtlTest : IntegrationTestBase() {
     val uri = "/action-plans/schedules/reschedule-inductions-following-transfer"
 
     @Test
-    fun `should correct induction schedule`() {
+    fun `should correct induction schedule given prisoner does not have completed Screenings and Assessments`() {
       // Given
       val prisonNumber = randomValidPrisonNumber()
 
@@ -87,10 +91,113 @@ class ScheduleEtlTest : IntegrationTestBase() {
         val inductionSchedule = getInductionSchedule(prisonNumber)
         assertThat(inductionSchedule)
           .hasReference(inductionScheduleReference)
+          .wasStatus(InductionScheduleStatusApi.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS)
+          .hasDeadlineDate(today)
+
+        val inductionScheduleHistories = getInductionScheduleHistory(prisonNumber)
+        assertThat(inductionScheduleHistories)
+          .hasNumberOfInductionScheduleVersions(5)
+          .inductionScheduleVersion(1) {
+            it.hasReference(inductionScheduleReference)
+              .wasStatus(InductionScheduleStatusApi.SCHEDULED)
+          }
+          .inductionScheduleVersion(2) {
+            it.hasReference(inductionScheduleReference)
+              .wasStatus(InductionScheduleStatusApi.EXEMPT_PRISONER_TRANSFER)
+          }
+          .inductionScheduleVersion(3) {
+            it.hasReference(inductionScheduleReference)
+              .wasStatus(InductionScheduleStatusApi.SCHEDULED)
+              .hasDeadlineDate(LocalDate.parse("2026-03-31")) // The original incorrect deadline date
+          }
+          .inductionScheduleVersion(4) {
+            it.hasReference(inductionScheduleReference)
+              .wasStatus(InductionScheduleStatusApi.EXEMPT_PRISONER_TRANSFER)
+          }
+          .inductionScheduleVersion(5) {
+            it.hasReference(inductionScheduleReference)
+              .wasStatus(InductionScheduleStatusApi.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS)
+              .hasDeadlineDate(today)
+          }
+
+        // test that outbound events are also created:
+        val inductionScheduleEvents = domainEventQueue.receiveEventsOnQueue(QueueType.INDUCTION)
+        assertThat(inductionScheduleEvents).hasSize(2)
+        inductionScheduleEvents.onEach {
+          assertThat(it.personReference.identifiers[0].value).isEqualTo(prisonNumber)
+          assertThat(it.detailUrl).isEqualTo("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
+        }
+      }
+    }
+
+    @Test
+    fun `should correct induction schedule given prisoner alrwady has completed Screenings and Assessments`() {
+      // Given
+      val prisonNumber = randomValidPrisonNumber()
+
+      val inductionScheduleReference = UUID.randomUUID()
+      createInductionScheduleHistory(
+        prisonNumber = prisonNumber,
+        status = InductionScheduleStatus.SCHEDULED,
+        reference = inductionScheduleReference,
+        version = 1,
+      )
+      createInductionScheduleHistory(
+        prisonNumber = prisonNumber,
+        status = InductionScheduleStatus.EXEMPT_PRISONER_TRANSFER,
+        reference = inductionScheduleReference,
+        version = 2,
+      )
+      createInductionScheduleHistory(
+        prisonNumber = prisonNumber,
+        status = InductionScheduleStatus.SCHEDULED,
+        deadlineDate = LocalDate.parse("2026-03-31"),
+        reference = inductionScheduleReference,
+        version = 3,
+      )
+      createInductionSchedule(
+        prisonNumber = prisonNumber,
+        status = InductionScheduleStatus.SCHEDULED,
+        reference = inductionScheduleReference,
+        deadlineDate = LocalDate.parse("2026-03-31"),
+      )
+
+      educationAssessmentEventRepository.save(
+        EducationAssessmentEventEntity(
+          reference = UUID.randomUUID(),
+          prisonNumber = prisonNumber,
+          status = ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+          statusChangeDate = LocalDate.now().minusDays(2),
+          source = "CURIOUS",
+          detailUrl = null,
+          createdAtPrison = "BXI",
+          updatedAtPrison = "BXI",
+        ),
+      )
+
+      clearQueues()
+
+      val requestBody = PrisonNumbersRequest(prisonNumbers = listOf(prisonNumber))
+
+      // When
+      webTestClient.post()
+        .uri(uri)
+        .withBody(requestBody)
+        .bearerToken(aValidTokenWithAuthority(REVIEWS_RW))
+        .contentType(APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+
+      // Then
+      await untilAsserted {
+        val inductionSchedule = getInductionSchedule(prisonNumber)
+        assertThat(inductionSchedule)
+          .hasReference(inductionScheduleReference)
           .wasStatus(InductionScheduleStatusApi.SCHEDULED)
           .hasDeadlineDate(
-            LocalDate.now().plusDays(20),
-          ) // Deadline should have been extended to date of admission + 20 days, as per standard induction rules for a transfer
+            today.plusDays(10),
+          ) // Deadline should have been extended to date of admission + 10 days, as per PES induction rules for a transfer
 
         val inductionScheduleHistories = getInductionScheduleHistory(prisonNumber)
         assertThat(inductionScheduleHistories)
@@ -116,8 +223,8 @@ class ScheduleEtlTest : IntegrationTestBase() {
             it.hasReference(inductionScheduleReference)
               .wasStatus(InductionScheduleStatusApi.SCHEDULED)
               .hasDeadlineDate(
-                LocalDate.now().plusDays(20),
-              ) // Deadline should have been extended to date of admission + 20 days, as per standard induction rules for a transfer
+                today.plusDays(10),
+              ) // Deadline should have been extended to date of admission + 10 days, as per PES induction rules for a transfer
           }
 
         // test that outbound events are also created:
@@ -288,7 +395,7 @@ class ScheduleEtlTest : IntegrationTestBase() {
             it.hasReference(activeReviewScheduleReference)
               .hasStatus(ReviewScheduleStatusApi.SCHEDULED)
               .hasReviewDateTo(
-                LocalDate.now().plusDays(10),
+                today.plusDays(10),
               ) // Deadline should have been extended to date of admission + 10 days, as per standard review rules for a transfer
           }
 
@@ -322,7 +429,7 @@ class ScheduleEtlTest : IntegrationTestBase() {
               .reviewScheduleAtVersion(5) {
                 it.hasStatus(ReviewScheduleStatusApi.SCHEDULED)
                   .hasReviewDateTo(
-                    LocalDate.now().plusDays(10),
+                    today.plusDays(10),
                   ) // Deadline should have been extended to date of admission + 10 days, as per standard induction rules for a transfer
               }
           }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/specialtests/pef/ScheduleEtlTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/specialtests/pef/ScheduleEtlTest.kt
@@ -1,0 +1,131 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.specialtests.pef
+
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.induction.InductionScheduleStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.PrisonNumbersRequest
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.resource.REVIEWS_RW
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.bearerToken
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.induction.assertThat
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.withBody
+import java.time.LocalDate
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.resource.model.InductionScheduleStatus as InductionScheduleStatusApi
+
+@Isolated
+@ActiveProfiles("integration-test", "ciag-kpi-pef-rules")
+class ScheduleEtlTest : IntegrationTestBase() {
+
+  @BeforeEach
+  fun setup() {
+    clearDatabase()
+  }
+
+  @Nested
+  inner class CorrectInductionSchedules {
+    val uri = "/action-plans/schedules/reschedule-inductions-following-transfer"
+
+    @Test
+    fun `should correct induction schedule`() {
+      // Given
+      val prisonNumber = randomValidPrisonNumber()
+
+      val inductionScheduleReference = UUID.randomUUID()
+      createInductionScheduleHistory(
+        prisonNumber = prisonNumber,
+        status = InductionScheduleStatus.SCHEDULED,
+        reference = inductionScheduleReference,
+        version = 1,
+      )
+      createInductionScheduleHistory(
+        prisonNumber = prisonNumber,
+        status = InductionScheduleStatus.EXEMPT_PRISONER_TRANSFER,
+        reference = inductionScheduleReference,
+        version = 2,
+      )
+      createInductionScheduleHistory(
+        prisonNumber = prisonNumber,
+        status = InductionScheduleStatus.SCHEDULED,
+        deadlineDate = LocalDate.parse("2026-03-31"),
+        reference = inductionScheduleReference,
+        version = 3,
+      )
+      createInductionSchedule(
+        prisonNumber = prisonNumber,
+        status = InductionScheduleStatus.SCHEDULED,
+        reference = inductionScheduleReference,
+        deadlineDate = LocalDate.parse("2026-03-31"),
+      )
+
+      clearQueues()
+
+      val requestBody = PrisonNumbersRequest(prisonNumbers = listOf(prisonNumber))
+
+      // When
+      webTestClient.post()
+        .uri(uri)
+        .withBody(requestBody)
+        .bearerToken(aValidTokenWithAuthority(REVIEWS_RW))
+        .contentType(APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+
+      // Then
+      await untilAsserted {
+        val inductionSchedule = getInductionSchedule(prisonNumber)
+        assertThat(inductionSchedule)
+          .hasReference(inductionScheduleReference)
+          .wasStatus(InductionScheduleStatusApi.SCHEDULED)
+          .hasDeadlineDate(
+            LocalDate.now().plusDays(20),
+          ) // Deadline should have been extended to date of admission + 20 days, as per PEF induction rules for a transfer
+
+        val inductionScheduleHistories = getInductionScheduleHistory(prisonNumber)
+        assertThat(inductionScheduleHistories)
+          .hasNumberOfInductionScheduleVersions(5)
+          .inductionScheduleVersion(1) {
+            it.hasReference(inductionScheduleReference)
+              .wasStatus(InductionScheduleStatusApi.SCHEDULED)
+          }
+          .inductionScheduleVersion(2) {
+            it.hasReference(inductionScheduleReference)
+              .wasStatus(InductionScheduleStatusApi.EXEMPT_PRISONER_TRANSFER)
+          }
+          .inductionScheduleVersion(3) {
+            it.hasReference(inductionScheduleReference)
+              .wasStatus(InductionScheduleStatusApi.SCHEDULED)
+              .hasDeadlineDate(LocalDate.parse("2026-03-31")) // The original incorrect deadline date
+          }
+          .inductionScheduleVersion(4) {
+            it.hasReference(inductionScheduleReference)
+              .wasStatus(InductionScheduleStatusApi.EXEMPT_PRISONER_TRANSFER)
+          }
+          .inductionScheduleVersion(5) {
+            it.hasReference(inductionScheduleReference)
+              .wasStatus(InductionScheduleStatusApi.SCHEDULED)
+              .hasDeadlineDate(
+                LocalDate.now().plusDays(20),
+              ) // Deadline should have been extended to date of admission + 20 days, as per PEF induction rules for a transfer
+          }
+
+        // test that outbound events are also created:
+        val inductionScheduleEvents = domainEventQueue.receiveEventsOnQueue(QueueType.INDUCTION)
+        assertThat(inductionScheduleEvents).hasSize(2)
+        inductionScheduleEvents.onEach {
+          assertThat(it.personReference.identifiers[0].value).isEqualTo(prisonNumber)
+          assertThat(it.detailUrl).isEqualTo("http://localhost:8080/inductions/$prisonNumber/induction-schedule")
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/config/DomainConfiguration.kt
@@ -10,10 +10,6 @@ import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.employability
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.employabilityskill.service.EmployabilitySkillsService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionEventService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionPersistenceAdapter
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleDateCalculationService
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleEventService
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionSchedulePersistenceAdapter
-import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.note.service.NoteService
 import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.review.service.ReviewEventService
@@ -85,17 +81,6 @@ class DomainConfiguration {
     inductionPersistenceAdapter: InductionPersistenceAdapter,
     inductionEventService: InductionEventService,
   ): InductionService = InductionService(inductionPersistenceAdapter, inductionEventService)
-
-  @Bean
-  fun inductionScheduleDomainService(
-    inductionSchedulePersistenceAdapter: InductionSchedulePersistenceAdapter,
-    inductionScheduleEventService: InductionScheduleEventService,
-    inductionScheduleDateCalculationService: InductionScheduleDateCalculationService,
-  ): InductionScheduleService = InductionScheduleService(
-    inductionSchedulePersistenceAdapter,
-    inductionScheduleEventService,
-    inductionScheduleDateCalculationService,
-  )
 
   @Bean
   fun educationDomainService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationService.kt
@@ -64,6 +64,11 @@ class PefInductionScheduleDateCalculationService(
   }
 
   /**
+   * PEF implementation. Induction Schedules are extended by 20 days when a prisoner is transferred
+   */
+  override fun extensionDaysForTransfer(): Long = TWENTY_DAYS
+
+  /**
    * Not supported under the PEF contract: a prisoner's Induction is scheduled on prison admission, not following the
    * completion of their Screening & Assessments, so there is no S&A based deadline to calculate.
    */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleService.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.inducton
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleDateCalculationService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleEventService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionSchedulePersistenceAdapter
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleService
+import java.time.LocalDate
+
+/**
+ * Implementation of [InductionScheduleService] with implemented behaviours specific to the CIAG PEF contracts.
+ *
+ * This bean is enabled when the PES implementation bean ([PesInductionScheduleService]) is not present.
+ */
+@Service
+@Primary
+@ConditionalOnMissingBean(PesInductionScheduleService::class)
+class PefInductionScheduleService(
+  inductionSchedulePersistenceAdapter: InductionSchedulePersistenceAdapter,
+  inductionScheduleEventService: InductionScheduleEventService,
+  private val inductionScheduleDateCalculationService: InductionScheduleDateCalculationService,
+) : InductionScheduleService(
+  inductionSchedulePersistenceAdapter,
+  inductionScheduleEventService,
+  inductionScheduleDateCalculationService,
+) {
+
+  override fun updatedInductionDeadlineForProcessingTransfer(inductionSchedule: InductionSchedule): LocalDate = inductionScheduleDateCalculationService.calculateAdjustedInductionDueDate(inductionSchedule)
+
+  override fun updatedStatusForProcessingTransfer(inductionSchedule: InductionSchedule): InductionScheduleStatus = InductionScheduleStatus.SCHEDULED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationService.kt
@@ -64,4 +64,9 @@ class PesInductionScheduleDateCalculationService(
     InductionScheduleCalculationRule.NEW_PRISON_ADMISSION_EXTENDED_DEADLINE_PERIOD -> TEN_DAYS // TODO - update here if the business decide they want a longer deadline over extended deadline periods such as Christmas
     else -> TEN_DAYS
   }
+
+  /**
+   * PES implementation. Induction Schedules are extended by 10 days when a prisoner is transferred
+   */
+  override fun extensionDaysForTransfer(): Long = TEN_DAYS
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleService.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.inducton
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleDateCalculationService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleEventService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionSchedulePersistenceAdapter
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleService
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.EducationAssessmentEventRepository
+import java.time.Clock
+import java.time.LocalDate
+
+/**
+ * Implementation of [InductionScheduleService] with implemented behaviours specific to the CIAG PES contracts.
+ *
+ * This bean is only enabled when the `ciag-kpi-processing-rule` property is set to `PES`; otherwise [PefInductionScheduleService]
+ * is used.
+ */
+@Service
+@ConditionalOnProperty(name = ["ciag-kpi-processing-rule"], havingValue = "PES")
+class PesInductionScheduleService(
+  inductionSchedulePersistenceAdapter: InductionSchedulePersistenceAdapter,
+  inductionScheduleEventService: InductionScheduleEventService,
+  private val inductionScheduleDateCalculationService: InductionScheduleDateCalculationService,
+  private val educationAssessmentEventRepository: EducationAssessmentEventRepository,
+  private val clock: Clock,
+) : InductionScheduleService(
+  inductionSchedulePersistenceAdapter,
+  inductionScheduleEventService,
+  inductionScheduleDateCalculationService,
+) {
+
+  override fun updatedInductionDeadlineForProcessingTransfer(inductionSchedule: InductionSchedule): LocalDate = if (hasCompletedAllAssessments(inductionSchedule.prisonNumber)) {
+    inductionScheduleDateCalculationService.calculateAdjustedInductionDueDate(inductionSchedule)
+  } else {
+    LocalDate.now(clock)
+  }
+
+  override fun updatedStatusForProcessingTransfer(inductionSchedule: InductionSchedule): InductionScheduleStatus = if (hasCompletedAllAssessments(inductionSchedule.prisonNumber)) {
+    InductionScheduleStatus.SCHEDULED
+  } else {
+    InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS
+  }
+
+  private fun hasCompletedAllAssessments(prisonNumber: String): Boolean = educationAssessmentEventRepository.existsByPrisonNumberAndStatus(
+    prisonNumber,
+    EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleDateCalculationServiceTest.kt
@@ -58,4 +58,15 @@ class PefInductionScheduleDateCalculationServiceTest {
       service.determineDeadlineDateForCompletedAssessments(InductionScheduleCalculationRule.NEW_PRISON_ADMISSION)
     }
   }
+
+  @Test
+  fun `should get the number of extension days for a transfer`() {
+    // Given
+
+    // When
+    val actual = service.extensionDaysForTransfer()
+
+    // Then
+    assertThat(actual).isEqualTo(20)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PefInductionScheduleServiceTest.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.inducton
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidInductionSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleDateCalculationService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleEventService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionSchedulePersistenceAdapter
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class PefInductionScheduleServiceTest {
+
+  @InjectMocks
+  private lateinit var inductionScheduleService: PefInductionScheduleService
+
+  @Mock
+  private lateinit var inductionSchedulePersistenceAdapter: InductionSchedulePersistenceAdapter
+
+  @Mock
+  private lateinit var inductionScheduleEventService: InductionScheduleEventService
+
+  @Mock
+  private lateinit var inductionScheduleDateCalculationService: InductionScheduleDateCalculationService
+
+  @Test
+  fun `should return updated deadline date for processing transfer`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber)
+
+    val expected = LocalDate.now().plusDays(20)
+    given(inductionScheduleDateCalculationService.calculateAdjustedInductionDueDate(any()))
+      .willReturn(expected)
+
+    // When
+    val actual = inductionScheduleService.updatedInductionDeadlineForProcessingTransfer(inductionSchedule)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+    verify(inductionScheduleDateCalculationService).calculateAdjustedInductionDueDate(inductionSchedule)
+  }
+
+  @Test
+  fun `should return updated status for processing transfer`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber)
+
+    // When
+    val actual = inductionScheduleService.updatedStatusForProcessingTransfer(inductionSchedule)
+
+    // Then
+    assertThat(actual).isEqualTo(InductionScheduleStatus.SCHEDULED)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleDateCalculationServiceTest.kt
@@ -57,4 +57,15 @@ class PesInductionScheduleDateCalculationServiceTest {
     // Then
     assertThat(actual).isEqualTo(LocalDate.parse("2026-04-27")) // fixed clock is 2026-04-17, plus 10 days
   }
+
+  @Test
+  fun `should get the number of extension days for a transfer`() {
+    // Given
+
+    // When
+    val actual = service.extensionDaysForTransfer()
+
+    // Then
+    assertThat(actual).isEqualTo(10)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/service/inducton/PesInductionScheduleServiceTest.kt
@@ -1,0 +1,130 @@
+package uk.gov.justice.digital.hmpps.educationandworkplanapi.app.service.inducton
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.InductionScheduleStatus
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.aValidInductionSchedule
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleDateCalculationService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionScheduleEventService
+import uk.gov.justice.digital.hmpps.domain.learningandworkprogress.induction.service.InductionSchedulePersistenceAdapter
+import uk.gov.justice.digital.hmpps.domain.randomValidPrisonNumber
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.entity.educationassessment.EducationAssessmentEventStatus
+import uk.gov.justice.digital.hmpps.educationandworkplanapi.app.database.jpa.repository.EducationAssessmentEventRepository
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+class PesInductionScheduleServiceTest {
+  private val inductionSchedulePersistenceAdapter: InductionSchedulePersistenceAdapter = mock()
+
+  private val inductionScheduleEventService: InductionScheduleEventService = mock()
+
+  private val inductionScheduleDateCalculationService: InductionScheduleDateCalculationService = mock()
+
+  private val educationAssessmentEventRepository: EducationAssessmentEventRepository = mock()
+
+  private val fixedTimestamp = Instant.parse("2026-04-17T09:13:22.123Z")
+  private val clock = Clock.fixed(fixedTimestamp, ZoneId.of("UTC"))
+
+  private val inductionScheduleService = PesInductionScheduleService(
+    inductionSchedulePersistenceAdapter,
+    inductionScheduleEventService,
+    inductionScheduleDateCalculationService,
+    educationAssessmentEventRepository,
+    clock,
+  )
+
+  @Test
+  fun `should return updated deadline date for processing transfer given prisoner has completed screenings and assessments`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber)
+
+    given(educationAssessmentEventRepository.existsByPrisonNumberAndStatus(any(), any()))
+      .willReturn(true)
+
+    val expected = LocalDate.now().plusDays(20)
+    given(inductionScheduleDateCalculationService.calculateAdjustedInductionDueDate(any()))
+      .willReturn(expected)
+
+    // When
+    val actual = inductionScheduleService.updatedInductionDeadlineForProcessingTransfer(inductionSchedule)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+    verify(inductionScheduleDateCalculationService).calculateAdjustedInductionDueDate(inductionSchedule)
+    verify(educationAssessmentEventRepository).existsByPrisonNumberAndStatus(
+      prisonNumber,
+      EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+    )
+  }
+
+  @Test
+  fun `should return updated deadline date for processing transfer given prisoner has not completed screenings and assessments`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber)
+
+    given(educationAssessmentEventRepository.existsByPrisonNumberAndStatus(any(), any()))
+      .willReturn(false)
+
+    val expected = LocalDate.now(clock)
+
+    // When
+    val actual = inductionScheduleService.updatedInductionDeadlineForProcessingTransfer(inductionSchedule)
+
+    // Then
+    assertThat(actual).isEqualTo(expected)
+    verifyNoInteractions(inductionScheduleDateCalculationService)
+    verify(educationAssessmentEventRepository).existsByPrisonNumberAndStatus(
+      prisonNumber,
+      EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+    )
+  }
+
+  @Test
+  fun `should return updated status for processing transfer given prisoner has completed screenings and assessments`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber)
+
+    given(educationAssessmentEventRepository.existsByPrisonNumberAndStatus(any(), any()))
+      .willReturn(true)
+
+    // When
+    val actual = inductionScheduleService.updatedStatusForProcessingTransfer(inductionSchedule)
+
+    // Then
+    assertThat(actual).isEqualTo(InductionScheduleStatus.SCHEDULED)
+    verify(educationAssessmentEventRepository).existsByPrisonNumberAndStatus(
+      prisonNumber,
+      EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+    )
+  }
+
+  @Test
+  fun `should return updated status for processing transfer given prisoner has not completed screenings and assessments`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val inductionSchedule = aValidInductionSchedule(prisonNumber = prisonNumber)
+
+    given(educationAssessmentEventRepository.existsByPrisonNumberAndStatus(any(), any()))
+      .willReturn(false)
+
+    // When
+    val actual = inductionScheduleService.updatedStatusForProcessingTransfer(inductionSchedule)
+
+    // Then
+    assertThat(actual).isEqualTo(InductionScheduleStatus.PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS)
+    verify(educationAssessmentEventRepository).existsByPrisonNumberAndStatus(
+      prisonNumber,
+      EducationAssessmentEventStatus.ALL_RELEVANT_ASSESSMENTS_COMPLETE,
+    )
+  }
+}


### PR DESCRIPTION
This PR fixes the implementation for transfers under PES. 

Basically the rules for transfers are slightly different under PES than they are under PEF:

On prisoner transfer, if the prisoner has not had their Induction for any reason:
* PEF (existing rules)
  * Set the InductionSchedule status to SCHEDULED, with a deadline date of today + 20

* PES (to be enabled 01/09/26)
  * If the prisoner has already completed their screenings and assessments
    * Set the InductionSchedule status to SCHEDULED, with a deadline date of today + 10
  * If the prisoner has not completed their screenings and assessments
    * Set the InductionSchedule status to PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS, with a deadline date of today


The Integration tests now pass