### PR TITLE
RR-2810 - Use correct title on SAR report

### DIFF
--- a/src/integrationTest/resources/sar/expected-report.html
+++ b/src/integrationTest/resources/sar/expected-report.html
@@ -221,7 +221,7 @@
 
 </style>
 
-<h1 class="title">Personal Learning Plan</h1>
+<h1 class="title">Learning and Work Progress</h1>
 
 <h2>Completed induction</h2>
 <table class="summary-list">

--- a/src/main/resources/static/sar/template.mustache
+++ b/src/main/resources/static/sar/template.mustache
@@ -1,4 +1,4 @@
-<h1 class="title">Personal Learning Plan</h1>
+<h1 class="title">Learning and Work Progress</h1>
 
 <h2>Completed induction</h2>
 {{#induction}}


### PR DESCRIPTION
PR to use the correct title in the SAR report
(previously it was Personal Learning Plans, which was a very very early name for our service)

See attached example report
[sar-generated-report.pdf](https://github.com/user-attachments/files/30407690/sar-generated-report.pdf)
