### PR TITLE
Renovate config to skip openapi-generator v7.23.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,13 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non major Gradle dependencies",
       "groupSlug": "all-gradle-minor-patch"
+    },
+    {
+      "description": "Skip broken openApi plugin version",
+      "matchPackageNames": [
+        "org.openapitools:openapi-generator-gradle-plugin"
+      ],
+      "allowedVersions": "!/7.23.0/"
     }
   ]
 }


### PR DESCRIPTION
This PR configures renovate so that it skips 7.23.0 of the openapi-generator plugin.

For the past few weeks, renovate has been trying to bump the openapi-generator plugin from 7.22.0 to 7.23.0.
7.23.0 fails the build, so every time I take it out of the PR and merge it, it creates a new renovate PR to bump it again!
Here is the [latest renovate PR which attempts to bump openapi-generator plugin](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/pull/980) from 7.22.0 to 7.23.0; and the build failure is because of the version bump.

Basically 7.23.0 contains a change which arguably is a breaking change (so perhaps should have been a major version bump). That aside, it is a breaking change for our project. It now generates data classes with the following annotation on nullable fields:
```
@field:JsonSetter(nulls = Nulls.FAIL)
@get:JsonProperty("surname") val surname: kotlin.String? = null
```
Such fields are deliberately nullable in our swagger spec. The kotlin datatype is nullable. But with the annotation, deserialisation of json fails if the property is null. IE. this will fail at runtime:
```
{
  ...
  surname: null,
  ...
}
```

That is a breaking change for us 😢 

We are not alone; this change has broken other people's projects in the same way, and [a bug has been raised for it](https://github.com/OpenAPITools/openapi-generator/issues/23976).
The bug has been fixed, but it is not clear when they will release a new version including this bug fix.

This change to our renovate config is to tell it to skip 7.23.0. As and when 7.24.0 (or 7.23.1 ?) is released hopefully renovate will pick it up and include it in a PR