### PR TITLE
RR-2767 apply 17day rule on transfer that already have a review schedule

### DIFF
--- a/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
+++ b/domain/learningandworkprogress/src/main/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleService.kt
@@ -179,6 +179,15 @@ class ReviewScheduleService(
   fun exemptActiveReviewScheduleStatusDueToUnknownReason(prisonNumber: String, prisonId: String) = exemptActiveReviewSchedule(prisonNumber, prisonId, ReviewScheduleStatus.EXEMPT_UNKNOWN)
 
   /**
+   * Exempts the prisoner's active Review Schedule as EXEMPT_PRISONER_TRANSFER **without** re-scheduling it.
+   * Used on transfer when the prisoner has less than 17 days left to serve, so that they have no review due (a
+   * today + 10 deadline would fall inside the last 7 days before release). EXEMPT_PRISONER_TRANSFER is not an
+   * "active" review status, so the prisoner is left with no active Review Schedule. If they later transfer again
+   * with 17 or more days left, the normal transfer handling creates a fresh Review Schedule due in 10 days.
+   */
+  fun exemptActiveReviewScheduleDueToPrisonerTransfer(prisonNumber: String, prisonId: String) = exemptActiveReviewSchedule(prisonNumber, prisonId, ReviewScheduleStatus.EXEMPT_PRISONER_TRANSFER)
+
+  /**
    * Updates the prisoner's active Review Schedule by setting its status to EXEMPT_PRISONER_TRANSFER, then immediately
    * re-scheduling it.
    * Applying both status changes in quick succession (EXEMPT_PRISONER_TRANSFER, immediately followed by SCHEDULED) allows

--- a/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleServiceTest.kt
+++ b/domain/learningandworkprogress/src/test/kotlin/uk/gov/justice/digital/hmpps/domain/learningandworkprogress/review/service/ReviewScheduleServiceTest.kt
@@ -294,6 +294,61 @@ class ReviewScheduleServiceTest {
   }
 
   @Nested
+  inner class ExemptActiveReviewScheduleDueToPrisonerTransfer {
+    @Test
+    fun `should exempt active Review Schedule as EXEMPT_PRISONER_TRANSFER without re-scheduling`() {
+      // Given
+      val prisonNumber = randomValidPrisonNumber()
+      val prisonId = "BXI"
+
+      val activeReviewSchedule = aValidReviewSchedule(
+        prisonNumber = prisonNumber,
+        scheduleStatus = ReviewScheduleStatus.SCHEDULED,
+      )
+      given(reviewSchedulePersistenceAdapter.getActiveReviewSchedule(any())).willReturn(activeReviewSchedule)
+
+      val updatedReviewSchedule = activeReviewSchedule.copy(
+        scheduleStatus = ReviewScheduleStatus.EXEMPT_PRISONER_TRANSFER,
+      )
+      given(reviewSchedulePersistenceAdapter.updateReviewScheduleStatus(any())).willReturn(updatedReviewSchedule)
+
+      // When
+      reviewScheduleService.exemptActiveReviewScheduleDueToPrisonerTransfer(prisonNumber, prisonId)
+
+      // Then
+      verify(reviewSchedulePersistenceAdapter).getActiveReviewSchedule(prisonNumber)
+
+      val updateReviewScheduleStatusDtoCaptor = argumentCaptor<UpdateReviewScheduleStatusDto>()
+      // Exempt only - a single status update, with no follow-on re-schedule back to SCHEDULED
+      verify(reviewSchedulePersistenceAdapter).updateReviewScheduleStatus(updateReviewScheduleStatusDtoCaptor.capture())
+      val updateReviewScheduleStatusDto = updateReviewScheduleStatusDtoCaptor.firstValue
+      assertThat(updateReviewScheduleStatusDto.reference).isEqualTo(activeReviewSchedule.reference)
+      assertThat(updateReviewScheduleStatusDto.prisonNumber).isEqualTo(prisonNumber)
+      assertThat(updateReviewScheduleStatusDto.prisonId).isEqualTo(prisonId)
+      assertThat(updateReviewScheduleStatusDto.scheduleStatus).isEqualTo(ReviewScheduleStatus.EXEMPT_PRISONER_TRANSFER)
+    }
+
+    @Test
+    fun `should not exempt Review Schedule given prisoner does not have an active review schedule`() {
+      // Given
+      val prisonNumber = randomValidPrisonNumber()
+      val prisonId = "BXI"
+
+      given(reviewSchedulePersistenceAdapter.getActiveReviewSchedule(any())).willReturn(null)
+
+      // When
+      val exception = assertThrows(ReviewScheduleNotFoundException::class.java) {
+        reviewScheduleService.exemptActiveReviewScheduleDueToPrisonerTransfer(prisonNumber, prisonId)
+      }
+
+      // Then
+      assertThat(exception.prisonNumber).isEqualTo(prisonNumber)
+      verify(reviewSchedulePersistenceAdapter).getActiveReviewSchedule(prisonNumber)
+      verifyNoInteractions(reviewScheduleEventService)
+    }
+  }
+
+  @Nested
   inner class ExemptAndReScheduleActiveReviewScheduleDueToPrisonerTransfer {
     @Test
     fun `should exempt and re-schedule active Review Schedule for prisoner`() {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventDueToTransferTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedEventDueToTransferTest.kt
@@ -1253,6 +1253,137 @@ class PrisonerReceivedEventDueToTransferTest : IntegrationTestBase() {
             .hasReviewDateTo(LocalDate.now().plusDays(10))
         }
     }
+
+    @Test
+    fun `prisoner with an active review schedule who transfers with less than 17 days left to serve has it exempted and NOT re-scheduled`() {
+      // Given
+      // an active SCHEDULED review schedule (created while the prisoner had more than 3 months left to serve)
+      val prisonNumber = setUpRandomPrisoner(releaseDate = LocalDate.now().plusDays(100))
+      createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork(prisonId = ORIGINAL_PRISON))
+      createActionPlan(prisonNumber)
+
+      // their release date has since moved to within 17 days
+      wiremockService.stubGetPrisonerFromPrisonerSearchApi(
+        prisonNumber,
+        aValidPrisoner(
+          prisonerNumber = prisonNumber,
+          legalStatus = LegalStatus.SENTENCED,
+          releaseDate = LocalDate.now().plusDays(16),
+        ),
+      )
+
+      await untilCallTo {
+        reviewScheduleEventQueue.countAllMessagesOnQueue()
+      } matches { it != null && it > 0 }
+      clearQueues()
+
+      val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+        prisonNumber = prisonNumber,
+        eventType = PRISONER_RECEIVED_INTO_PRISON,
+        additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+          prisonNumber = prisonNumber,
+          prisonId = PRISON_TRANSFERRING_TO,
+          reason = TRANSFERRED,
+        ),
+      )
+
+      // When
+      sendDomainEvent(sqsMessage)
+
+      // Then
+      await untilCallTo {
+        domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+      } matches { it == 0 }
+
+      // the existing review schedule is exempted due to transfer and NOT re-scheduled, so no review is due
+      assertThat(getReviewSchedules(prisonNumber))
+        .hasNumberOfReviewSchedules(2)
+        .reviewScheduleAtVersion(1) {
+          it.hasStatus(ReviewScheduleStatus.SCHEDULED)
+        }
+        .reviewScheduleAtVersion(2) {
+          it.hasStatus(ReviewScheduleStatus.EXEMPT_PRISONER_TRANSFER)
+        }
+    }
+
+    @Test
+    fun `prisoner exempted on transfer with less than 17 days left gets a review due in 10 days when they transfer again with more than 17 days left`() {
+      // Given
+      // an active SCHEDULED review schedule
+      val prisonNumber = setUpRandomPrisoner(releaseDate = LocalDate.now().plusDays(100))
+      createInduction(prisonNumber, aValidCreateInductionRequestForPrisonerNotLookingToWork(prisonId = ORIGINAL_PRISON))
+      createActionPlan(prisonNumber)
+
+      // When they transfer with less than 17 days left to serve
+      wiremockService.stubGetPrisonerFromPrisonerSearchApi(
+        prisonNumber,
+        aValidPrisoner(
+          prisonerNumber = prisonNumber,
+          legalStatus = LegalStatus.SENTENCED,
+          releaseDate = LocalDate.now().plusDays(16),
+        ),
+      )
+      await untilCallTo {
+        reviewScheduleEventQueue.countAllMessagesOnQueue()
+      } matches { it != null && it > 0 }
+      clearQueues()
+
+      sendDomainEvent(
+        aValidHmppsDomainEventsSqsMessage(
+          prisonNumber = prisonNumber,
+          eventType = PRISONER_RECEIVED_INTO_PRISON,
+          additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+            prisonNumber = prisonNumber,
+            prisonId = PRISON_TRANSFERRING_TO,
+            reason = TRANSFERRED,
+          ),
+        ),
+      )
+      await untilCallTo {
+        domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+      } matches { it == 0 }
+
+      // Then no review is due - the schedule is exempted, not re-scheduled
+      assertThat(getReviewSchedules(prisonNumber))
+        .hasNumberOfReviewSchedules(2)
+        .reviewScheduleAtVersion(2) {
+          it.hasStatus(ReviewScheduleStatus.EXEMPT_PRISONER_TRANSFER)
+        }
+
+      // When they transfer again and their release date has been pushed back beyond 17 days
+      wiremockService.stubGetPrisonerFromPrisonerSearchApi(
+        prisonNumber,
+        aValidPrisoner(
+          prisonerNumber = prisonNumber,
+          legalStatus = LegalStatus.SENTENCED,
+          releaseDate = LocalDate.now().plusDays(100),
+        ),
+      )
+      clearQueues()
+
+      sendDomainEvent(
+        aValidHmppsDomainEventsSqsMessage(
+          prisonNumber = prisonNumber,
+          eventType = PRISONER_RECEIVED_INTO_PRISON,
+          additionalInformation = aValidPrisonerReceivedAdditionalInformation(
+            prisonNumber = prisonNumber,
+            prisonId = PRISON_TRANSFERRING_TO,
+            reason = TRANSFERRED,
+          ),
+        ),
+      )
+      await untilCallTo {
+        domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+      } matches { it == 0 }
+
+      // Then their current review schedule is due in 10 days (a fresh schedule is created because the exempted
+      // one is no longer active)
+      assertThat(getActionPlanReviews(prisonNumber))
+        .latestReviewSchedule {
+          it.hasStatus(ReviewScheduleStatus.SCHEDULED)
+            .hasReviewDateTo(LocalDate.now().plusDays(10))
+        }
+    }
   }
 
   private fun completeReview(prisonNumber: String) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventService.kt
@@ -184,28 +184,41 @@ class PrisonerReceivedIntoPrisonEventService(
       log.warn { "Exception thrown when completing induction or creating review schedule: ${e.message}" }
     }
 
-    handle(
-      scheduleType = REVIEW_SCHEDULE,
-      action = {
-        reviewScheduleService.exemptAndReScheduleActiveReviewScheduleDueToPrisonerTransfer(
-          prisonNumber = nomsNumber,
-          prisonTransferredTo = prisonId,
-        )
-      },
-    )
-
-    // RR-2767: On transfer, if the prisoner has completed their induction but has no active review
-    // schedule, apply the "17 day rule" regardless of whether a pre-release review was ever recorded.
-    // A review is only skipped when the release date is known and falls within the next 17 days, because
-    // a today + 10 day deadline would then land inside the last 7 days before release. In every other case
-    // (17+ days left to serve, a release date in the past, or no release date at all) a new review schedule
-    // is created with a deadline of today + 10 days.
+    // RR-2767: the "17 day rule" runs on every transfer, whether or not the prisoner already has
+    // a Review Schedule. A review is only withheld when the release date is known and falls within the next 17
+    // days, because a today + 10 day deadline would then land inside the last 7 days before release. In every
+    // other case (17+ days left to serve, a release date in the past, or no release date at all) the prisoner
+    // should have a review due today + 10.
+    // Only a prisoner who has completed their induction can have a Review Schedule, so gating the whole block on
+    // isInductionComplete also covers the "prisoner already has an active Review Schedule" case.
     if (scheduleAdapter.isInductionComplete(nomsNumber)) {
       val releaseDate = prisonerSearchApiService.getPrisoner(nomsNumber).releaseDate
       val today = LocalDate.now(clock)
       val hasLessThan17DaysLeftToServe = releaseDate != null &&
         !releaseDate.isBefore(today) &&
         releaseDate.isBefore(today.plusDays(17))
+
+      // If the prisoner already has an active Review Schedule, re-schedule it to today + 10 - or, when they now
+      // have less than 17 days left, exempt it without re-scheduling so that they have no review due.
+      handle(
+        scheduleType = REVIEW_SCHEDULE,
+        action = {
+          if (hasLessThan17DaysLeftToServe) {
+            reviewScheduleService.exemptActiveReviewScheduleDueToPrisonerTransfer(
+              prisonNumber = nomsNumber,
+              prisonId = prisonId,
+            )
+          } else {
+            reviewScheduleService.exemptAndReScheduleActiveReviewScheduleDueToPrisonerTransfer(
+              prisonNumber = nomsNumber,
+              prisonTransferredTo = prisonId,
+            )
+          }
+        },
+      )
+
+      // If the prisoner has no active Review Schedule, create one with a deadline of today + 10 (unless they
+      // have less than 17 days left to serve, in which case no review is due).
       if (!hasLessThan17DaysLeftToServe) {
         reviewScheduleService.handle17DayTransferRule(
           prisonNumber = nomsNumber,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationandworkplanapi/app/messaging/PrisonerReceivedIntoPrisonEventServiceTest.kt
@@ -515,10 +515,10 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
   }
 
   @Test
-  fun `should process event given reason is prisoner transfer`() {
+  fun `should re-schedule the active review schedule on transfer given prisoner has completed their induction and has 17 or more days left to serve`() {
     // Given
     val prisonNumber = randomValidPrisonNumber()
-    val prisoner = aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "BXI")
+    val prisoner = aValidPrisoner(prisonerNumber = prisonNumber, prisonId = "BXI", releaseDate = today.plusDays(18))
 
     val additionalInformation = aValidPrisonerReceivedAdditionalInformation(
       prisonNumber = prisonNumber,
@@ -526,12 +526,51 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
       prisonId = "BXI",
     )
     val inboundEvent = anInboundEvent(additionalInformation)
+    given(scheduleAdapter.isInductionComplete(prisonNumber)).willReturn(true)
+    given(prisonerSearchApiService.getPrisoner(prisonNumber)).willReturn(prisoner)
 
     // When
     eventService.process(inboundEvent, additionalInformation)
 
     // Then
     verify(reviewScheduleService).exemptAndReScheduleActiveReviewScheduleDueToPrisonerTransfer(prisonNumber, "BXI")
+    verify(reviewScheduleService, never()).exemptActiveReviewScheduleDueToPrisonerTransfer(any(), any())
+  }
+
+  @Test
+  fun `should exempt without re-scheduling the active review schedule on transfer given prisoner has completed their induction but has less than 17 days left to serve`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val additionalInformation = aValidPrisonerReceivedAdditionalInformation(prisonNumber = prisonNumber, reason = TRANSFERRED, prisonId = "BXI")
+    val inboundEvent = anInboundEvent(additionalInformation)
+    given(scheduleAdapter.isInductionComplete(prisonNumber)).willReturn(true)
+    given(prisonerSearchApiService.getPrisoner(prisonNumber)).willReturn(aValidPrisoner(prisonerNumber = prisonNumber, releaseDate = today.plusDays(16)))
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(reviewScheduleService).exemptActiveReviewScheduleDueToPrisonerTransfer(prisonNumber, "BXI")
+    verify(reviewScheduleService, never()).exemptAndReScheduleActiveReviewScheduleDueToPrisonerTransfer(any(), any())
+    verify(reviewScheduleService, never()).handle17DayTransferRule(any(), any(), any())
+  }
+
+  @Test
+  fun `should not touch the review schedule on transfer given prisoner has not completed their induction`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    val additionalInformation = aValidPrisonerReceivedAdditionalInformation(prisonNumber = prisonNumber, reason = TRANSFERRED, prisonId = "BXI")
+    val inboundEvent = anInboundEvent(additionalInformation)
+    given(scheduleAdapter.isInductionComplete(prisonNumber)).willReturn(false)
+
+    // When
+    eventService.process(inboundEvent, additionalInformation)
+
+    // Then
+    verify(reviewScheduleService, never()).exemptActiveReviewScheduleDueToPrisonerTransfer(any(), any())
+    verify(reviewScheduleService, never()).exemptAndReScheduleActiveReviewScheduleDueToPrisonerTransfer(any(), any())
+    verify(reviewScheduleService, never()).handle17DayTransferRule(any(), any(), any())
+    verify(prisonerSearchApiService, never()).getPrisoner(prisonNumber)
   }
 
   @Test
@@ -569,22 +608,6 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
   }
 
   @Test
-  fun `should not apply 17 day transfer rule given prisoner has completed their induction but has less than 17 days left to serve`() {
-    // Given
-    val prisonNumber = randomValidPrisonNumber()
-    val additionalInformation = aValidPrisonerReceivedAdditionalInformation(prisonNumber = prisonNumber, reason = TRANSFERRED, prisonId = "BXI")
-    val inboundEvent = anInboundEvent(additionalInformation)
-    given(scheduleAdapter.isInductionComplete(prisonNumber)).willReturn(true)
-    given(prisonerSearchApiService.getPrisoner(prisonNumber)).willReturn(aValidPrisoner(prisonerNumber = prisonNumber, releaseDate = today.plusDays(16)))
-
-    // When
-    eventService.process(inboundEvent, additionalInformation)
-
-    // Then
-    verify(reviewScheduleService, never()).handle17DayTransferRule(any(), any(), any())
-  }
-
-  @Test
   fun `should apply 17 day transfer rule given prisoner has completed their induction but has no release date`() {
     // Given
     val prisonNumber = randomValidPrisonNumber()
@@ -598,22 +621,6 @@ class PrisonerReceivedIntoPrisonEventServiceTest {
 
     // Then
     verify(reviewScheduleService).handle17DayTransferRule(prisonNumber, "BXI", null)
-  }
-
-  @Test
-  fun `should not apply 17 day transfer rule given prisoner has not completed their induction`() {
-    // Given
-    val prisonNumber = randomValidPrisonNumber()
-    val additionalInformation = aValidPrisonerReceivedAdditionalInformation(prisonNumber = prisonNumber, reason = TRANSFERRED, prisonId = "BXI")
-    val inboundEvent = anInboundEvent(additionalInformation)
-    given(scheduleAdapter.isInductionComplete(prisonNumber)).willReturn(false)
-
-    // When
-    eventService.process(inboundEvent, additionalInformation)
-
-    // Then
-    verify(reviewScheduleService, never()).handle17DayTransferRule(any(), any(), any())
-    verify(prisonerSearchApiService, never()).getPrisoner(prisonNumber)
   }
 
   @ParameterizedTest


### PR DESCRIPTION
RR-2767 applied the transfer "17 day rule" only to prisoners with no active review schedule. The 17-day check now runs on every transfer.
